### PR TITLE
docs(pr-template): clarify the CLA checkbox is not the signature

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,9 @@ Closes #
 - [ ] Tests pass where applicable (`pnpm test`)
 - [ ] I updated the relevant `docs/systems/` spec if this changed schema, API routes, WebSocket events, the federation protocol, permissions, or the design system
 - [ ] This change resolves the correct federated identity where it compares IDs, checks permissions, or talks to remote servers (no assumption of a single global user ID)
-- [ ] I have read and agree to the [CLA](../CLA.md)
+- [ ] I have read and agree to the [CLA](../CLA.md) — ticking this box is not the
+      signature. After opening this PR, post a separate comment containing exactly:
+      `I have read the CLA Document and I hereby sign the CLA`
 
 ## Notes for reviewers
 


### PR DESCRIPTION
## What this changes

The PR template's CLA line reads "I have read and agree to the CLA". A contributor can tick it in good faith and reasonably assume they are done — but the CLA Assistant only records a signature when the exact phrase is posted as a **comment** on the PR. The checkbox alone leaves the check red with no explanation.

That is what happened on #39: the box was ticked, the check was red, and the contributor had no way of knowing a comment was also required.

Spell the comment out next to the checkbox, using the exact phrase configured as `custom-pr-sign-comment` in `.github/workflows/cla.yml` so it can be copied straight from the template.

Related: #40 fixed the other half of that incident — the bot could not record signatures at all, because it was writing to `main` against the ruleset.

## Type of change

- [x] Documentation

## Checklist

- [x] Tests pass where applicable — template text only, no code paths touched
- [x] I have read and agree to the [CLA](../CLA.md)