### PR TITLE
Enhance windows dev support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,13 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: Build & test
+    name: Build & test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 24]
 
     steps:
       - name: Checkout
@@ -33,15 +38,10 @@ jobs:
         uses: pnpm/action-setup@v5
         with:
           version: 10.34.3
-
-      # Node 20 is the project's supported runtime (package.json engines pins
-      # >=20 <21, .nvmrc says 20). Running the matrix on 20 also means the fresh
-      # install below pulls better-sqlite3's prebuilt binary for the correct ABI,
-      # which is what makes the server suite runnable in CI.
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
 
       # The desktop postinstall tries to rebuild the native uiohook-napi module.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,23 @@ jobs:
       # Runs every package's `test` script (server, web, desktop) via vitest.
       - name: Test
         run: pnpm -r test
+
+  # Aggregate gate reporting a single, matrix-independent "Build & test" status.
+  # Branch protection on main requires the "Build & test" context, but the matrix
+  # job above reports per-version contexts ("Build & test (Node 20/24)"). This job
+  # keeps the stable required context alive and fails unless every matrix leg
+  # succeeded (if: always() so a matrix failure still reports a definitive result
+  # instead of leaving the required check pending forever).
+  build-and-test-required:
+    name: Build & test
+    if: always()
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify matrix result
+        run: |
+          if [ "${{ needs.build-and-test.result }}" != "success" ]; then
+            echo "Matrix build-and-test did not succeed: ${{ needs.build-and-test.result }}"
+            exit 1
+          fi
+          echo "All matrix legs passed."

--- a/README.md
+++ b/README.md
@@ -465,16 +465,29 @@ briefly restarts the `backspace` container (clients reconnect automatically).
 
 ## Development
 
-Requirements: **Node.js 20 (LTS)** and **pnpm 10**, both pinned (`.nvmrc` plus
-the `packageManager` field), so `nvm use` and Corepack select the right versions
-automatically. Newer Node majors are untested; the Docker image always builds on
-Node 20 regardless of your host.
+Requirements: **Node.js 20 or newer** and **pnpm 10**. The `.nvmrc` file keeps
+Node 20 as the default development and production baseline, while newer Node
+majors are supported and exercised in CI. The Docker image continues to build
+on Node 20 regardless of your host.
 
 ```bash
 pnpm install
 cp .env.example .env          # set JWT_SECRET (openssl rand -hex 32)
 pnpm dev                       # API server on :3005, Vite dev server on :5173
 ```
+
+On Windows PowerShell, confirm Node 20 or newer and use the native copy command:
+
+```powershell
+node --version
+pnpm install
+Copy-Item .env.example .env
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+Paste the generated value after `JWT_SECRET=` in `.env`, then start both
+development servers with `pnpm dev`. Use `node --version` to confirm the active
+version if pnpm reports an engine warning.
 
 > **Server/web only?** `pnpm install` also builds the desktop app's native
 > keyboard-hook module (`uiohook-napi`), which needs a C++ toolchain
@@ -604,7 +617,7 @@ packages/
 
 | Layer        | Technology |
 |--------------|------------|
-| Server       | Node.js 20 (LTS), Fastify 4, TypeScript (strict) |
+| Server       | Node.js 20+, Fastify 4, TypeScript (strict) |
 | Database     | SQLite (better-sqlite3) + Drizzle ORM |
 | Auth         | JWT + bcrypt |
 | Frontend     | React 18, Vite 6, Tailwind CSS 3, Zustand 5 |

--- a/README.md
+++ b/README.md
@@ -466,9 +466,9 @@ briefly restarts the `backspace` container (clients reconnect automatically).
 ## Development
 
 Requirements: **Node.js 20 or newer** and **pnpm 10**. The `.nvmrc` file keeps
-Node 20 as the default development and production baseline, while newer Node
-majors are supported and exercised in CI. The Docker image continues to build
-on Node 20 regardless of your host.
+Node 20 as the default development and production baseline; CI additionally
+exercises Node 24, and newer majors generally work but are not part of the test
+matrix. The Docker image continues to build on Node 20 regardless of your host.
 
 ```bash
 pnpm install
@@ -487,7 +487,9 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 Paste the generated value after `JWT_SECRET=` in `.env`, then start both
 development servers with `pnpm dev`. Use `node --version` to confirm the active
-version if pnpm reports an engine warning.
+version if pnpm reports an engine warning. This covers the server and web dev
+servers; building the Electron desktop app still expects a POSIX shell (macOS or
+Linux).
 
 > **Server/web only?** `pnpm install` also builds the desktop app's native
 > keyboard-hook module (`uiohook-napi`), which needs a C++ toolchain

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev:server": "pnpm --filter @backspace/server dev",
     "dev:web": "pnpm --filter @backspace/web dev",
-    "dev": "pnpm --filter @backspace/server dev & pnpm --filter @backspace/web dev",
+    "dev": "pnpm --parallel --filter @backspace/server --filter @backspace/web dev",
     "build:shared": "pnpm --filter @backspace/shared build",
     "build:server": "pnpm --filter @backspace/server build",
     "build:web": "pnpm --filter @backspace/web build",
@@ -42,7 +42,7 @@
   },
   "packageManager": "pnpm@10.34.3",
   "engines": {
-    "node": ">=20.0.0 <21.0.0",
+    "node": ">=20.0.0",
     "pnpm": ">=10.0.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
   "author": "Jannis Braun",
   "type": "module",
   "scripts": {
-    "dev": "PORT=3005 tsx watch src/index.ts",
+    "dev": "cross-env PORT=3005 tsx watch src/index.ts",
     "start": "node --import tsx/esm src/index.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
@@ -41,6 +41,7 @@
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.14.0",
     "@types/ws": "^8.18.1",
+    "cross-env": "^7.0.3",
     "drizzle-kit": "^0.24.0",
     "typescript": "^5.4.0",
     "vitest": "^4.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       drizzle-kit:
         specifier: ^0.24.0
         version: 0.24.2
@@ -2655,6 +2658,11 @@ packages:
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -7992,6 +8000,10 @@ snapshots:
     dependencies:
       buffer: 5.7.1
     optional: true
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
<!-- Thanks for contributing. Keep one logical change per pull request. -->

## What this changes

Improves the local development experience on Windows:

- Uses `cross-env` to set the server port without POSIX-only shell syntax.
- Uses pnpm’s cross-platform parallel runner to start the server and web client together.
- Adds PowerShell setup instructions to the development documentation.
- Supports Node.js 20 and newer, with CI coverage for Node 20 and Node 24.

Closes: N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Other

## Checklist

- [x] `pnpm build` succeeds (shared types, server, and web all build)
- [x] `pnpm dev` starts the server and web client without errors
- [x] Tests pass where applicable (`pnpm test`)
- [x] I updated the relevant `docs/systems/` spec if this changed schema, API routes, WebSocket events, the federation protocol, permissions, or the design system
- [x] This change resolves the correct federated identity where it compares IDs, checks permissions, or talks to remote servers (no assumption of a single global user ID)
- [x] I have read and agree to the [CLA](../CLA.md)

## Notes for reviewers

- No production, schema, API, WebSocket, federation, permission, or design-system behavior changes.
- The Docker and release environments continue to use Node 20 as their baseline.
- Builds were verified on Node 20 and Node 25.
- On Windows, `pnpm dev` successfully started the API on port 3005 and Vite on port 5173.
- Vite HTTP and WebSocket proxying to the API server was verified.
- Server unit tests passed: 100 files and 779 tests.
- Web tests passed: 55 files and 457 tests.
- Desktop tests passed: 3 files and 54 tests.