### PR TITLE
fix(spaces): clearer 403 for non-members on invite endpoint

### DIFF
--- a/packages/server/src/routes/spaces.ts
+++ b/packages/server/src/routes/spaces.ts
@@ -561,6 +561,12 @@ export async function spaceRoutes(app: FastifyInstance): Promise<void> {
     }
 
     if (!hasPermission(request.userId, id, PermissionBits.CREATE_INVITE)) {
+      // Owners and instance admins always pass hasPermission, so anyone who lands
+      // here is either a non-member or a member without CREATE_INVITE. Give the
+      // non-member a clearer "go join first" message instead of a permission error.
+      if (!isMember(id, request.userId)) {
+        return reply.code(403).send({ error: 'Space membership required', statusCode: 403 });
+      }
       return reply.code(403).send({ error: 'Missing CREATE_INVITE permission', statusCode: 403 });
     }
 


### PR DESCRIPTION
Follow-up to #12 (closed).

The invite-bypass #12 aimed at was already fixed in 85e1975f: non-members resolve to zero permissions in a space, so `hasPermission` already denies them the invite endpoint even when @everyone grants CREATE_INVITE. Re-adding a membership gate in the route would just duplicate that.

What's worth keeping from #12 is the clearer error message. `hasPermission` returning false reads as "missing CREATE_INVITE permission", which is misleading when the real reason is that the caller never joined. This refines the message on the existing denial path (no second gate): non-members get `403 Space membership required`, members lacking the permission still get `403 Missing CREATE_INVITE permission`.

Message wording credited to @BadAtCaptchas via the co-author trailer.

Typecheck passes (`tsc --noEmit` in packages/server).