### PR TITLE
fix(server): upgrade better-sqlite3 to 12.x for Node 24 compatibility

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,7 +25,7 @@
     "@tus/file-store": "^1.5.1",
     "@tus/server": "^1.10.2",
     "bcryptjs": "^2.4.3",
-    "better-sqlite3": "^11.3.0",
+    "better-sqlite3": "^12.11.1",
     "cheerio": "^1.0.0",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3
       better-sqlite3:
-        specifier: ^11.3.0
-        version: 11.10.0
+        specifier: ^12.11.1
+        version: 12.11.1
       cheerio:
         specifier: ^1.0.0
         version: 1.2.0
@@ -88,7 +88,7 @@ importers:
         version: 16.6.1
       drizzle-orm:
         specifier: ^0.33.0
-        version: 0.33.0(@types/better-sqlite3@7.6.13)(@types/react@18.3.28)(better-sqlite3@11.10.0)(react@18.3.1)
+        version: 0.33.0(@types/better-sqlite3@7.6.13)(@types/react@18.3.28)(better-sqlite3@12.11.1)(react@18.3.1)
       fastify:
         specifier: ^4.28.1
         version: 4.29.1
@@ -834,7 +834,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -2374,8 +2374,9 @@ packages:
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -4426,6 +4427,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   pretty-bytes@5.6.0:
@@ -7658,7 +7660,7 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -8197,11 +8199,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.33.0(@types/better-sqlite3@7.6.13)(@types/react@18.3.28)(better-sqlite3@11.10.0)(react@18.3.1):
+  drizzle-orm@0.33.0(@types/better-sqlite3@7.6.13)(@types/react@18.3.28)(better-sqlite3@12.11.1)(react@18.3.1):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
       '@types/react': 18.3.28
-      better-sqlite3: 11.10.0
+      better-sqlite3: 12.11.1
       react: 18.3.1
 
   dunder-proto@1.0.1:


### PR DESCRIPTION
## What this changes

Unblocks CI. `Build & test (Node 24)` currently fails on **every** pull request, including ones touching no server code (#40 changes one string in a workflow file and fails identically). Since it is the only required status check, nothing can merge.

## Root cause

All 804 server tests pass, then four vitest workers abort during teardown:

```
#  Assertion failed: (env) != nullptr
1: node::Assert(node::AssertionInfo const&)
2: node::RemoveEnvironmentCleanupHook(v8::Isolate*, void (*)(void*), void*)
3: Statement::~Statement()  [better-sqlite3@11.10.0/better_sqlite3.node]
```

better-sqlite3 11.x removes its environment cleanup hook from `Statement::~Statement()` after the Node environment is already gone. Node 24.19.0 asserts on the null environment and aborts the worker, so vitest reports `Worker exited unexpectedly` and exits non-zero despite a fully green test run.

This is why it appeared without any code change: nothing has run CI on `main` since 13 July, and the runner image has moved to Node 24.19.0 since.

11.x also ships no prebuild for Node 24 (`prebuild-install warn install No prebuilt binaries found (target=24.19.0)`), so CI compiles it from source on every run. 12.x has prebuilds for that ABI and the V8 13.9 shims 11.x lacks.

## Compatibility

`drizzle-orm` declares `better-sqlite3: >=7`, so the major bump is in range. No source changes were needed.

## Supersedes

#26 (dependabot's bump to the same version). That PR's green checks are from 13 July and predate the breakage, so they are not evidence either way — this PR exists to get a run on the current runner image.

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm build` succeeds
- [x] Tests pass where applicable (`pnpm test`) — verified by this PR's own CI
- [x] I have read and agree to the [CLA](../CLA.md)