### PR TITLE
test: give federation integration suites a realistic per-test timeout

### DIFF
--- a/packages/server/test/federation-by-home-id.test.ts
+++ b/packages/server/test/federation-by-home-id.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { bootTwoInstances, type TwoInstanceHarness } from './helpers/twoInstanceHarness.js';
 import { peerInstances } from './helpers/seedPeer.js';
 import { registerLocal } from './helpers/testUsers.js';
 import { buildHeadersForOrigin } from './helpers/hmacSign.js';
+
+// Boots real federated instances and drives S2S over HTTP; the 5s unit-test
+// default is too tight under CI load. See federation-identity-deletion.test.ts
+// for the rationale. A genuine hang still trips this ceiling.
+vi.setConfig({ testTimeout: 30_000 });
 
 let harness: TwoInstanceHarness;
 let sharedSecret: string;

--- a/packages/server/test/federation-handshake-desync.test.ts
+++ b/packages/server/test/federation-handshake-desync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   bootTwoInstancesForHandshake,
   registerAdmin,
@@ -10,6 +10,12 @@ import {
 } from './helpers/realHandshake.js';
 import type { TwoInstanceHarness } from './helpers/twoInstanceHarness.js';
 import { openInspector } from './helpers/dbInspect.js';
+
+// Boots real federated instances and drives the peering handshake over HTTP; the
+// 5s unit-test default is too tight under CI load. See
+// federation-identity-deletion.test.ts for the rationale. A genuine hang still
+// trips this ceiling.
+vi.setConfig({ testTimeout: 30_000 });
 
 /**
  * Acceptance-gate integration suite for the federation handshake desync bugs.

--- a/packages/server/test/federation-identity-deletion.test.ts
+++ b/packages/server/test/federation-identity-deletion.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { bootTwoInstances, bootHomePlusRemotes, type TwoInstanceHarness, type MultiRemoteHarness, type SpawnedInstance } from './helpers/twoInstanceHarness.js';
 import { peerInstances } from './helpers/seedPeer.js';
 import type { TestUser } from './helpers/testUsers.js';
 import { connectWs } from './helpers/wsListener.js';
+
+// Every test here boots real federated instances and drives S2S over HTTP, and
+// several deliberately wait on log matchers (e.g. logMatched(..., 1_000) per
+// remote). The 5s default per-test timeout is meant for unit tests and is too
+// tight for this — under CI load the multi-remote fan-out tests intermittently
+// timed out. Give the whole file a realistic ceiling; a genuine hang still trips
+// it well before then. Hooks keep their own explicit timeouts (beforeAll 90s).
+vi.setConfig({ testTimeout: 30_000 });
 
 let harness: TwoInstanceHarness;
 let sharedHmacSecret: string;


### PR DESCRIPTION
## Problem

After PR #1 merged, the `Build & test` check went red on `main` — but not because of the SSRF fix. A single heavy integration test timed out:

```
FAIL test/federation-identity-deletion.test.ts > #2 leave mode all-remotes
Error: Test timed out in 5000ms.
```

It was flaky: the same test passed on both PR runs and the prior main run, and a re-run of the failed job went green. The runner was just under load (server suite took 230s vs the usual ~90s).

## Root cause

The three `packages/server/test/*.test.ts` files boot **real federated instances** and drive S2S over HTTP, and several tests **deliberately wait** on log matchers (e.g. `logMatched(..., 1_000)` per remote — 2s of intentional waiting in the multi-remote fan-out tests alone). They all ran on vitest's **5s default per-test timeout**, which is meant for unit tests. Under CI load that's too tight, so the heaviest tests tip over intermittently.

## Fix

Set a file-level `vi.setConfig({ testTimeout: 30_000 })` in each of the three harness-based suites:
- `federation-identity-deletion.test.ts` (boots up to 3 instances)
- `federation-by-home-id.test.ts`
- `federation-handshake-desync.test.ts`

Scoped **per-file** so unit tests keep the strict 5s default (a global bump would mask real hangs). 30s is a generous ceiling — normal runs take 1–3s, so a genuine hang still trips it, well under the 90s `beforeAll` hook budget. **No test logic changed.**