### PR TITLE
ci: bump actions to Node 24 runtimes to clear deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.34.3
 
@@ -39,7 +39,7 @@ jobs:
       # install below pulls better-sqlite3's prebuilt binary for the correct ABI,
       # which is what makes the server suite runnable in CI.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,10 +24,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v5
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./site
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # The runtime image bakes the git commit for the AGPL-3.0 § 13 source
       # offer (config.commit → GET /api/instance/info). The .git dir is not in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
@@ -65,12 +65,12 @@ jobs:
           sudo gem install --no-document fpm
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.34.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
Clears the "Node.js 20 is deprecated ... forced to run on Node.js 24" warning that printed on every CI run.

## Changes
- `actions/checkout@v4 -> v5`, `actions/setup-node@v4 -> v5`, `pnpm/action-setup@v4 -> v5` across ci.yml, release.yml, docker-publish.yml (checkout), deploy-pages.yml (checkout).
- Pages actions in deploy-pages.yml: `configure-pages@v5 -> v6`, `upload-pages-artifact@v3 -> v5`, `deploy-pages@v4 -> v5` (these were also on Node 20).

## Why v5 (not the latest v6/v7 for checkout)
v5 is the first major on the Node 24 runtime, so it's the minimal bump that clears the warning. checkout v6 (credential-persistence change) and v7 (blocks fork-PR checkout on `pull_request_target`/`workflow_run`) add behavior we don't need. None of our checkout jobs use `pull_request_target`/`workflow_run`, so we're unaffected either way.

## Validation
- ci.yml runs on this PR: proves checkout/setup-node/pnpm v5 all work and the warning is gone.
- release.yml and ci.yml use an identical pnpm/setup-node invocation, so this run transitively validates release.yml's steps too.
- docker-publish.yml, deploy-pages.yml, and release.yml only trigger on tags/Pages/dispatch, so those are drop-in bumps that will first exercise on their next real run. Inputs unchanged.