### PR TITLE
ci(cla): store CLA signatures on a dedicated branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,8 +2,16 @@ name: CLA Assistant
 
 # Requires every contributor to sign the project Contributor License Agreement
 # (CLA.md) before their pull request can be merged. Signatures are stored in
-# this repository at signatures/cla.json — no external service or database is
-# used. A contributor signs by commenting the exact sentence configured below.
+# this repository at signatures/cla.json on the `cla-signatures` branch — no
+# external service or database is used. A contributor signs by commenting the
+# exact sentence configured below.
+#
+# Why not `main`: the action appends each signature as a direct commit, which
+# the "Require CI on main" ruleset rejects ("Repository rule violations found"),
+# leaving the signature unrecorded and the check permanently red. Keeping the
+# store on its own branch lets the bot append without granting any actor a
+# bypass on main. That branch has its own ruleset blocking deletion and
+# force-pushes, so the record cannot be rewritten.
 
 on:
   issue_comment:
@@ -37,7 +45,7 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           # The CLA document contributors are agreeing to.
           path-to-document: 'https://github.com/TheZwiss/backspace/blob/main/CLA.md'
-          branch: 'main'
+          branch: 'cla-signatures'
           # Accounts that never need to sign (maintainer + automation).
           allowlist: 'TheZwiss,dependabot[bot],github-actions[bot]'
           # The exact phrase a contributor comments to sign.


### PR DESCRIPTION
## What this changes

Fixes a deadlock that blocks **every** outside contribution.

The CLA Assistant appends each signature as a direct commit to the branch named in `branch:`. That was `main`, which the **Require CI on main** ruleset rejects:

```
##[error]Could not update the JSON file: Repository rule violations found
```

So the signature is never recorded and the check stays red however many times the contributor signs. Seen on #39: the contributor posted the exact phrase, the bot even commented "All contributors have signed the CLA", and the same run errored out with `Committers of Pull Request number 39 have to sign the CLA`. `signatures/cla.json` on `main` still holds only the July signature.

## The fix

Point the store at a `cla-signatures` branch. The ruleset targets `~DEFAULT_BRANCH` only, so the bot can append there **without granting any actor a bypass on `main`** — the alternative fix, and a much wider hole given it would let any workflow with `contents: write` push past CI.

Already in place:
- `cla-signatures` branch seeded with the existing signature (`BadAtCaptchas`), so no record is lost.
- Ruleset **Protect CLA signature store** on that branch blocking deletion and non-fast-forward pushes, so the record cannot be rewritten.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests pass where applicable (`pnpm test`) — no code paths touched, CI config only
- [x] I have read and agree to the [CLA](../CLA.md)

## Notes for reviewers

After merge, re-run the CLA workflow on #39 so the check re-attaches to the head commit. A `recheck` comment alone will not clear it: `issue_comment` runs do not attach to a PR's head SHA, which is why the contributor's signing looked like it did nothing.