### PR TITLE
feat(metrics): archive repo traffic data past GitHub's 14-day window

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1,0 +1,134 @@
+name: Metrics backfill
+
+# Reconstructs history that permanent per-item timestamps make recoverable:
+# stars from `starred_at`, forks from `created_at`, releases from
+# `published_at`. See docs/systems/metrics.md.
+#
+# Dispatch only, never scheduled — this is a one-shot reconstruction, not a
+# recurring job. It is safe to run at any time, including more than once,
+# because every write is if-absent: it fills dates that have no row and
+# never replaces one the daily collector (metrics.yml) measured. That rule
+# matters because /stargazers lists only CURRENT stargazers, so a
+# reconstruction cannot see anyone who starred and later unstarred —
+# overwriting a measured value with a reconstructed one would silently
+# replace a correct number with a systematically wrong one. A rerun over
+# dates it already filled writes nothing new; it is not destructive.
+#
+# Traffic (views/clones/referrers/paths) is not backfillable by any means —
+# GitHub only ever exposes a trailing 14-day window for it — and this
+# workflow never touches it.
+#
+# Never runs on a fork: METRICS_TOKEN does not propagate to forks, so a
+# fork owner dispatching this would otherwise get a loud failure on every
+# attempt with nothing they could do about it, and there is no scenario
+# where a fork should be writing to this repo's archive anyway.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Shares metrics.yml's exact group so a dispatched backfill cannot race the
+# daily cron's write to the same branch. Never cancel in progress: the two
+# workflows write the same files, and cancelling mid-write is worse than
+# queueing — the write is the entire point of running this.
+concurrency:
+  group: metrics-data
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill history
+    # Skip entirely on forks. A fork's dispatch still resolves
+    # `github.repository` to its own slug, but it never has METRICS_TOKEN
+    # (secrets do not propagate to forks) — see header.
+    if: ${{ !github.event.repository.fork }}
+    runs-on: ubuntu-latest
+    # The stargazer list is the one genuinely long paginated call this
+    # package makes (100/page, no fixed cap) and this job has no other slow
+    # step, so a generous bound here is purely a backstop against a stuck
+    # run tying up the shared `metrics-data` concurrency group and delaying
+    # the next scheduled collection, not a limit expected to be hit.
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      # The data branch must be created BEFORE actions/checkout is asked for
+      # it: checkout with a nonexistent ref hard-fails the job, so a
+      # bootstrap step placed after it could never run. Backfill does not
+      # require metrics.yml to have run first — it can be dispatched right
+      # after this package is adopted, before any daily collection has
+      # happened — so this workflow cannot assume `metrics-data` exists.
+      #
+      # Built as a `git worktree add --orphan` into a scratch directory
+      # rather than `git switch --orphan` in place. Both start genuinely
+      # empty — `git switch --orphan` removes all tracked files, and only
+      # the legacy `git checkout --orphan` carries the previous tree over
+      # into the index. The worktree is preferred because it never touches
+      # the primary checkout at all: the later "Backfill" step runs the CLI
+      # from the repository root and needs that tree intact, and a scratch
+      # worktree removes any way for this step to leave it modified on an
+      # early exit.
+      - name: Bootstrap the data branch if absent
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin metrics-data >/dev/null 2>&1; then
+            echo "metrics-data exists"
+          else
+            echo "Creating orphan branch metrics-data"
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git worktree add --orphan -b metrics-data .metrics-init
+            git -C .metrics-init commit --allow-empty -m "chore(metrics): initialise data branch"
+            git -C .metrics-init push origin metrics-data
+            git worktree remove .metrics-init --force
+          fi
+
+      - name: Checkout the data branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: metrics-data
+          path: .metrics-data
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          # Pinned to 24: the CLI is TypeScript executed directly by Node's
+          # native type stripping, with no build step and no dependencies.
+          node-version: 24
+
+      - name: Backfill
+        env:
+          # Must be the PAT, not GITHUB_TOKEN: the latter carries a 1,000
+          # requests/hour per-repository limit rather than 5,000, and in any
+          # case cannot reach the traffic-scoped "Administration: read"
+          # permission the collector needs — see metrics.yml's header. This
+          # job does not read traffic, but it uses the same token as the
+          # daily collector for one PAT rather than provisioning a second.
+          METRICS_TOKEN: ${{ secrets.METRICS_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          METRICS_DATA_DIR: ${{ github.workspace }}/.metrics-data
+        run: node scripts/metrics/src/cli-backfill.ts
+
+      - name: Commit and push
+        working-directory: .metrics-data
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No change to commit"
+            exit 0
+          fi
+          git commit -m "chore(metrics): backfill reconstructable history"
+          git push origin metrics-data

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -71,15 +71,13 @@ jobs:
       # placed after it could never run.
       #
       # Built as a `git worktree add --orphan` into a scratch directory rather
-      # than `git switch --orphan` in place: switching the primary checkout to
-      # an orphan branch leaves the previous HEAD's tree staged (an orphan
-      # branch has no parent to diff against, so the working tree and index
-      # are carried over unchanged), so `commit --allow-empty` would commit
-      # the *entire main branch source tree* as the archive's first commit,
-      # not an empty one — and it would require rm -rf'ing the primary
-      # checkout to fix, which the later "Collect" step still needs intact.
-      # A worktree keeps the primary checkout completely untouched and starts
-      # genuinely empty, so the init commit is empty as intended.
+      # than `git switch --orphan` in place. Both start genuinely empty —
+      # `git switch --orphan` removes all tracked files, and only the legacy
+      # `git checkout --orphan` carries the previous tree over into the index.
+      # The worktree is preferred because it never touches the primary
+      # checkout at all: the later "Collect" step runs the collector from the
+      # repository root and needs that tree intact, and a scratch worktree
+      # removes any way for this step to leave it modified on an early exit.
       - name: Bootstrap the data branch if absent
         run: |
           set -euo pipefail
@@ -171,7 +169,14 @@ jobs:
           git add meta.json
           git diff --cached --quiet || {
             git commit -m "chore(metrics): record run outcome"
-            git push origin metrics-data || true
+            # This commit carries only run metadata; the data commit above has
+          # its own retry loop and hard-fails on its own. Swallow a failure
+          # here so a metadata push cannot mask a successful collection, but
+          # surface it — an unannotated `|| true` is how a real problem stays
+          # invisible for months.
+          git push origin metrics-data \
+            || echo "::warning::failed to push run metadata to metrics-data"
+
           }
 
       - name: Keep the schedule alive

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -137,54 +137,53 @@ jobs:
           echo "Could not push after 3 attempts"
           exit 1
 
-      # Runs even when collection failed, so a stalled collector is visible on
-      # the data branch and in the dashboard header rather than only in this tab.
-      - name: Record run outcome
-        if: always()
-        working-directory: .metrics-data
+      # Runs only when something upstream in this job failed (a required
+      # fetch in "Collect", or the "Commit and push" step itself) — never on
+      # success. On success there is nothing left to record: `collect()`
+      # already wrote a complete, correct meta.json as the last step of its
+      # own atomic write phase (see collect.ts), and the "Commit and push"
+      # step above already commits it alongside the data files via
+      # `git add -A`. A second write here on the success path would just be
+      # a redundant, confusing second daily commit — which is exactly what
+      # this replaces. See docs/systems/metrics.md §3.3.
+      - name: Record failure
+        if: failure()
         env:
-          OUTCOME: ${{ job.status }}
+          METRICS_DATA_DIR: ${{ github.workspace }}/.metrics-data
+          METRICS_RUN_OUTCOME: ${{ job.status }}
+        run: node scripts/metrics/src/cli-record-failure.ts
+
+      # Split from "Record failure" above rather than folded into one step:
+      # the CLI only ever touches the working tree (via `store.ts`), and
+      # every other step in this job that runs `git` does so as its own
+      # step with its own identity/add/commit/push, for the same reason
+      # "Commit and push" above is separate from "Collect" — a step that
+      # fails partway through this shell script (e.g. the push) should not
+      # be indistinguishable in the logs from the write itself failing.
+      - name: Commit and push failure record
+        if: failure()
+        working-directory: .metrics-data
         run: |
           set -euo pipefail
-          # This step runs on every path, including the failure path the
-          # "Commit and push" step above does NOT run on (it has no `if:` and
-          # so defaults to `if: success()`). Without its own identity here,
-          # the `git commit` below either fails outright on a failed run or
-          # commits under an auto-detected `runner@<vm>` identity inconsistent
-          # with every other commit on this branch — on exactly the runs this
-          # step exists to make visible.
+          # Own identity for the same reason "Commit and push" above needs
+          # one: this step can run on a path where no prior step in this job
+          # configured git, and a `git commit` under an auto-detected
+          # `runner@<vm>` identity would be inconsistent with every other
+          # commit on this branch — on exactly the runs this step exists to
+          # make visible.
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Single-quoted on purpose: the ${...} below are JS template-literal
-          # interpolations for `node -e`, not shell expansions, and must reach
-          # node unexpanded.
-          # shellcheck disable=SC2016
-          node -e '
-            const fs = require("node:fs");
-            const now = new Date().toISOString();
-            let meta = { last_run: now, last_success: null, error: null, series_last_date: {} };
-            if (fs.existsSync("meta.json")) {
-              meta = JSON.parse(fs.readFileSync("meta.json", "utf8"));
-            }
-            meta.last_run = now;
-            if (process.env.OUTCOME === "success") {
-              meta.last_success = now;
-              meta.error = null;
-            } else {
-              meta.error = `run failed: ${process.env.OUTCOME}`;
-            }
-            fs.writeFileSync("meta.json", JSON.stringify(meta, null, 2) + "\n");
-          '
           git add meta.json
           git diff --cached --quiet || {
-            git commit -m "chore(metrics): record run outcome"
-            # This commit carries only run metadata; the data commit above has
-            # its own retry loop and hard-fails on its own. Swallow a failure
-            # here so a metadata push cannot mask a successful collection, but
-            # surface it — an unannotated `|| true` is how a real problem stays
-            # invisible for months.
+            git commit -m "chore(metrics): record run failure"
+            # This commit carries only run metadata; the data commit (when
+            # it happens) has its own retry loop and hard-fails on its own.
+            # Swallow a push failure here so a metadata push cannot mask or
+            # compound an already-failed run, but surface it — an
+            # unannotated `|| true` is how a real problem stays invisible
+            # for months.
             git push origin metrics-data \
-              || echo "::warning::failed to push run metadata to metrics-data"
+              || echo "::warning::failed to push failure record to metrics-data"
           }
 
       - name: Keep the schedule alive

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -146,6 +146,15 @@ jobs:
           OUTCOME: ${{ job.status }}
         run: |
           set -euo pipefail
+          # This step runs on every path, including the failure path the
+          # "Commit and push" step above does NOT run on (it has no `if:` and
+          # so defaults to `if: success()`). Without its own identity here,
+          # the `git commit` below either fails outright on a failed run or
+          # commits under an auto-detected `runner@<vm>` identity inconsistent
+          # with every other commit on this branch — on exactly the runs this
+          # step exists to make visible.
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Single-quoted on purpose: the ${...} below are JS template-literal
           # interpolations for `node -e`, not shell expansions, and must reach
           # node unexpanded.
@@ -170,17 +179,17 @@ jobs:
           git diff --cached --quiet || {
             git commit -m "chore(metrics): record run outcome"
             # This commit carries only run metadata; the data commit above has
-          # its own retry loop and hard-fails on its own. Swallow a failure
-          # here so a metadata push cannot mask a successful collection, but
-          # surface it — an unannotated `|| true` is how a real problem stays
-          # invisible for months.
-          git push origin metrics-data \
-            || echo "::warning::failed to push run metadata to metrics-data"
-
+            # its own retry loop and hard-fails on its own. Swallow a failure
+            # here so a metadata push cannot mask a successful collection, but
+            # surface it — an unannotated `|| true` is how a real problem stays
+            # invisible for months.
+            git push origin metrics-data \
+              || echo "::warning::failed to push run metadata to metrics-data"
           }
 
       - name: Keep the schedule alive
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow enable metrics.yml --repo "${{ github.repository }}" || true
+          REPO: ${{ github.repository }}
+        run: gh workflow enable metrics.yml --repo "$REPO" || true

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,181 @@
+name: Metrics
+
+# Snapshots this repo's traffic metrics daily into the orphan `metrics-data`
+# branch. Purpose: GitHub's Insights -> Traffic panel discards views, clones,
+# referrers, and popular paths after 14 days, and no API can reconstruct them.
+# Every day this does not run is a day of history destroyed permanently.
+#
+# Why two tokens: the traffic endpoints require the "Administration: read"
+# permission, and there is no `administration` key in the Actions `permissions:`
+# vocabulary at all — so GITHUB_TOKEN cannot reach them under any configuration.
+# METRICS_TOKEN (a fine-grained, repo-scoped, read-only PAT) reads; GITHUB_TOKEN
+# writes. Neither alone can both read traffic and modify the archive.
+#
+# Never runs on a fork: METRICS_TOKEN does not propagate to forks, so a fork's
+# scheduled run would fail every single day with nothing anyone could do about
+# it short of disabling the workflow. `github.event.repository.fork` gates the
+# job instead of a hardcoded repo slug, which stays correct if the project is
+# ever renamed or transferred.
+#
+# Why `gh workflow enable`: GitHub disables scheduled workflows after 60 days
+# with no repository activity. This workflow's own commits go to a non-default
+# branch and are made with GITHUB_TOKEN, so they cannot be relied on to reset
+# that timer. Re-enabling on every run is idempotent and costs one API call.
+# It needs `actions: write` — without that scope the call fails silently
+# (masked by `|| true` so a stalled collector doesn't also fail the run over
+# a self-heal step), which would defeat the entire point of running it.
+#
+# See docs/systems/metrics.md.
+
+on:
+  schedule:
+    # 03:00 UTC daily. The exact hour does not matter: the traffic API returns a
+    # 14-day window, so any gap of 13 days or less is repaired by the next run.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never cancel in progress: metrics.yml and backfill.yml write the same files,
+# and cancelling a collection run loses that day irrecoverably. Sharing the
+# `metrics-data` group also means the two workflows queue instead of racing
+# each other's pushes.
+concurrency:
+  group: metrics-data
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: Collect metrics
+    # Skip entirely on forks. A fork's Actions run still resolves
+    # `github.repository` to its own slug, but it never has METRICS_TOKEN
+    # (secrets do not propagate to forks), so the job would otherwise fail
+    # loudly on a schedule the fork owner never opted into.
+    if: ${{ !github.event.repository.fork }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      # The data branch must be created BEFORE actions/checkout is asked for it:
+      # checkout with a nonexistent ref hard-fails the job, so a bootstrap step
+      # placed after it could never run.
+      #
+      # Built as a `git worktree add --orphan` into a scratch directory rather
+      # than `git switch --orphan` in place: switching the primary checkout to
+      # an orphan branch leaves the previous HEAD's tree staged (an orphan
+      # branch has no parent to diff against, so the working tree and index
+      # are carried over unchanged), so `commit --allow-empty` would commit
+      # the *entire main branch source tree* as the archive's first commit,
+      # not an empty one — and it would require rm -rf'ing the primary
+      # checkout to fix, which the later "Collect" step still needs intact.
+      # A worktree keeps the primary checkout completely untouched and starts
+      # genuinely empty, so the init commit is empty as intended.
+      - name: Bootstrap the data branch if absent
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin metrics-data >/dev/null 2>&1; then
+            echo "metrics-data exists"
+          else
+            echo "Creating orphan branch metrics-data"
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git worktree add --orphan -b metrics-data .metrics-init
+            git -C .metrics-init commit --allow-empty -m "chore(metrics): initialise data branch"
+            git -C .metrics-init push origin metrics-data
+            git worktree remove .metrics-init --force
+          fi
+
+      - name: Checkout the data branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: metrics-data
+          path: .metrics-data
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          # Pinned to 24: the collector is TypeScript executed directly by Node's
+          # native type stripping, with no build step and no dependencies.
+          node-version: 24
+
+      - name: Collect
+        env:
+          METRICS_TOKEN: ${{ secrets.METRICS_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          METRICS_DATA_DIR: ${{ github.workspace }}/.metrics-data
+        run: node scripts/metrics/src/cli-collect.ts
+
+      - name: Commit and push
+        working-directory: .metrics-data
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No change to commit"
+            exit 0
+          fi
+          git commit -m "chore(metrics): snapshot $(date -u +%Y-%m-%d)"
+          # backfill.yml can be dispatched while this runs. Rebase and retry
+          # rather than clobbering, then fail loudly if it still will not land.
+          for attempt in 1 2 3; do
+            if git push origin metrics-data; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt), rebasing"
+            git pull --rebase origin metrics-data
+          done
+          echo "Could not push after 3 attempts"
+          exit 1
+
+      # Runs even when collection failed, so a stalled collector is visible on
+      # the data branch and in the dashboard header rather than only in this tab.
+      - name: Record run outcome
+        if: always()
+        working-directory: .metrics-data
+        env:
+          OUTCOME: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          # Single-quoted on purpose: the ${...} below are JS template-literal
+          # interpolations for `node -e`, not shell expansions, and must reach
+          # node unexpanded.
+          # shellcheck disable=SC2016
+          node -e '
+            const fs = require("node:fs");
+            const now = new Date().toISOString();
+            let meta = { last_run: now, last_success: null, error: null, series_last_date: {} };
+            if (fs.existsSync("meta.json")) {
+              meta = JSON.parse(fs.readFileSync("meta.json", "utf8"));
+            }
+            meta.last_run = now;
+            if (process.env.OUTCOME === "success") {
+              meta.last_success = now;
+              meta.error = null;
+            } else {
+              meta.error = `run failed: ${process.env.OUTCOME}`;
+            }
+            fs.writeFileSync("meta.json", JSON.stringify(meta, null, 2) + "\n");
+          '
+          git add meta.json
+          git diff --cached --quiet || {
+            git commit -m "chore(metrics): record run outcome"
+            git push origin metrics-data || true
+          }
+
+      - name: Keep the schedule alive
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow enable metrics.yml --repo "${{ github.repository }}" || true

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ tests/reports/*
 # via `git add -A`, produce confusing partial-checkout behavior on clones.
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+
+# Metrics data branch, checked out into the workspace by .github/workflows/metrics.yml
+.metrics-data/

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ tests/reports/*
 
 # Metrics data branch, checked out into the workspace by .github/workflows/metrics.yml
 .metrics-data/
+# Scratch orphan-branch bootstrap worktree created (and normally removed) by the
+# same workflow's "Bootstrap the data branch if absent" step.
+.metrics-init/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,11 @@ packages/
   server/   — Fastify server, DB schema, routes, WS handler, federation, utils
   web/      — React SPA, stores, hooks, components (layout/chat/voice/modals/ui), platform layer
   desktop/  — Electron wrapper (main, preload, activity detector, keybind manager)
+scripts/
+  metrics/  — @backspace/metrics: repo traffic collector (workspace package)
 ```
+
+The metrics subsystem currently spans only `scripts/metrics` (a workspace package). A `site/insights` dashboard that reads the collected archive is planned as a separate workstream and does not exist yet.
 
 Data: `packages/server/data/` (backspace.db + uploads/)
 
@@ -161,6 +165,7 @@ Before modifying any subsystem, read its spec from `docs/systems/`. After making
 | [deployment.md](docs/systems/deployment.md) | Hosting pipeline: Docker/Caddy build, admin bootstrap, DB backup/restore, image pinning, env vars | Any deploy, backup/restore, or hosting change |
 | [activity-presence.md](docs/systems/activity-presence.md) | Presence states, rich activities, activity types/priorities, broadcast pipeline, visibility control, ActivityCard/Panel | Presence, rich activities, activity display, status management |
 | [security-scanning.md](docs/systems/security-scanning.md) | CI security pipeline: Dependabot, CodeQL SAST, gitleaks, OSV-Scanner, Trivy (config/license; image scan in a later plan), OpenSSF Scorecard, SHA-pinning, harden-runner, tiered enforcement policy, maintainer settings checklist | Any CI security work, adding/changing scanners, enabling enforcement, supply-chain hardening |
+| [metrics.md](docs/systems/metrics.md) | Traffic archive: daily collection into the `metrics-data` branch, CSV/NDJSON schemas, upsert and write-if-absent semantics, backfill, the 202 stats problem, PAT scopes, the 60-day schedule hazard | Any repo-analytics work, changing collected series, debugging a stalled collector |
 
 ---
 

--- a/docs/superpowers/plans/2026-08-25-plan-a-metrics-collection.md
+++ b/docs/superpowers/plans/2026-08-25-plan-a-metrics-collection.md
@@ -1,0 +1,2528 @@
+# Metrics Collection Pipeline (WS1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A daily GitHub Action that snapshots this repo's ephemeral traffic metrics into an orphan `metrics-data` branch as CSV/NDJSON, retained indefinitely, plus a one-shot backfill of reconstructable history.
+
+**Architecture:** A zero-runtime-dependency TypeScript package (`scripts/metrics`) executed directly by Node 24's native type stripping, so there is no build step. Parsing and upsert logic are pure functions unit-tested against fixtures; the API client is injected so no test touches the network. Data is committed to an orphan branch, isolating ~365 commits/year from `main`.
+
+**Tech Stack:** TypeScript 5.8 (strict, `erasableSyntaxOnly`), Node 24, vitest 4, GitHub Actions, `gh` CLI. No runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-repo-metrics-design.md`
+
+## Global Constraints
+
+Copied verbatim from the spec. Every task's requirements implicitly include these.
+
+- **Zero runtime dependencies.** `src/` imports only `node:` builtins and global `fetch`. Enforced by a test (Task 2).
+- **`import type` is mandatory** for type-only imports. Without it Node throws `SyntaxError` at runtime while `tsc` stays green. (spec 3.7)
+- **Relative imports carry the `.ts` extension**: `import './series.ts'`, never `'./series'`. (spec 3.7)
+- **Forbidden syntax:** enums, namespaces with runtime code, parameter properties, import aliases, decorators. Enforced by `erasableSyntaxOnly`. (spec 3.7)
+- **Traffic is required; releases and stats are optional.** A failed required fetch aborts the entire write. A failed optional fetch skips, leaving the prior value. (spec 4.4, 5.2)
+- **Backfill is write-if-absent.** It may never overwrite a date that already has a row. (spec 5.2)
+- **No zero-filling.** A missing date means "not collected", never "zero". (spec 5.2)
+- **Never assume the traffic window ends today.** The last bucket is frequently yesterday, non-deterministically. (spec 5.2)
+- **A persistent HTTP 202 is a skip, never a zero.** (spec 6.1)
+- **Workflows:** header comment explaining *why*, `step-security/harden-runner` with `egress-policy: audit`, every `uses:` pinned to a full SHA with a trailing `# vX.Y.Z`. (spec 4)
+- **Repo slug** is read from `github.repository`, never hardcoded. (spec 10)
+- **Commit identity:** the workflow commits as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`.
+
+### Deviation from spec 3.6, deliberate
+
+Spec 3.6 specifies the package `test` script as `tsc --noEmit && vitest run && node --experimental-strip-types vendor-check.ts`. `vendor-check.ts` belongs to WS3 — it guards the vendored uPlot copy, which does not exist yet. This plan sets `test` to `tsc --noEmit && vitest run`; **WS3 appends the vendor-check clause.** Recorded here so the WS3 implementer knows it is their job.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `pnpm-workspace.yaml` | Add `scripts/metrics` to the workspace (modify) |
+| `.gitignore` | Ignore `.metrics-data/` (modify) |
+| `scripts/metrics/package.json` | Package manifest, `test` script, TS 5.8 |
+| `scripts/metrics/tsconfig.json` | Strict + `erasableSyntaxOnly` + `.ts` imports |
+| `scripts/metrics/src/types.ts` | Row shapes. Types only, no runtime values |
+| `scripts/metrics/src/series.ts` | CSV/NDJSON parse, format, upsert. Pure functions |
+| `scripts/metrics/src/github.ts` | API client: auth, pagination, 202 retry. Injectable `fetch` |
+| `scripts/metrics/src/store.ts` | Filesystem read/write of the data directory |
+| `scripts/metrics/src/collect.ts` | Daily orchestration and atomicity. Injectable client |
+| `scripts/metrics/src/backfill.ts` | Historical reconstruction, write-if-absent |
+| `scripts/metrics/src/no-runtime-deps.test.ts` | Static guard on imports |
+| `.github/workflows/metrics.yml` | Daily cron |
+| `.github/workflows/backfill.yml` | `workflow_dispatch` only |
+| `docs/systems/metrics.md` | Subsystem doc |
+| `CLAUDE.md` | Subsystem table + monorepo structure rows (modify) |
+| `docs/systems/security-scanning.md` | Two maintainer-checklist entries (modify) |
+
+---
+
+## Task 1: Package scaffold and workspace wiring
+
+**Files:**
+- Modify: `pnpm-workspace.yaml`
+- Create: `scripts/metrics/package.json`
+- Create: `scripts/metrics/tsconfig.json`
+- Create: `scripts/metrics/src/types.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the `@backspace/metrics` package, picked up by `pnpm -r test`. Types `IsoDate`, `TrafficPoint`, `CountPoint`, `ReleaseRow`, `RepoPoint`, `DimensionRow` for every later task.
+
+- [ ] **Step 1: Add the package to the workspace**
+
+Modify `pnpm-workspace.yaml` to read exactly:
+
+```yaml
+packages:
+  - "packages/*"
+  # Repo tooling that needs typecheck + tests, listed explicitly rather than as
+  # `scripts/*` so unrelated one-off scripts (gen-icons.mjs) stay out of the
+  # workspace. See docs/systems/metrics.md.
+  - "scripts/metrics"
+```
+
+- [ ] **Step 2: Create the package manifest**
+
+Create `scripts/metrics/package.json`:
+
+```json
+{
+  "name": "@backspace/metrics",
+  "version": "1.0.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "author": "Jannis Braun",
+  "type": "module",
+  "engines": {
+    "node": ">=22.18"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsc --noEmit && vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0",
+    "vitest": "^4.0.18"
+  }
+}
+```
+
+Note the TypeScript floor. Every other workspace pins `^5.4.0`, but `erasableSyntaxOnly` did not land until 5.8, so this package needs its own newer copy. pnpm handles the divergence.
+
+- [ ] **Step 3: Create the tsconfig**
+
+Create `scripts/metrics/tsconfig.json`:
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*"]
+}
+```
+
+`erasableSyntaxOnly` and `verbatimModuleSyntax` are the whole point: they make `tsc --noEmit` reject the constructs Node's type stripper cannot handle, so the failure surfaces in CI instead of at 03:00 in the cron. `allowImportingTsExtensions` permits the mandatory `.ts` import suffixes and requires `noEmit`, which is set. `declaration`, `declarationMap`, and `sourceMap` are turned back off because `tsconfig.base.json` enables them and they are illegal alongside `noEmit`.
+
+- [ ] **Step 4: Create the shared types**
+
+Create `scripts/metrics/src/types.ts`:
+
+```ts
+/** A UTC calendar date, `YYYY-MM-DD`. */
+export type IsoDate = string;
+
+/** One day of views or clones. */
+export interface TrafficPoint {
+  date: IsoDate;
+  count: number;
+  uniques: number;
+}
+
+/** One day of a cumulative counter (stars, forks, contributors). */
+export interface CountPoint {
+  date: IsoDate;
+  total: number;
+}
+
+/** A published release. `date` is the UTC day of `published_at`. */
+export interface ReleaseRow {
+  date: IsoDate;
+  tag: string;
+  name: string;
+}
+
+/** One day of repo-object counters. */
+export interface RepoPoint {
+  date: IsoDate;
+  subscribers: number;
+  open_issues: number;
+  downloads_total: number;
+}
+
+/**
+ * One row of a trailing-14-day aggregate, tagged with the day it was fetched.
+ * `dimension` is the referrer host or the content path.
+ */
+export interface DimensionRow {
+  snapshot_date: IsoDate;
+  dimension: string;
+  title: string;
+  count: number;
+  uniques: number;
+}
+```
+
+This file must contain **no runtime values** — no `const`, no `enum`, no class. Consumers import from it with `import type`.
+
+- [ ] **Step 5: Install and verify the workspace picks it up**
+
+Run: `pnpm install`
+
+Then run: `pnpm --filter @backspace/metrics exec tsc --noEmit`
+Expected: exits 0, no output.
+
+Then run: `pnpm -r test 2>&1 | grep -c "@backspace/metrics"`
+Expected: at least `1`. The package appears in the recursive run and fails for having no test files; that is Task 2's job.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pnpm-workspace.yaml pnpm-lock.yaml scripts/metrics/package.json scripts/metrics/tsconfig.json scripts/metrics/src/types.ts
+git commit -m "chore(metrics): scaffold @backspace/metrics workspace package"
+```
+
+---
+
+## Task 2: Zero-runtime-dependency guard
+
+**Files:**
+- Create: `scripts/metrics/src/no-runtime-deps.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a standing guard. Every later task that adds a `src/*.ts` file is covered automatically.
+
+This task comes before the modules it guards so the constraint cannot silently regress as they are written.
+
+- [ ] **Step 1: Write the test**
+
+Create `scripts/metrics/src/no-runtime-deps.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const srcDir = path.dirname(fileURLToPath(import.meta.url));
+
+function sourceFiles(): string[] {
+  return readdirSync(srcDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+}
+
+/** Matches the module specifier of any static import or re-export. */
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s+['"]([^'"]+)['"]/g;
+
+describe('collector source constraints', () => {
+  it('has source files to check', () => {
+    expect(sourceFiles().length).toBeGreaterThan(0);
+  });
+
+  it('imports nothing outside node: builtins and relative paths', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(path.join(srcDir, file), 'utf8');
+      for (const match of text.matchAll(IMPORT_RE)) {
+        const spec = match[1];
+        if (spec === undefined) continue;
+        const ok = spec.startsWith('node:') || spec.startsWith('./') || spec.startsWith('../');
+        if (!ok) offenders.push(`${file} -> ${spec}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('uses the .ts extension on every relative import', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(path.join(srcDir, file), 'utf8');
+      for (const match of text.matchAll(IMPORT_RE)) {
+        const spec = match[1];
+        if (spec === undefined) continue;
+        if ((spec.startsWith('./') || spec.startsWith('../')) && !spec.endsWith('.ts')) {
+          offenders.push(`${file} -> ${spec}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('imports types with the type keyword so Node can erase them', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(path.join(srcDir, file), 'utf8');
+      for (const match of text.matchAll(IMPORT_RE)) {
+        const spec = match[1];
+        if (spec === undefined) continue;
+        if (!spec.endsWith('types.ts')) continue;
+        if (!/import\s+type\b/.test(match[0])) {
+          offenders.push(`${file} -> ${spec} (missing import type)`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+```
+
+The fourth test is the important one. `types.ts` holds only types, so a value-import of it is a runtime `SyntaxError` under Node's stripper, and that failure would otherwise appear for the first time in the cron.
+
+- [ ] **Step 2: Run the test**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS, 4 tests. Only `types.ts` exists so far and it imports nothing, so all four are trivially green. If instead it errors with "No test files found", vitest did not install — re-run `pnpm install`.
+
+- [ ] **Step 3: Verify the guard actually catches a violation**
+
+A guard that has never been seen to fail is not a guard. Temporarily add this line to the top of `scripts/metrics/src/types.ts`:
+
+```ts
+import { readFileSync } from 'fs';
+```
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: FAIL — "imports nothing outside node: builtins" reports `types.ts -> fs`.
+
+Now delete that line and re-run.
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/metrics/src/no-runtime-deps.test.ts
+git commit -m "test(metrics): guard collector against runtime deps and unerasable imports"
+```
+
+---
+
+## Task 3: CSV series — parse, format, upsert
+
+**Files:**
+- Create: `scripts/metrics/src/series.ts`
+- Create: `scripts/metrics/src/series.test.ts`
+
+**Interfaces:**
+- Consumes: `IsoDate` from `types.ts`.
+- Produces:
+  - `parseCsv(text: string): Record<string, string>[]`
+  - `formatCsv(header: readonly string[], rows: ReadonlyArray<Record<string, string | number>>): string`
+  - `upsertByDate<T extends { date: IsoDate }>(existing: readonly T[], incoming: readonly T[], mode: 'overwrite' | 'if-absent'): T[]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/metrics/src/series.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseCsv, formatCsv, upsertByDate } from './series.ts';
+
+describe('parseCsv', () => {
+  it('parses a header and rows into keyed records', () => {
+    const text = 'date,count,uniques\n2026-08-01,10,4\n2026-08-02,12,5\n';
+    expect(parseCsv(text)).toEqual([
+      { date: '2026-08-01', count: '10', uniques: '4' },
+      { date: '2026-08-02', count: '12', uniques: '5' },
+    ]);
+  });
+
+  it('returns an empty array for empty or header-only input', () => {
+    expect(parseCsv('')).toEqual([]);
+    expect(parseCsv('date,count\n')).toEqual([]);
+  });
+
+  it('round-trips quoted fields containing commas and quotes', () => {
+    const rows = [{ snapshot_date: '2026-08-01', title: 'Backspace: chat, voice and "video"' }];
+    const text = formatCsv(['snapshot_date', 'title'], rows);
+    expect(parseCsv(text)).toEqual([
+      { snapshot_date: '2026-08-01', title: 'Backspace: chat, voice and "video"' },
+    ]);
+  });
+});
+
+describe('formatCsv', () => {
+  it('emits a header, sorts by the first column, and ends with a newline', () => {
+    const text = formatCsv(['date', 'total'], [
+      { date: '2026-08-02', total: 2 },
+      { date: '2026-08-01', total: 1 },
+    ]);
+    expect(text).toBe('date,total\n2026-08-01,1\n2026-08-02,2\n');
+  });
+});
+
+describe('upsertByDate', () => {
+  const existing = [
+    { date: '2026-08-01', total: 1 },
+    { date: '2026-08-02', total: 2 },
+  ];
+
+  it('overwrite mode: fetched values win on collision', () => {
+    const result = upsertByDate(existing, [{ date: '2026-08-02', total: 99 }], 'overwrite');
+    expect(result).toEqual([
+      { date: '2026-08-01', total: 1 },
+      { date: '2026-08-02', total: 99 },
+    ]);
+  });
+
+  it('overwrite mode: overlapping windows produce no duplicates', () => {
+    const incoming = [
+      { date: '2026-08-02', total: 2 },
+      { date: '2026-08-03', total: 3 },
+    ];
+    const result = upsertByDate(existing, incoming, 'overwrite');
+    expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-02', '2026-08-03']);
+  });
+
+  it('overwrite mode: re-running with identical input is byte-identical', () => {
+    const once = upsertByDate(existing, existing, 'overwrite');
+    const twice = upsertByDate(once, existing, 'overwrite');
+    expect(formatCsv(['date', 'total'], twice)).toBe(formatCsv(['date', 'total'], once));
+  });
+
+  it('if-absent mode: never overwrites a date that already has a row', () => {
+    const result = upsertByDate(existing, [{ date: '2026-08-02', total: 99 }], 'if-absent');
+    expect(result).toEqual(existing);
+  });
+
+  it('if-absent mode: fills only genuinely missing dates', () => {
+    const result = upsertByDate(existing, [
+      { date: '2026-08-02', total: 99 },
+      { date: '2026-08-03', total: 3 },
+    ], 'if-absent');
+    expect(result).toEqual([
+      { date: '2026-08-01', total: 1 },
+      { date: '2026-08-02', total: 2 },
+      { date: '2026-08-03', total: 3 },
+    ]);
+  });
+
+  it('leaves gaps absent rather than zero-filling them', () => {
+    const result = upsertByDate([], [
+      { date: '2026-08-01', total: 1 },
+      { date: '2026-08-05', total: 5 },
+    ], 'overwrite');
+    expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-05']);
+  });
+
+  it('sorts output ascending regardless of input order', () => {
+    const result = upsertByDate([], [
+      { date: '2026-08-09', total: 9 },
+      { date: '2026-08-01', total: 1 },
+    ], 'overwrite');
+    expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-09']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: FAIL — `Failed to resolve import "./series.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/metrics/src/series.ts`:
+
+```ts
+import type { IsoDate } from './types.ts';
+
+/** Quotes a CSV field only when it contains a comma, quote, or newline. */
+function quote(value: string): string {
+  if (!/[",\n\r]/.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/** Splits one CSV line, honouring quoted fields and doubled escape quotes. */
+function splitLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char ?? '';
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      fields.push(current);
+      current = '';
+    } else {
+      current += char ?? '';
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+export function parseCsv(text: string): Record<string, string>[] {
+  const lines = text.split('\n').filter((line) => line.length > 0);
+  const headerLine = lines.shift();
+  if (headerLine === undefined) return [];
+  const header = splitLine(headerLine);
+  return lines.map((line) => {
+    const fields = splitLine(line);
+    const row: Record<string, string> = {};
+    header.forEach((key, index) => {
+      row[key] = fields[index] ?? '';
+    });
+    return row;
+  });
+}
+
+export function formatCsv(
+  header: readonly string[],
+  rows: ReadonlyArray<Record<string, string | number>>,
+): string {
+  const sortKey = header[0];
+  if (sortKey === undefined) throw new Error('formatCsv requires at least one header column');
+  const sorted = [...rows].sort((a, b) =>
+    String(a[sortKey] ?? '').localeCompare(String(b[sortKey] ?? '')),
+  );
+  const body = sorted.map((row) => header.map((key) => quote(String(row[key] ?? ''))).join(','));
+  return [header.join(','), ...body].join('\n') + '\n';
+}
+
+/**
+ * Merges `incoming` into `existing`, keyed by `date`, returning a
+ * date-ascending array.
+ *
+ * `overwrite` — the fetched value wins. Used by the daily collector, where the
+ * API is authoritative and re-fetching a 14-day window must be idempotent.
+ *
+ * `if-absent` — an existing row is never replaced. Used by backfill, which
+ * reconstructs history from `starred_at` and therefore cannot see stars that
+ * were later removed. Overwriting a measured value with a reconstructed one
+ * would silently corrupt the series.
+ */
+export function upsertByDate<T extends { date: IsoDate }>(
+  existing: readonly T[],
+  incoming: readonly T[],
+  mode: 'overwrite' | 'if-absent',
+): T[] {
+  const byDate = new Map<IsoDate, T>();
+  for (const row of existing) byDate.set(row.date, row);
+  for (const row of incoming) {
+    if (mode === 'if-absent' && byDate.has(row.date)) continue;
+    byDate.set(row.date, row);
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS, all `series.test.ts` and `no-runtime-deps.test.ts` cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/metrics/src/series.ts scripts/metrics/src/series.test.ts
+git commit -m "feat(metrics): add CSV series parse, format, and date upsert"
+```
+
+---
+
+## Task 4: NDJSON dimensional series
+
+**Files:**
+- Modify: `scripts/metrics/src/series.ts`
+- Modify: `scripts/metrics/src/series.test.ts`
+
+**Interfaces:**
+- Consumes: `DimensionRow` from `types.ts`.
+- Produces:
+  - `parseNdjson(text: string): DimensionRow[]`
+  - `formatNdjson(rows: readonly DimensionRow[]): string`
+  - `upsertDimensional(existing: readonly DimensionRow[], incoming: readonly DimensionRow[]): DimensionRow[]`
+
+Split from Task 3 because the sort contract is different and load-bearing: the wrong secondary sort churns the whole file on every commit, which defeats the plain-text-over-SQLite rationale (spec 5.3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `scripts/metrics/src/series.test.ts`:
+
+```ts
+import { parseNdjson, formatNdjson, upsertDimensional } from './series.ts';
+import type { DimensionRow } from './types.ts';
+
+function row(snapshot_date: string, dimension: string, count: number): DimensionRow {
+  return { snapshot_date, dimension, title: '', count, uniques: 1 };
+}
+
+describe('formatNdjson', () => {
+  it('sorts by snapshot_date asc, then count desc, then dimension asc', () => {
+    const text = formatNdjson([
+      row('2026-08-02', 'b.com', 5),
+      row('2026-08-01', 'z.com', 1),
+      row('2026-08-01', 'a.com', 9),
+      row('2026-08-01', 'm.com', 9),
+    ]);
+    const order = text
+      .trim()
+      .split('\n')
+      .map((line) => {
+        const parsed = JSON.parse(line) as DimensionRow;
+        return `${parsed.snapshot_date}/${parsed.dimension}`;
+      });
+    expect(order).toEqual([
+      '2026-08-01/a.com',
+      '2026-08-01/m.com',
+      '2026-08-01/z.com',
+      '2026-08-02/b.com',
+    ]);
+  });
+
+  it('round-trips through parseNdjson', () => {
+    const rows = [row('2026-08-01', 'news.ycombinator.com', 118)];
+    expect(parseNdjson(formatNdjson(rows))).toEqual(rows);
+  });
+
+  it('ignores blank lines when parsing', () => {
+    expect(parseNdjson('\n\n')).toEqual([]);
+  });
+});
+
+describe('upsertDimensional', () => {
+  it('replaces a row with the same (snapshot_date, dimension)', () => {
+    const existing = [row('2026-08-01', 'a.com', 1)];
+    const result = upsertDimensional(existing, [row('2026-08-01', 'a.com', 42)]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.count).toBe(42);
+  });
+
+  it('keeps rows from other snapshots untouched', () => {
+    const existing = [row('2026-08-01', 'a.com', 1)];
+    const result = upsertDimensional(existing, [row('2026-08-02', 'a.com', 2)]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not resurrect a dimension that dropped out of the new snapshot', () => {
+    const existing = [row('2026-08-01', 'a.com', 1)];
+    const result = upsertDimensional(existing, [row('2026-08-02', 'b.com', 2)]);
+    const day2 = result.filter((r) => r.snapshot_date === '2026-08-02');
+    expect(day2.map((r) => r.dimension)).toEqual(['b.com']);
+  });
+
+  it('re-running with identical input is byte-identical', () => {
+    const rows = [row('2026-08-01', 'a.com', 1), row('2026-08-01', 'b.com', 2)];
+    const once = upsertDimensional([], rows);
+    const twice = upsertDimensional(once, rows);
+    expect(formatNdjson(twice)).toBe(formatNdjson(once));
+  });
+});
+```
+
+The third test encodes spec 5.3: a dimension absent from a snapshot means "outside the top 10", not zero, so it simply has no row for that day and the dashboard renders a break.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: FAIL — `parseNdjson is not exported by ./series.ts`.
+
+- [ ] **Step 3: Write the implementation**
+
+First change the existing type import at the top of `scripts/metrics/src/series.ts` to:
+
+```ts
+import type { DimensionRow, IsoDate } from './types.ts';
+```
+
+Then append to the same file:
+
+```ts
+export function parseNdjson(text: string): DimensionRow[] {
+  return text
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as DimensionRow);
+}
+
+/**
+ * Serialises dimensional rows with a fixed total order: `snapshot_date`
+ * ascending, then `count` descending, then `dimension` ascending as the
+ * tie-break.
+ *
+ * The order is part of the storage contract, not a preference. Any unstable
+ * ordering rewrites the whole file on every daily commit, which would defeat
+ * the one-line-per-day diff that justified plain text over SQLite.
+ */
+export function formatNdjson(rows: readonly DimensionRow[]): string {
+  const sorted = [...rows].sort((a, b) => {
+    if (a.snapshot_date !== b.snapshot_date) {
+      return a.snapshot_date.localeCompare(b.snapshot_date);
+    }
+    if (a.count !== b.count) return b.count - a.count;
+    return a.dimension.localeCompare(b.dimension);
+  });
+  return sorted.map((row) => JSON.stringify(row)).join('\n') + '\n';
+}
+
+/** Merges dimensional rows keyed by `(snapshot_date, dimension)`. */
+export function upsertDimensional(
+  existing: readonly DimensionRow[],
+  incoming: readonly DimensionRow[],
+): DimensionRow[] {
+  const byKey = new Map<string, DimensionRow>();
+  for (const row of existing) byKey.set(`${row.snapshot_date} ${row.dimension}`, row);
+  for (const row of incoming) byKey.set(`${row.snapshot_date} ${row.dimension}`, row);
+  return parseNdjson(formatNdjson([...byKey.values()]));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/metrics/src/series.ts scripts/metrics/src/series.test.ts
+git commit -m "feat(metrics): add NDJSON dimensional series with a fixed sort contract"
+```
+
+---
+
+## Task 5: GitHub API client with 202 retry and pagination
+
+**Files:**
+- Create: `scripts/metrics/src/github.ts`
+- Create: `scripts/metrics/src/github.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `class GitHubError extends Error` with a readonly `status: number`
+  - `interface GitHubClient { get<T>(path: string, accept?: string): Promise<T>; getStats<T>(path: string): Promise<T | null>; paginate<T>(path: string, accept?: string): Promise<T[]>; }`
+  - `createClient(token: string, options?: { fetchImpl?: typeof fetch; sleep?: (ms: number) => Promise<void>; statsAttempts?: number }): GitHubClient`
+
+`getStats` returns `null` on a persistent 202. Callers treat null as "skip", never as zero.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/metrics/src/github.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { createClient, GitHubError } from './github.ts';
+
+const noSleep = async (): Promise<void> => {};
+
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+  });
+}
+
+describe('createClient.get', () => {
+  it('sends the token and the API version header', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ ok: true }));
+    const client = createClient('tok_123', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await client.get('/repos/o/r');
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe('https://api.github.com/repos/o/r');
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer tok_123');
+    expect(headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+  });
+
+  it('honours a custom Accept header for the star media type', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse([]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await client.get('/stargazers', 'application/vnd.github.star+json');
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers.Accept).toBe('application/vnd.github.star+json');
+  });
+
+  it('throws GitHubError carrying the status on a non-2xx response', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ message: 'Not Found' }, { status: 404 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.get('/nope')).rejects.toBeInstanceOf(GitHubError);
+    await expect(client.get('/nope')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('createClient.getStats', () => {
+  it('retries a 202 and returns the body once it becomes 200', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, { status: 202 }))
+      .mockResolvedValueOnce(jsonResponse([{ total: 5 }]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.getStats('/stats/contributors')).resolves.toEqual([{ total: 5 }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null after a persistent 202 rather than an empty body', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, { status: 202 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+      statsAttempts: 3,
+    });
+    const result = await client.getStats('/stats/contributors');
+    expect(result).toBeNull();
+    expect(result).not.toEqual({});
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('createClient.paginate', () => {
+  it('follows rel=next until it is absent and concatenates pages', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 1 }], {
+          headers: { link: '<https://api.github.com/x?page=2>; rel="next"' },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse([{ id: 2 }]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/x')).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('requests 100 items per page', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse([]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await client.paginate('/x');
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toContain('per_page=100');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: FAIL — `Failed to resolve import "./github.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/metrics/src/github.ts`:
+
+```ts
+const API_ROOT = 'https://api.github.com';
+
+export class GitHubError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(`GitHub API ${status}: ${message}`);
+    this.name = 'GitHubError';
+    this.status = status;
+  }
+}
+
+export interface GitHubClient {
+  /** Fetches one resource. Throws GitHubError on any non-2xx response. */
+  get<T>(path: string, accept?: string): Promise<T>;
+  /**
+   * Fetches a `/stats/*` resource, which returns 202 while GitHub computes it.
+   * Returns `null` when it is still computing after every attempt. Callers MUST
+   * treat null as "leave the previous value alone", never as zero.
+   */
+  getStats<T>(path: string): Promise<T | null>;
+  /** Fetches every page of a list endpoint by following rel="next". */
+  paginate<T>(path: string, accept?: string): Promise<T[]>;
+}
+
+export interface ClientOptions {
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  statsAttempts?: number;
+}
+
+function nextLink(header: string | null): string | null {
+  if (header === null) return null;
+  for (const part of header.split(',')) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (match?.[1] !== undefined) return match[1];
+  }
+  return null;
+}
+
+export function createClient(token: string, options: ClientOptions = {}): GitHubClient {
+  const doFetch = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const statsAttempts = options.statsAttempts ?? 5;
+
+  const baseHeaders: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'backspace-metrics',
+  };
+
+  function absolute(path: string): string {
+    return path.startsWith('http') ? path : `${API_ROOT}${path}`;
+  }
+
+  async function request(url: string, accept?: string): Promise<Response> {
+    const headers = accept === undefined ? baseHeaders : { ...baseHeaders, Accept: accept };
+    return doFetch(url, { headers });
+  }
+
+  async function get<T>(path: string, accept?: string): Promise<T> {
+    const response = await request(absolute(path), accept);
+    if (!response.ok) throw new GitHubError(response.status, await response.text());
+    return (await response.json()) as T;
+  }
+
+  async function getStats<T>(path: string): Promise<T | null> {
+    for (let attempt = 0; attempt < statsAttempts; attempt++) {
+      const response = await request(absolute(path));
+      // 202 means GitHub is still computing the statistic and the body is `{}`.
+      // Reading that as data would write a zero over a real value. The stats
+      // cache is keyed by the default branch SHA and reset by every push to
+      // main, so on an active repo this is routine, not exceptional.
+      if (response.status === 202) {
+        await sleep(2000 * (attempt + 1));
+        continue;
+      }
+      if (!response.ok) throw new GitHubError(response.status, await response.text());
+      return (await response.json()) as T;
+    }
+    return null;
+  }
+
+  async function paginate<T>(path: string, accept?: string): Promise<T[]> {
+    const separator = path.includes('?') ? '&' : '?';
+    let url: string | null = absolute(`${path}${separator}per_page=100`);
+    const items: T[] = [];
+    while (url !== null) {
+      const response: Response = await request(url, accept);
+      if (!response.ok) throw new GitHubError(response.status, await response.text());
+      items.push(...((await response.json()) as T[]));
+      url = nextLink(response.headers.get('link'));
+    }
+    return items;
+  }
+
+  return { get, getStats, paginate };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/metrics/src/github.ts scripts/metrics/src/github.test.ts
+git commit -m "feat(metrics): add GitHub client with 202 stats retry and pagination"
+```
+
+---
+
+## Task 6: Filesystem store
+
+**Files:**
+- Create: `scripts/metrics/src/store.ts`
+- Create: `scripts/metrics/src/store.test.ts`
+
+**Interfaces:**
+- Consumes: `parseCsv`, `formatCsv`, `parseNdjson`, `formatNdjson` from `series.ts`; `DimensionRow`, `IsoDate` from `types.ts`.
+- Produces:
+  - `interface Meta { last_run: string; last_success: string | null; error: string | null; series_last_date: Record<string, IsoDate>; }`
+  - `interface Store { readCsv(file: string): Record<string, string>[]; writeCsv(file: string, header: readonly string[], rows: ReadonlyArray<Record<string, string | number>>): void; readNdjson(file: string): DimensionRow[]; writeNdjson(file: string, rows: readonly DimensionRow[]): void; readMeta(): Meta | null; writeMeta(meta: Meta): void; }`
+  - `createStore(dataDir: string): Store`
+
+The store is the only module that touches the filesystem. Isolating it here is what lets Task 7 test orchestration against a temp directory with no mocking of `node:fs`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/metrics/src/store.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createStore } from './store.ts';
+
+let dir = '';
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'metrics-store-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('createStore', () => {
+  it('returns an empty array for a file that does not exist', () => {
+    const store = createStore(dir);
+    expect(store.readCsv('stars.csv')).toEqual([]);
+    expect(store.readNdjson('traffic/referrers.ndjson')).toEqual([]);
+  });
+
+  it('creates nested directories on write', () => {
+    const store = createStore(dir);
+    store.writeCsv('traffic/views.csv', ['date', 'count'], [{ date: '2026-08-01', count: 3 }]);
+    expect(existsSync(path.join(dir, 'traffic/views.csv'))).toBe(true);
+  });
+
+  it('round-trips CSV through the filesystem', () => {
+    const store = createStore(dir);
+    store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-08-01', total: 56 }]);
+    expect(store.readCsv('stars.csv')).toEqual([{ date: '2026-08-01', total: '56' }]);
+  });
+
+  it('round-trips NDJSON through the filesystem', () => {
+    const store = createStore(dir);
+    const rows = [
+      { snapshot_date: '2026-08-01', dimension: 'a.com', title: '', count: 5, uniques: 2 },
+    ];
+    store.writeNdjson('traffic/referrers.ndjson', rows);
+    expect(store.readNdjson('traffic/referrers.ndjson')).toEqual(rows);
+  });
+
+  it('returns null when meta.json is absent', () => {
+    expect(createStore(dir).readMeta()).toBeNull();
+  });
+
+  it('writes meta.json as pretty-printed JSON with a trailing newline', () => {
+    const store = createStore(dir);
+    store.writeMeta({
+      last_run: '2026-08-25T03:00:41Z',
+      last_success: '2026-08-25T03:00:41Z',
+      error: null,
+      series_last_date: { 'stars.csv': '2026-08-25' },
+    });
+    const text = readFileSync(path.join(dir, 'meta.json'), 'utf8');
+    expect(text.endsWith('\n')).toBe(true);
+    expect(text).toContain('\n  "last_run"');
+    expect(store.readMeta()?.series_last_date['stars.csv']).toBe('2026-08-25');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: FAIL — `Failed to resolve import "./store.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/metrics/src/store.ts`:
+
+```ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { parseCsv, formatCsv, parseNdjson, formatNdjson } from './series.ts';
+import type { DimensionRow, IsoDate } from './types.ts';
+
+/** Collector health, written to `meta.json` at the root of the data branch. */
+export interface Meta {
+  last_run: string;
+  last_success: string | null;
+  error: string | null;
+  /** Keys are exact file paths, e.g. `traffic/views.csv`. */
+  series_last_date: Record<string, IsoDate>;
+}
+
+export interface Store {
+  readCsv(file: string): Record<string, string>[];
+  writeCsv(
+    file: string,
+    header: readonly string[],
+    rows: ReadonlyArray<Record<string, string | number>>,
+  ): void;
+  readNdjson(file: string): DimensionRow[];
+  writeNdjson(file: string, rows: readonly DimensionRow[]): void;
+  readMeta(): Meta | null;
+  writeMeta(meta: Meta): void;
+}
+
+export function createStore(dataDir: string): Store {
+  function resolve(file: string): string {
+    return path.join(dataDir, file);
+  }
+
+  function read(file: string): string | null {
+    const full = resolve(file);
+    if (!existsSync(full)) return null;
+    return readFileSync(full, 'utf8');
+  }
+
+  function write(file: string, text: string): void {
+    const full = resolve(file);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, text, 'utf8');
+  }
+
+  return {
+    readCsv(file) {
+      const text = read(file);
+      return text === null ? [] : parseCsv(text);
+    },
+    writeCsv(file, header, rows) {
+      write(file, formatCsv(header, rows));
+    },
+    readNdjson(file) {
+      const text = read(file);
+      return text === null ? [] : parseNdjson(text);
+    },
+    writeNdjson(file, rows) {
+      write(file, formatNdjson(rows));
+    },
+    readMeta() {
+      const text = read('meta.json');
+      return text === null ? null : (JSON.parse(text) as Meta);
+    },
+    writeMeta(meta) {
+      write('meta.json', JSON.stringify(meta, null, 2) + '\n');
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/metrics/src/store.ts scripts/metrics/src/store.test.ts
+git commit -m "feat(metrics): add filesystem store for the data branch"
+```
+
+---
+
+## Task 7: Daily collection with atomicity
+
+**Files:**
+- Create: `scripts/metrics/src/collect.ts`
+- Create: `scripts/metrics/src/collect.test.ts`
+
+**Interfaces:**
+- Consumes: `GitHubClient` from `github.ts`; `Store`, `Meta` from `store.ts`; `upsertByDate`, `upsertDimensional` from `series.ts`; all row types from `types.ts`.
+- Produces:
+  - `interface CollectResult { written: string[]; skipped: string[]; }`
+  - `collect(options: { client: GitHubClient; store: Store; slug: string; today: IsoDate; now: string }): Promise<CollectResult>`
+
+`today` and `now` are injected rather than read from the clock so tests are deterministic.
+
+This is the task where the spec's two hardest rules become code: **any required fetch failing means nothing is written at all**, and **an optional fetch failing skips without writing a zero**.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/metrics/src/collect.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createStore } from './store.ts';
+import { collect } from './collect.ts';
+import type { GitHubClient } from './github.ts';
+
+let dir = '';
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'metrics-collect-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const VIEWS = {
+  views: [
+    { timestamp: '2026-08-23T00:00:00Z', count: 40, uniques: 12 },
+    { timestamp: '2026-08-24T00:00:00Z', count: 51, uniques: 15 },
+  ],
+};
+const CLONES = {
+  clones: [{ timestamp: '2026-08-24T00:00:00Z', count: 4, uniques: 3 }],
+};
+const REFERRERS = [{ referrer: 'news.ycombinator.com', count: 118, uniques: 94 }];
+const PATHS = [{ path: '/TheZwiss/backspace', title: 'Backspace', count: 402, uniques: 161 }];
+const REPO = {
+  stargazers_count: 56,
+  forks_count: 3,
+  subscribers_count: 1,
+  open_issues_count: 13,
+};
+const RELEASES = [
+  {
+    tag_name: 'v1.0.0',
+    name: 'Backspace 1.0.0',
+    published_at: '2026-08-01T10:00:00Z',
+    assets: [{ download_count: 20 }, { download_count: 17 }],
+  },
+];
+const CONTRIBUTORS = [{ weeks: [{ w: 1771200000, c: 3 }] }, { weeks: [{ w: 1771804800, c: 1 }] }];
+
+function fakeClient(overrides: Partial<Record<string, unknown>> = {}): GitHubClient {
+  const routes: Record<string, unknown> = {
+    '/repos/o/r/traffic/views': VIEWS,
+    '/repos/o/r/traffic/clones': CLONES,
+    '/repos/o/r/traffic/popular/referrers': REFERRERS,
+    '/repos/o/r/traffic/popular/paths': PATHS,
+    '/repos/o/r': REPO,
+    '/repos/o/r/releases': RELEASES,
+    ...overrides,
+  };
+  return {
+    async get<T>(p: string): Promise<T> {
+      const value = routes[p];
+      if (value instanceof Error) throw value;
+      if (value === undefined) throw new Error(`unexpected GET ${p}`);
+      return value as T;
+    },
+    async getStats<T>(p: string): Promise<T | null> {
+      if (Object.prototype.hasOwnProperty.call(overrides, p)) {
+        return overrides[p] as T | null;
+      }
+      if (p === '/repos/o/r/stats/contributors') return CONTRIBUTORS as T;
+      return null;
+    },
+    async paginate<T>(): Promise<T[]> {
+      throw new Error('collect must not paginate');
+    },
+  };
+}
+
+const base = { slug: 'o/r', today: '2026-08-25', now: '2026-08-25T03:00:41Z' };
+
+describe('collect', () => {
+  it('writes traffic keyed by the bucket date, not by today', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('traffic/views.csv')).toEqual([
+      { date: '2026-08-23', count: '40', uniques: '12' },
+      { date: '2026-08-24', count: '51', uniques: '15' },
+    ]);
+  });
+
+  it('does not invent a row for today when the window ends yesterday', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const dates = store.readCsv('traffic/views.csv').map((r) => r.date);
+    expect(dates).not.toContain('2026-08-25');
+  });
+
+  it('tags dimensional snapshots with today', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const rows = store.readNdjson('traffic/referrers.ndjson');
+    expect(rows).toEqual([
+      {
+        snapshot_date: '2026-08-25',
+        dimension: 'news.ycombinator.com',
+        title: '',
+        count: 118,
+        uniques: 94,
+      },
+    ]);
+  });
+
+  it('writes stars and forks from the repo object counters, dated today', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('stars.csv')).toEqual([{ date: '2026-08-25', total: '56' }]);
+    expect(store.readCsv('forks.csv')).toEqual([{ date: '2026-08-25', total: '3' }]);
+  });
+
+  it('sums every asset download count into repo.csv', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('repo.csv')).toEqual([
+      {
+        date: '2026-08-25',
+        subscribers: '1',
+        open_issues: '13',
+        downloads_total: '37',
+      },
+    ]);
+  });
+
+  it('records release publish dates for the growth-chart annotations', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'Backspace 1.0.0' },
+    ]);
+  });
+
+  it('aborts the entire write when a required traffic fetch fails', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({ '/repos/o/r/traffic/clones': new Error('boom') });
+    await expect(collect({ client, store, ...base })).rejects.toThrow('boom');
+    expect(store.readCsv('traffic/views.csv')).toEqual([]);
+    expect(store.readCsv('stars.csv')).toEqual([]);
+    expect(store.readMeta()).toBeNull();
+  });
+
+  it('skips contributors on a persistent 202 without writing a zero', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({ '/repos/o/r/stats/contributors': null });
+    const result = await collect({ client, store, ...base });
+    expect(store.readCsv('contributors.csv')).toEqual([]);
+    expect(result.skipped).toContain('contributors.csv');
+    expect(store.readCsv('traffic/views.csv')).not.toEqual([]);
+  });
+
+  it('preserves a previous contributor value when the stats endpoint is computing', async () => {
+    const store = createStore(dir);
+    store.writeCsv('contributors.csv', ['date', 'total'], [{ date: '2026-08-24', total: 4 }]);
+    const client = fakeClient({ '/repos/o/r/stats/contributors': null });
+    await collect({ client, store, ...base });
+    expect(store.readCsv('contributors.csv')).toEqual([{ date: '2026-08-24', total: '4' }]);
+  });
+
+  it('skips releases without aborting when that optional fetch fails', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
+    const result = await collect({ client, store, ...base });
+    expect(result.skipped).toContain('releases.csv');
+    expect(store.readCsv('traffic/views.csv')).not.toEqual([]);
+  });
+
+  it('is idempotent: a second run over the same data changes nothing', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const first = store.readCsv('traffic/views.csv');
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('traffic/views.csv')).toEqual(first);
+  });
+
+  it('merges a new window over existing history without duplicating dates', async () => {
+    const store = createStore(dir);
+    store.writeCsv(
+      'traffic/views.csv',
+      ['date', 'count', 'uniques'],
+      [
+        { date: '2026-08-01', count: 5, uniques: 2 },
+        { date: '2026-08-23', count: 1, uniques: 1 },
+      ],
+    );
+    await collect({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('traffic/views.csv');
+    expect(rows.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-23', '2026-08-24']);
+    expect(rows[1]?.count).toBe('40');
+  });
+
+  it('writes meta.json with last_success and per-file high-water marks', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const meta = store.readMeta();
+    expect(meta?.last_run).toBe('2026-08-25T03:00:41Z');
+    expect(meta?.last_success).toBe('2026-08-25T03:00:41Z');
+    expect(meta?.error).toBeNull();
+    expect(meta?.series_last_date['traffic/views.csv']).toBe('2026-08-24');
+    expect(meta?.series_last_date['stars.csv']).toBe('2026-08-25');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: FAIL — `Failed to resolve import "./collect.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/metrics/src/collect.ts`:
+
+```ts
+import { upsertByDate, upsertDimensional } from './series.ts';
+import type { GitHubClient } from './github.ts';
+import type { Meta, Store } from './store.ts';
+import type {
+  CountPoint,
+  DimensionRow,
+  IsoDate,
+  ReleaseRow,
+  RepoPoint,
+  TrafficPoint,
+} from './types.ts';
+
+interface TrafficBucket {
+  timestamp: string;
+  count: number;
+  uniques: number;
+}
+interface ViewsResponse {
+  views: TrafficBucket[];
+}
+interface ClonesResponse {
+  clones: TrafficBucket[];
+}
+interface ReferrerResponse {
+  referrer: string;
+  count: number;
+  uniques: number;
+}
+interface PathResponse {
+  path: string;
+  title: string;
+  count: number;
+  uniques: number;
+}
+interface RepoResponse {
+  stargazers_count: number;
+  forks_count: number;
+  subscribers_count: number;
+  open_issues_count: number;
+}
+interface ReleaseResponse {
+  tag_name: string;
+  name: string | null;
+  published_at: string | null;
+  assets: Array<{ download_count: number }>;
+}
+interface ContributorResponse {
+  weeks: Array<{ w: number; c: number }>;
+}
+
+export interface CollectResult {
+  written: string[];
+  skipped: string[];
+}
+
+export interface CollectOptions {
+  client: GitHubClient;
+  store: Store;
+  /** `owner/repo`, from `github.repository`. */
+  slug: string;
+  /** Today in UTC, `YYYY-MM-DD`. Injected for deterministic tests. */
+  today: IsoDate;
+  /** Run timestamp, ISO 8601. Injected for deterministic tests. */
+  now: string;
+}
+
+/** Converts an ISO timestamp to its UTC calendar date. */
+function toDate(timestamp: string): IsoDate {
+  const date = timestamp.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Unparseable timestamp from the API: ${timestamp}`);
+  }
+  return date;
+}
+
+function toTraffic(buckets: TrafficBucket[]): TrafficPoint[] {
+  return buckets.map((bucket) => ({
+    date: toDate(bucket.timestamp),
+    count: bucket.count,
+    uniques: bucket.uniques,
+  }));
+}
+
+/**
+ * Runs the daily collection.
+ *
+ * Atomicity is the whole design of this function: every required series is
+ * fetched into memory before a single byte is written. A required failure
+ * propagates, leaving the data directory and `meta.json` untouched, so a
+ * half-failed run can never produce a file the next run treats as
+ * authoritative. Optional series degrade to a skip instead, because releases
+ * and contributor stats are reconstructable at any later date while traffic
+ * is not.
+ */
+export async function collect(options: CollectOptions): Promise<CollectResult> {
+  const { client, store, slug, today, now } = options;
+  const repoPath = `/repos/${slug}`;
+  const skipped: string[] = [];
+
+  // --- Required. Any rejection here aborts before any write. ---
+  const [views, clones, referrers, paths, repo] = await Promise.all([
+    client.get<ViewsResponse>(`${repoPath}/traffic/views`),
+    client.get<ClonesResponse>(`${repoPath}/traffic/clones`),
+    client.get<ReferrerResponse[]>(`${repoPath}/traffic/popular/referrers`),
+    client.get<PathResponse[]>(`${repoPath}/traffic/popular/paths`),
+    client.get<RepoResponse>(repoPath),
+  ]);
+
+  // --- Optional. A failure skips the series, never zeroes it. ---
+  let releases: ReleaseResponse[] | null = null;
+  try {
+    releases = await client.get<ReleaseResponse[]>(`${repoPath}/releases`);
+  } catch {
+    skipped.push('releases.csv');
+    skipped.push('repo.csv:downloads_total');
+  }
+
+  let contributors: ContributorResponse[] | null = null;
+  try {
+    contributors = await client.getStats<ContributorResponse[]>(`${repoPath}/stats/contributors`);
+  } catch {
+    contributors = null;
+  }
+  if (contributors === null) skipped.push('contributors.csv');
+
+  const written: string[] = [];
+
+  function writeCsvSeries(
+    file: string,
+    header: readonly string[],
+    incoming: ReadonlyArray<Record<string, string | number> & { date: IsoDate }>,
+  ): void {
+    const existing = store.readCsv(file) as unknown as Array<{ date: IsoDate }>;
+    const merged = upsertByDate(existing, incoming, 'overwrite');
+    store.writeCsv(file, header, merged as unknown as Array<Record<string, string | number>>);
+    written.push(file);
+  }
+
+  function writeDimensional(file: string, incoming: readonly DimensionRow[]): void {
+    const merged = upsertDimensional(store.readNdjson(file), incoming);
+    store.writeNdjson(file, merged);
+    written.push(file);
+  }
+
+  writeCsvSeries('traffic/views.csv', ['date', 'count', 'uniques'], toTraffic(views.views));
+  writeCsvSeries('traffic/clones.csv', ['date', 'count', 'uniques'], toTraffic(clones.clones));
+
+  writeDimensional(
+    'traffic/referrers.ndjson',
+    referrers.map((item) => ({
+      snapshot_date: today,
+      dimension: item.referrer,
+      title: '',
+      count: item.count,
+      uniques: item.uniques,
+    })),
+  );
+  writeDimensional(
+    'traffic/paths.ndjson',
+    paths.map((item) => ({
+      snapshot_date: today,
+      dimension: item.path,
+      title: item.title,
+      count: item.count,
+      uniques: item.uniques,
+    })),
+  );
+
+  // Stars and forks come from the repo object's counters rather than by listing
+  // stargazers. That is a point-in-time measurement, so it correctly reflects
+  // people who starred and later unstarred — which the backfill, working from
+  // `starred_at`, structurally cannot see.
+  const stars: CountPoint = { date: today, total: repo.stargazers_count };
+  const forks: CountPoint = { date: today, total: repo.forks_count };
+  writeCsvSeries('stars.csv', ['date', 'total'], [stars]);
+  writeCsvSeries('forks.csv', ['date', 'total'], [forks]);
+
+  const downloadsTotal =
+    releases === null
+      ? 0
+      : releases.reduce(
+          (sum, release) =>
+            sum + release.assets.reduce((assetSum, asset) => assetSum + asset.download_count, 0),
+          0,
+        );
+
+  const repoPoint: RepoPoint = {
+    date: today,
+    subscribers: repo.subscribers_count,
+    open_issues: repo.open_issues_count,
+    downloads_total: downloadsTotal,
+  };
+  writeCsvSeries('repo.csv', ['date', 'subscribers', 'open_issues', 'downloads_total'], [repoPoint]);
+
+  if (releases !== null) {
+    const releaseRows: ReleaseRow[] = releases
+      .filter((release) => release.published_at !== null)
+      .map((release) => ({
+        date: toDate(release.published_at as string),
+        tag: release.tag_name,
+        name: release.name ?? release.tag_name,
+      }));
+    writeCsvSeries('releases.csv', ['date', 'tag', 'name'], releaseRows);
+  }
+
+  if (contributors !== null) {
+    // A contributor counts from the week of their first commit onward, so the
+    // series is a cumulative distinct count rather than a weekly total.
+    const firstWeeks = contributors
+      .map((contributor) => contributor.weeks.find((week) => week.c > 0)?.w)
+      .filter((week): week is number => week !== undefined)
+      .sort((a, b) => a - b);
+    let running = 0;
+    const points: CountPoint[] = firstWeeks.map((week) => {
+      running += 1;
+      return { date: new Date(week * 1000).toISOString().slice(0, 10), total: running };
+    });
+    if (points.length > 0) {
+      writeCsvSeries('contributors.csv', ['date', 'total'], points);
+    }
+  }
+
+  const lastDate = (file: string): IsoDate | undefined => {
+    const rows = store.readCsv(file);
+    return rows[rows.length - 1]?.date;
+  };
+
+  const seriesLastDate: Record<string, IsoDate> = {};
+  for (const file of written) {
+    if (!file.endsWith('.csv')) continue;
+    const last = lastDate(file);
+    if (last !== undefined) seriesLastDate[file] = last;
+  }
+
+  const meta: Meta = {
+    last_run: now,
+    last_success: now,
+    error: null,
+    series_last_date: seriesLastDate,
+  };
+  store.writeMeta(meta);
+
+  return { written, skipped };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS, all 14 `collect.test.ts` cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/metrics/src/collect.ts scripts/metrics/src/collect.test.ts
+git commit -m "feat(metrics): add daily collection with atomic writes and 202 skips"
+```
+
+---
+
+## Task 8: Backfill, write-if-absent
+
+**Files:**
+- Create: `scripts/metrics/src/backfill.ts`
+- Create: `scripts/metrics/src/backfill.test.ts`
+
+**Interfaces:**
+- Consumes: `GitHubClient`, `Store`, `upsertByDate`, row types.
+- Produces: `backfill(options: { client: GitHubClient; store: Store; slug: string }): Promise<{ written: string[] }>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/metrics/src/backfill.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createStore } from './store.ts';
+import { backfill } from './backfill.ts';
+import type { GitHubClient } from './github.ts';
+
+let dir = '';
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'metrics-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const STARGAZERS = [
+  { starred_at: '2026-02-20T10:00:00Z' },
+  { starred_at: '2026-02-20T18:00:00Z' },
+  { starred_at: '2026-03-01T09:00:00Z' },
+];
+const FORKS = [{ created_at: '2026-03-05T09:00:00Z' }];
+const RELEASES = [
+  { tag_name: 'v1.0.0', name: 'Backspace 1.0.0', published_at: '2026-08-01T10:00:00Z' },
+];
+
+function fakeClient(pages: Record<string, unknown[]> = {}): GitHubClient {
+  const routes: Record<string, unknown[]> = {
+    '/repos/o/r/stargazers': STARGAZERS,
+    '/repos/o/r/forks?sort=oldest': FORKS,
+    '/repos/o/r/releases': RELEASES,
+    ...pages,
+  };
+  return {
+    async get<T>(p: string): Promise<T> {
+      throw new Error(`backfill must paginate, not get: ${p}`);
+    },
+    async getStats<T>(): Promise<T | null> {
+      return null;
+    },
+    async paginate<T>(p: string): Promise<T[]> {
+      const value = routes[p];
+      if (value === undefined) throw new Error(`unexpected paginate ${p}`);
+      return value as T[];
+    },
+  };
+}
+
+const base = { slug: 'o/r' };
+
+describe('backfill', () => {
+  it('accumulates stars cumulatively by the UTC day of starred_at', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('stars.csv')).toEqual([
+      { date: '2026-02-20', total: '2' },
+      { date: '2026-03-01', total: '3' },
+    ]);
+  });
+
+  it('accumulates forks cumulatively by created_at', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('forks.csv')).toEqual([{ date: '2026-03-05', total: '1' }]);
+  });
+
+  it('records release dates', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'Backspace 1.0.0' },
+    ]);
+  });
+
+  it('NEVER overwrites a date the collector already measured', async () => {
+    const store = createStore(dir);
+    // The collector measured 1 star on 2026-03-01, because someone unstarred.
+    // The reconstruction from /stargazers cannot see that and would say 3.
+    store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-03-01', total: 1 }]);
+    await backfill({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('stars.csv');
+    expect(rows.find((r) => r.date === '2026-03-01')?.total).toBe('1');
+  });
+
+  it('still fills dates the collector never saw', async () => {
+    const store = createStore(dir);
+    store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-03-01', total: 1 }]);
+    await backfill({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('stars.csv');
+    expect(rows.find((r) => r.date === '2026-02-20')?.total).toBe('2');
+  });
+
+  it('never touches traffic files or repo.csv', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(existsSync(path.join(dir, 'traffic'))).toBe(false);
+    expect(existsSync(path.join(dir, 'repo.csv'))).toBe(false);
+  });
+
+  it('reports exactly the files it may write', async () => {
+    const store = createStore(dir);
+    const result = await backfill({ client: fakeClient(), store, ...base });
+    expect(result.written.sort()).toEqual(['forks.csv', 'releases.csv', 'stars.csv']);
+  });
+
+  it('is idempotent across repeated runs', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    const first = store.readCsv('stars.csv');
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('stars.csv')).toEqual(first);
+  });
+
+  it('handles multi-page stargazer results', async () => {
+    const many = Array.from({ length: 150 }, (_, i) => ({
+      starred_at: `2026-04-${String((i % 28) + 1).padStart(2, '0')}T00:00:00Z`,
+    }));
+    const store = createStore(dir);
+    await backfill({ client: fakeClient({ '/repos/o/r/stargazers': many }), store, ...base });
+    const rows = store.readCsv('stars.csv');
+    expect(rows[rows.length - 1]?.total).toBe('150');
+  });
+});
+```
+
+The fourth test is the point of the whole task. It encodes the exact scenario that would otherwise destroy measured history.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: FAIL — `Failed to resolve import "./backfill.ts"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/metrics/src/backfill.ts`:
+
+```ts
+import { upsertByDate } from './series.ts';
+import type { GitHubClient } from './github.ts';
+import type { Store } from './store.ts';
+import type { CountPoint, IsoDate, ReleaseRow } from './types.ts';
+
+interface StargazerResponse {
+  starred_at: string;
+}
+interface ForkResponse {
+  created_at: string;
+}
+interface ReleaseResponse {
+  tag_name: string;
+  name: string | null;
+  published_at: string | null;
+}
+
+export interface BackfillOptions {
+  client: GitHubClient;
+  store: Store;
+  slug: string;
+}
+
+/**
+ * Files backfill is permitted to write. Exhaustive and deliberately short.
+ *
+ * `traffic/*` is excluded because it is unreconstructable, and `repo.csv`
+ * because `subscribers` has no historical API at all — a stray rewrite would
+ * be a permanent loss with nothing to restore from.
+ */
+const WRITABLE = ['stars.csv', 'forks.csv', 'releases.csv'] as const;
+
+/** Turns a list of event timestamps into a cumulative daily series. */
+function cumulativeByDay(timestamps: readonly string[]): CountPoint[] {
+  const perDay = new Map<IsoDate, number>();
+  for (const timestamp of timestamps) {
+    const date = timestamp.slice(0, 10);
+    perDay.set(date, (perDay.get(date) ?? 0) + 1);
+  }
+  const days = [...perDay.keys()].sort((a, b) => a.localeCompare(b));
+  let running = 0;
+  return days.map((date) => {
+    running += perDay.get(date) ?? 0;
+    return { date, total: running };
+  });
+}
+
+/**
+ * Reconstructs history that permanent timestamps make recoverable.
+ *
+ * Every write is `if-absent`. The reconstruction works from `/stargazers`,
+ * which lists only *current* stargazers — anyone who starred and later
+ * unstarred is invisible to it. Overwriting a date the collector measured
+ * would therefore replace a correct value with a systematically wrong one.
+ */
+export async function backfill(options: BackfillOptions): Promise<{ written: string[] }> {
+  const { client, store, slug } = options;
+  const repoPath = `/repos/${slug}`;
+
+  const stargazers = await client.paginate<StargazerResponse>(
+    `${repoPath}/stargazers`,
+    'application/vnd.github.star+json',
+  );
+  const forks = await client.paginate<ForkResponse>(`${repoPath}/forks?sort=oldest`);
+  const releases = await client.paginate<ReleaseResponse>(`${repoPath}/releases`);
+
+  function mergeIfAbsent(
+    file: string,
+    header: readonly string[],
+    incoming: ReadonlyArray<Record<string, string | number> & { date: IsoDate }>,
+  ): void {
+    const existing = store.readCsv(file) as unknown as Array<{ date: IsoDate }>;
+    const merged = upsertByDate(existing, incoming, 'if-absent');
+    store.writeCsv(file, header, merged as unknown as Array<Record<string, string | number>>);
+  }
+
+  mergeIfAbsent(
+    'stars.csv',
+    ['date', 'total'],
+    cumulativeByDay(stargazers.map((item) => item.starred_at)),
+  );
+  mergeIfAbsent(
+    'forks.csv',
+    ['date', 'total'],
+    cumulativeByDay(forks.map((item) => item.created_at)),
+  );
+
+  const releaseRows: ReleaseRow[] = releases
+    .filter((release) => release.published_at !== null)
+    .map((release) => ({
+      date: (release.published_at as string).slice(0, 10),
+      tag: release.tag_name,
+      name: release.name ?? release.tag_name,
+    }));
+  mergeIfAbsent('releases.csv', ['date', 'tag', 'name'], releaseRows);
+
+  return { written: [...WRITABLE] };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/metrics/src/backfill.ts scripts/metrics/src/backfill.test.ts
+git commit -m "feat(metrics): add write-if-absent historical backfill"
+```
+
+---
+
+## Task 9: CLI entrypoints
+
+**Files:**
+- Create: `scripts/metrics/src/cli-collect.ts`
+- Create: `scripts/metrics/src/cli-backfill.ts`
+- Modify: `.gitignore`
+
+**Interfaces:**
+- Consumes: `collect`, `backfill`, `createClient`, `createStore`.
+- Produces: two executables the workflows invoke as `node scripts/metrics/src/cli-collect.ts`.
+
+Kept separate from `collect.ts` so that module stays pure and testable. These files read the environment and the clock; nothing else does.
+
+- [ ] **Step 1: Write the collect entrypoint**
+
+Create `scripts/metrics/src/cli-collect.ts`:
+
+```ts
+import { createClient } from './github.ts';
+import { createStore } from './store.ts';
+import { collect } from './collect.ts';
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+const token = required('METRICS_TOKEN');
+const slug = required('GITHUB_REPOSITORY');
+const dataDir = required('METRICS_DATA_DIR');
+
+const nowDate = new Date();
+const now = nowDate.toISOString();
+const today = now.slice(0, 10);
+
+const result = await collect({
+  client: createClient(token),
+  store: createStore(dataDir),
+  slug,
+  today,
+  now,
+});
+
+console.log(`wrote: ${result.written.join(', ')}`);
+if (result.skipped.length > 0) {
+  console.log(`skipped (left at previous value): ${result.skipped.join(', ')}`);
+}
+```
+
+- [ ] **Step 2: Write the backfill entrypoint**
+
+Create `scripts/metrics/src/cli-backfill.ts`:
+
+```ts
+import { createClient } from './github.ts';
+import { createStore } from './store.ts';
+import { backfill } from './backfill.ts';
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+const result = await backfill({
+  client: createClient(required('METRICS_TOKEN')),
+  store: createStore(required('METRICS_DATA_DIR')),
+  slug: required('GITHUB_REPOSITORY'),
+});
+
+console.log(`backfilled (write-if-absent): ${result.written.join(', ')}`);
+```
+
+- [ ] **Step 3: Ignore the workflow's data checkout**
+
+Add to `.gitignore`, under a new labelled section matching the file's existing style:
+
+```gitignore
+# Metrics data branch, checked out into the workspace by .github/workflows/metrics.yml
+.metrics-data/
+```
+
+- [ ] **Step 4: Verify the entrypoints type-check and run**
+
+Run: `pnpm --filter @backspace/metrics test`
+Expected: PASS. The `no-runtime-deps` guard now also covers both CLI files.
+
+Then verify Node can actually execute the TypeScript, which nothing so far has proven:
+
+```bash
+node --version   # must be >= 22.18
+METRICS_TOKEN=x GITHUB_REPOSITORY=o/r METRICS_DATA_DIR=/tmp/mx \
+  node scripts/metrics/src/cli-collect.ts
+```
+
+Expected: it reaches the network and fails with a GitHub API 401. That is success for this step — it proves type stripping works and the module graph loads. A `SyntaxError` here means an `import type` or `.ts` extension was missed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/metrics/src/cli-collect.ts scripts/metrics/src/cli-backfill.ts .gitignore
+git commit -m "feat(metrics): add collect and backfill CLI entrypoints"
+```
+
+---
+
+## Task 10: Daily collection workflow
+
+**Files:**
+- Create: `.github/workflows/metrics.yml`
+
+**Interfaces:**
+- Consumes: `cli-collect.ts`.
+- Produces: the `metrics-data` branch and its daily commits.
+
+- [ ] **Step 1: Look up the current action SHAs**
+
+Every `uses:` must be a full commit SHA with a trailing version comment. Reuse the SHAs already pinned in this repo rather than looking them up fresh — `ci.yml` has `harden-runner` and `checkout` at the versions this repo has standardised on:
+
+```bash
+grep -h "uses:" .github/workflows/ci.yml .github/workflows/cla.yml
+```
+
+Copy the `step-security/harden-runner` and `actions/checkout` lines verbatim, including the `# vX.Y.Z` comments.
+
+- [ ] **Step 2: Write the workflow**
+
+Create `.github/workflows/metrics.yml`. Substitute the two `uses:` lines with the pinned values from Step 1:
+
+```yaml
+name: Metrics
+
+# Snapshots this repo's traffic metrics daily into the orphan `metrics-data`
+# branch. Purpose: GitHub's Insights -> Traffic panel discards views, clones,
+# referrers, and popular paths after 14 days, and no API can reconstruct them.
+# Every day this does not run is a day of history destroyed permanently.
+#
+# Why two tokens: the traffic endpoints require the "Administration: read"
+# permission, and there is no `administration` key in the Actions `permissions:`
+# vocabulary at all — so GITHUB_TOKEN cannot reach them under any configuration.
+# METRICS_TOKEN (a fine-grained, repo-scoped, read-only PAT) reads; GITHUB_TOKEN
+# writes. Neither alone can both read traffic and modify the archive.
+#
+# Why the deploy job re-declares permissions: a called workflow's permissions can
+# only be reduced, never elevated, and anything unlisted becomes `none`. The job
+# that calls deploy-pages.yml must therefore hold pages:write and id-token:write
+# itself, or the Pages deploy fails with "Resource not accessible by integration".
+#
+# Why `gh workflow enable`: GitHub disables scheduled workflows after 60 days
+# with no repository activity. This workflow's own commits go to a non-default
+# branch and are made with GITHUB_TOKEN, so they cannot be relied on to reset
+# that timer. Re-enabling on every run is idempotent and costs one API call.
+#
+# See docs/systems/metrics.md.
+
+on:
+  schedule:
+    # 03:00 UTC daily. The exact hour does not matter: the traffic API returns a
+    # 14-day window, so any gap of 13 days or less is repaired by the next run.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never cancel in progress: metrics.yml and backfill.yml write the same files,
+# and cancelling a collection run loses that day irrecoverably.
+concurrency:
+  group: metrics-data
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: Collect metrics
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      # The data branch must be created BEFORE actions/checkout is asked for it:
+      # checkout with a nonexistent ref hard-fails the job, so a bootstrap step
+      # placed after it could never run.
+      - name: Bootstrap the data branch if absent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin metrics-data >/dev/null 2>&1; then
+            echo "metrics-data exists"
+          else
+            echo "Creating orphan branch metrics-data"
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git switch --orphan metrics-data
+            git commit --allow-empty -m "chore(metrics): initialise data branch"
+            git push origin metrics-data
+            git switch -
+          fi
+
+      - name: Checkout the data branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: metrics-data
+          path: .metrics-data
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          # Pinned to 24: the collector is TypeScript executed directly by Node's
+          # native type stripping, with no build step and no dependencies.
+          node-version: 24
+
+      - name: Collect
+        env:
+          METRICS_TOKEN: ${{ secrets.METRICS_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          METRICS_DATA_DIR: ${{ github.workspace }}/.metrics-data
+        run: node scripts/metrics/src/cli-collect.ts
+
+      - name: Commit and push
+        working-directory: .metrics-data
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No change to commit"
+            exit 0
+          fi
+          git commit -m "chore(metrics): snapshot $(date -u +%Y-%m-%d)"
+          # backfill.yml can be dispatched while this runs. Rebase and retry
+          # rather than clobbering, then fail loudly if it still will not land.
+          for attempt in 1 2 3; do
+            if git push origin metrics-data; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt), rebasing"
+            git pull --rebase origin metrics-data
+          done
+          echo "Could not push after 3 attempts"
+          exit 1
+
+      # Runs even when collection failed, so a stalled collector is visible on
+      # the data branch and in the dashboard header rather than only in this tab.
+      - name: Record run outcome
+        if: always()
+        working-directory: .metrics-data
+        env:
+          OUTCOME: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("node:fs");
+            const now = new Date().toISOString();
+            let meta = { last_run: now, last_success: null, error: null, series_last_date: {} };
+            if (fs.existsSync("meta.json")) {
+              meta = JSON.parse(fs.readFileSync("meta.json", "utf8"));
+            }
+            meta.last_run = now;
+            if (process.env.OUTCOME !== "success") {
+              meta.error = `run failed: ${process.env.OUTCOME}`;
+            }
+            fs.writeFileSync("meta.json", JSON.stringify(meta, null, 2) + "\n");
+          '
+          git add meta.json
+          git diff --cached --quiet || {
+            git commit -m "chore(metrics): record run outcome"
+            git push origin metrics-data || true
+          }
+
+      - name: Keep the schedule alive
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow enable metrics.yml --repo "${{ github.repository }}" || true
+```
+
+WS1 deliberately ships with **no deploy job**. WS2 (`plan-b-metrics-bundle-deploy.md`) adds it, declaring `contents: read`, `pages: write`, and `id-token: write` on that job — the header comment above records why those cannot be inherited. Collection is independently valuable without a dashboard, and keeping the Pages change out of this workstream means a regression there cannot block the archive from accruing.
+
+- [ ] **Step 3: Validate the workflow syntax**
+
+Run: `gh workflow view metrics.yml --repo TheZwiss/backspace 2>&1 | head -5`
+Expected: an error that the workflow does not exist yet, since it is not pushed. That is fine — this step is only to confirm `gh` is authenticated for Step 5.
+
+Validate the YAML parses:
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/metrics.yml')); print('valid yaml')"
+```
+
+Expected: `valid yaml`.
+
+- [ ] **Step 4: Confirm the action pins match the rest of the repo**
+
+```bash
+grep -o "uses: [^ ]*@[a-f0-9]\{40\}" .github/workflows/metrics.yml
+```
+
+Expected: three lines, each a 40-character SHA. If any `uses:` lacks a SHA, fix it before committing — the repo pins every action without exception.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/metrics.yml
+git commit -m "ci(metrics): add daily traffic collection workflow"
+```
+
+---
+
+## Task 11: Backfill workflow
+
+**Files:**
+- Create: `.github/workflows/backfill.yml`
+
+**Interfaces:**
+- Consumes: `cli-backfill.ts`, and the `metrics-data` branch created by Task 10.
+- Produces: a manually dispatched historical reconstruction.
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/backfill.yml`, reusing the same pinned SHAs as `metrics.yml`:
+
+```yaml
+name: Metrics backfill
+
+# Reconstructs history that permanent timestamps make recoverable: stars from
+# `starred_at`, forks from `created_at`, releases from `published_at`.
+#
+# Dispatch only, never scheduled. It is safe to run at any time because every
+# write is if-absent: it fills dates that have no row and never replaces one the
+# daily collector measured. That rule matters because /stargazers lists only
+# CURRENT stargazers, so a reconstruction cannot see anyone who starred and
+# later unstarred — overwriting a measured value with a reconstructed one would
+# replace a correct number with a systematically wrong one.
+#
+# Traffic is not backfillable by any means and this workflow never touches it.
+#
+# See docs/systems/metrics.md.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Shares metrics.yml's group so a dispatched backfill cannot race the daily
+# cron and clobber it.
+concurrency:
+  group: metrics-data
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill history
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Checkout the data branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: metrics-data
+          path: .metrics-data
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 24
+
+      - name: Backfill
+        env:
+          # Must be the PAT, not GITHUB_TOKEN: the latter carries a 1,000
+          # requests/hour per-repository limit rather than 5,000.
+          METRICS_TOKEN: ${{ secrets.METRICS_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          METRICS_DATA_DIR: ${{ github.workspace }}/.metrics-data
+        run: node scripts/metrics/src/cli-backfill.ts
+
+      - name: Commit and push
+        working-directory: .metrics-data
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No change to commit"
+            exit 0
+          fi
+          git commit -m "chore(metrics): backfill reconstructable history"
+          git push origin metrics-data
+```
+
+Note this workflow deliberately has **no bootstrap step**. Backfill is meaningless before the collector exists, so requiring `metrics.yml` to have run once is the correct dependency. If the branch is absent, the checkout fails loudly, which is the right outcome.
+
+- [ ] **Step 2: Validate the YAML**
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/backfill.yml')); print('valid yaml')"
+```
+
+Expected: `valid yaml`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/backfill.yml
+git commit -m "ci(metrics): add dispatch-only historical backfill workflow"
+```
+
+---
+
+## Task 12: Documentation and maintainer checklist
+
+**Files:**
+- Create: `docs/systems/metrics.md`
+- Modify: `CLAUDE.md`
+- Modify: `docs/systems/security-scanning.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the subsystem record CLAUDE.md's documentation rule requires.
+
+- [ ] **Step 1: Write the subsystem doc**
+
+Create `docs/systems/metrics.md` covering, in this order:
+
+1. **Why this exists** — GitHub retains traffic for 14 days; no API reconstructs it; every uncollected day is destroyed permanently.
+2. **What is and is not recoverable** — copy the table from spec section 1.
+3. **Architecture** — `scripts/metrics` package, orphan `metrics-data` branch, the two workflows.
+4. **Data schemas** — every file, every column, copied from spec section 5.1 and 5.3, including that dimensional rows are trailing-14-day aggregates and that an absent dimension means "outside the top 10", never zero.
+5. **Write semantics** — fetch-wins for the collector, write-if-absent for backfill, atomicity, no zero-filling. State the unstar hazard explicitly.
+6. **The 202 problem** — `/stats/contributors` returns 202 while computing, the cache is reset by every push to `main`, and a persistent 202 is a skip and never a zero.
+7. **Field-name traps** — copy spec section 5.6 verbatim: `watchers_count` is stars and `subscribers_count` is watchers; the repo object's `open_issues` includes PRs; `/stargazers` is admin/collaborator-gated as of July 2026.
+8. **Token setup** — a fine-grained PAT, this repo only, `Administration: read` plus `Contents: read`, stored as `METRICS_TOKEN`. Note there is no `administration` key in the Actions permissions vocabulary, so this cannot be replaced by `GITHUB_TOKEN`.
+9. **The 60-day hazard** — scheduled workflows are disabled after 60 days of no repository activity; the collector's commits go to a non-default branch with `GITHUB_TOKEN` and cannot be relied on to reset that timer; `gh workflow enable` runs every execution; the dashboard's staleness warning is the backstop.
+10. **Operations** — how to run a backfill, how to recover from a gap (any gap of 13 days or less self-heals), what a rejected push means, and how to read `meta.json`.
+11. **Adding a repo** — the slug comes from `github.repository`; a second repo needs a file-layout decision first, since paths are currently flat.
+
+- [ ] **Step 2: Add the CLAUDE.md subsystem table row**
+
+Add to the subsystem documentation table in `CLAUDE.md`, keeping the existing column format:
+
+```markdown
+| [metrics.md](docs/systems/metrics.md) | Traffic archive: daily collection into the `metrics-data` branch, CSV/NDJSON schemas, upsert and write-if-absent semantics, backfill, the 202 stats problem, PAT scopes, the 60-day schedule hazard, dashboard | Any repo-analytics work, changing collected series, debugging a stalled collector |
+```
+
+- [ ] **Step 3: Add the monorepo structure entry**
+
+In the `## Monorepo Structure` block in `CLAUDE.md`, add below the `packages/` tree:
+
+```
+scripts/
+  metrics/  — @backspace/metrics: repo traffic collector (workspace package)
+```
+
+Then add this sentence after the block: "The metrics subsystem spans `scripts/metrics` (a workspace package) and `site/insights` (a static page, not a workspace)."
+
+- [ ] **Step 4: Add the maintainer checklist entries**
+
+In `docs/systems/security-scanning.md`, under the existing "Maintainer checklist (one-time GitHub settings — NOT code)" heading, append:
+
+```markdown
+- [ ] Create a fine-grained PAT scoped to this repository only, with
+      **Administration: read** and **Contents: read**, and store it as the
+      `METRICS_TOKEN` repository secret. Traffic endpoints are unreachable
+      without it — there is no `administration` key in the Actions
+      `permissions:` vocabulary, so `GITHUB_TOKEN` cannot substitute.
+- [ ] Create a ruleset on the `metrics-data` branch blocking **deletion** and
+      **force-push**, with no bypass actors, matching the existing
+      `cla-signatures` ruleset. Do NOT require pull requests or status checks:
+      the collector commits directly. This branch holds the only irreplaceable
+      data in the repository.
+```
+
+- [ ] **Step 5: Verify nothing is stale**
+
+```bash
+grep -c "metrics.md" CLAUDE.md
+grep -c "METRICS_TOKEN" docs/systems/security-scanning.md docs/systems/metrics.md
+```
+
+Expected: `1` for CLAUDE.md, and at least `1` for each of the other two files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/systems/metrics.md docs/systems/security-scanning.md CLAUDE.md
+git commit -m "docs(metrics): document the traffic archive subsystem"
+```
+
+---
+
+## Task 13: End-to-end verification against the live repo
+
+**Files:** none created. This task proves the pipeline works before it is trusted with irreplaceable data.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the Definition-of-Done evidence.
+
+- [ ] **Step 1: Confirm the maintainer prerequisites exist**
+
+Task 12 Step 4 lists two settings only the repo owner can apply. Confirm both before proceeding:
+
+```bash
+gh secret list --repo TheZwiss/backspace | grep METRICS_TOKEN
+gh api repos/TheZwiss/backspace/rulesets --jq '.[] | .name'
+```
+
+Expected: `METRICS_TOKEN` is listed, and a ruleset covering `metrics-data` appears. If either is missing, stop and ask the maintainer — do not proceed.
+
+- [ ] **Step 2: Run the collector once by hand**
+
+```bash
+gh workflow run metrics.yml --repo TheZwiss/backspace
+sleep 60
+gh run list --workflow metrics.yml --repo TheZwiss/backspace --limit 1
+```
+
+Expected: the run concludes `success`.
+
+- [ ] **Step 3: Verify the data landed**
+
+```bash
+git fetch origin metrics-data
+git show origin/metrics-data:traffic/views.csv | head -5
+git show origin/metrics-data:meta.json
+```
+
+Expected: `views.csv` has a header plus up to 14 dated rows, and `meta.json` has a non-null `last_success`.
+
+- [ ] **Step 4: Prove idempotency, which is the core storage guarantee**
+
+```bash
+BEFORE=$(git show origin/metrics-data:traffic/views.csv | sha256sum)
+gh workflow run metrics.yml --repo TheZwiss/backspace
+sleep 60
+git fetch origin metrics-data
+AFTER=$(git show origin/metrics-data:traffic/views.csv | sha256sum)
+echo "before: $BEFORE"
+echo "after:  $AFTER"
+```
+
+Expected: identical for every date before today. Today's row may legitimately differ, because the traffic window is still accumulating — this is why the Definition of Done says "byte-identical for all dates before the current UTC day" rather than "a no-op".
+
+If dates *before* today changed, stop: the upsert is not stable and the archive cannot be trusted.
+
+- [ ] **Step 5: Run the backfill and prove it preserved measured data**
+
+```bash
+BEFORE=$(git show origin/metrics-data:stars.csv | sha256sum)
+gh workflow run backfill.yml --repo TheZwiss/backspace
+sleep 90
+git fetch origin metrics-data
+git show origin/metrics-data:stars.csv | head -5
+git show origin/metrics-data:stars.csv | wc -l
+```
+
+Expected: many more rows than before, reaching back to 2026-02-18, **and** every date that already existed still carries its original value. Spot-check today's row against `BEFORE`.
+
+- [ ] **Step 6: Confirm backfill did not touch traffic**
+
+```bash
+git log origin/metrics-data --oneline -1 --name-only
+```
+
+Expected: the backfill commit lists only `stars.csv`, `forks.csv`, and `releases.csv`. If any `traffic/` path appears, the write-if-absent guard has a hole — stop and fix it before the next daily run.
+
+- [ ] **Step 7: Confirm two consecutive daily runs**
+
+Wait for the next scheduled 03:00 UTC run, then:
+
+```bash
+gh run list --workflow metrics.yml --repo TheZwiss/backspace --limit 3
+git log origin/metrics-data --oneline -5
+```
+
+Expected: two successful scheduled runs on consecutive days, each with its own snapshot commit.
+
+- [ ] **Step 8: Final check of the whole workspace**
+
+```bash
+pnpm -r test
+```
+
+Expected: PASS, including `@backspace/metrics`.
+
+WS1 is complete. The archive is accruing. WS2 (`plan-b-metrics-bundle-deploy.md`) and WS3 (`plan-c-metrics-dashboard.md`) can now proceed at any pace without further data being at risk.

--- a/docs/superpowers/plans/2026-08-25-plan-a-metrics-collection.md
+++ b/docs/superpowers/plans/2026-08-25-plan-a-metrics-collection.md
@@ -319,6 +319,18 @@ git commit -m "test(metrics): guard collector against runtime deps and unerasabl
 
 ## Task 3: CSV series — parse, format, upsert
 
+> **Amendment (2026-09-01, fix round 1 after task review).** The reference
+> `parseCsv` below splits the text on `'\n'` before parsing quote state, which
+> silently corrupts two inputs: CRLF files (a trailing `\r` contaminates the last
+> field and the last header key) and any quoted field containing an embedded
+> newline (one logical row becomes two malformed rows) — a case `quote()` below
+> deliberately writes. The shipped implementation parses quote state across the
+> whole text in a single pass instead, pads short rows with `''` so a column can
+> be added to a schema later, and throws on a row with more fields than the
+> header rather than silently dropping the excess. See the ledger ruling and
+> `.superpowers/sdd/2026-08-25-plan-a-metrics-collection/task-3-fix-brief.md`.
+> Read `scripts/metrics/src/series.ts` as the parser's authority, not the code below.
+
 **Files:**
 - Create: `scripts/metrics/src/series.ts`
 - Create: `scripts/metrics/src/series.test.ts`

--- a/docs/superpowers/specs/2026-08-25-repo-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-25-repo-metrics-design.md
@@ -213,9 +213,17 @@ The constraints that actually shape the code, all omitted from v1:
   import aliases, decorators.
 
 Mitigation is compiler-enforced, not discipline-enforced: the package tsconfig
-sets `erasableSyntaxOnly`, `verbatimModuleSyntax`, and
-`rewriteRelativeImportExtensions`, so `tsc --noEmit` — which now runs in CI via
-§3.6 — rejects every one of these at review time rather than at 03:00.
+sets `erasableSyntaxOnly` and `verbatimModuleSyntax`, so `tsc --noEmit` — which
+now runs in CI via §3.6 — rejects these at review time rather than at 03:00.
+
+> **Correction (2026-09-01, during implementation).** This paragraph originally
+> also named `rewriteRelativeImportExtensions`, and claimed the mandatory `.ts`
+> extension on relative imports was compiler-enforced. It is not. That flag was
+> never set, and no compiler option requires the extension —
+> `allowImportingTsExtensions` permits it without demanding it, so a missing
+> `.ts` typechecks cleanly and fails only when Node runs the file. The regex
+> scan in `scripts/metrics/src/no-runtime-deps.test.ts` is the only thing that
+> catches it. See `docs/systems/metrics.md`.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-25-repo-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-25-repo-metrics-design.md
@@ -1,0 +1,757 @@
+# Repository Metrics & Insights Archive — Design
+
+**Date:** 2026-08-25
+**Status:** Draft v2 (revised after technical + design review); pending user review
+**Author:** Lead Developer (Backspace)
+
+---
+
+## 1. Motivation
+
+GitHub's Insights → Traffic panel discards data after 14 days. For a project
+actively courting self-hosters, that window is too short to answer the questions
+that matter: did the federation write-up move the needle, did the v1 release
+change clone volume, is organic search growing or flat, which docs page do people
+read before deciding to deploy.
+
+Once a day falls out of the window it is gone permanently. GitHub does not retain
+it server-side and no API can reconstruct it. **Every day without a collector is
+a day of history destroyed.**
+
+### What is actually at risk
+
+Most of Insights is not ephemeral. Only two things need capturing:
+
+| Data | Retention | Action |
+|---|---|---|
+| Traffic: views, clones, referrers, popular paths | **14 days, then destroyed** | **Snapshot daily** |
+| Release asset download counts | Live cumulative total, no time series | **Snapshot daily** |
+| Stars | Permanent — `/stargazers` returns `starred_at` | Backfill once |
+| Forks | Permanent — `created_at` | Backfill once |
+| Issues, PRs | Permanent — timestamped | Backfill once |
+| Releases | Permanent — `published_at` | Backfill once |
+| Contributors | Permanent — `/stats/contributors` | Backfill once |
+
+Commits and code-frequency are also permanent, but nothing in the v1 dashboard
+(§7) consumes them, so they are not collected. See §2 non-goals.
+
+### Current state (measured live, 2026-08-25)
+
+- Repo created `2026-02-18T01:49:31Z` — roughly six months of backfillable history.
+- 56 stars, 3 forks, **1 watcher** (`subscribers_count`; see §5.6), 13 open
+  issues, 1 release with 22 assets.
+- Trailing 14 days: 655 views / 189 unique visitors.
+- `deploy-pages.yml` already publishes `site/` to GitHub Pages, so a dashboard
+  has a delivery mechanism already built.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+1. Capture every ephemeral metric daily, starting as soon as this ships, retained
+   indefinitely.
+2. Backfill all reconstructable history so the dashboard opens with the repo's
+   full life rather than an empty axis.
+3. Publish a single public URL rendering the archive with real interactivity —
+   zoom, cross-chart cursor, range presets — styled as part of the existing site.
+4. Zero infrastructure, zero recurring cost, zero third-party data custody. The
+   archive must outlive any vendor.
+5. Data stored in a format that is diffable, hand-recoverable, and independently
+   useful without the dashboard.
+6. Idempotent and self-healing: a missed run, a duplicate run, or a re-run must
+   never corrupt or duplicate data.
+
+### Non-Goals
+
+- **Per-day referrer or path resolution.** The API returns a single 14-day
+  aggregate, top 10 only, with no per-day breakdown (verified live). Not
+  obtainable by any means. See §5.3.
+- **Backfilling traffic.** Impossible. Whatever is in today's window is the
+  oldest traffic data this project will ever have.
+- **Issue/PR health, release-download breakdown, and commit-activity charts.**
+  Deferred from v1. These were cut deliberately: they are the sections whose
+  underlying data is either unavailable without extra endpoints that return 202
+  (§3.7) or unused by any question in §1. Revisit once the archive has a year of
+  data and there is something to see.
+- **Multi-repo support.** Only `TheZwiss/backspace` has meaningful activity. The
+  repo slug is read from `github.repository`, so the workflow is not hardcoded,
+  but no multi-repo file layout or comparison UI exists.
+- **Real-time or sub-daily collection.** Traffic updates daily upstream.
+- **Alerting.** No thresholds, no notifications. An archive and a dashboard.
+- **Private analytics tiers.** The dashboard and the raw data branch are both
+  fully public, by explicit decision.
+
+---
+
+## 3. Key Decisions & Rationale
+
+### 3.1 Git scraping over a database or SaaS
+
+Storing API snapshots as text committed to git on a schedule is the established
+pattern for this problem. It gives versioning, indefinite retention,
+auditability, and disaster recovery for free, at zero cost and zero operational
+burden. Alternatives considered and rejected:
+
+- **Hosted SaaS (Repohistory and similar):** requires granting a third party a
+  token with repo administration scope, places custody of the data outside the
+  project, and ties retention to that vendor's survival. Contradicts Goal 4 and
+  sits badly with a project whose pitch is self-hosting.
+- **Self-hosted Prometheus + Grafana on the Pi/VM:** correct at organisation
+  scale, but it is real infrastructure to run, monitor, back up, and patch,
+  sitting alongside the production Backspace instances. Disproportionate for one
+  repo.
+
+### 3.2 Plain text over SQLite
+
+Committed SQLite would allow arbitrary SQL in the browser via `sql.js`. Rejected
+because git stores a **complete new copy of a binary file on every commit**. A
+daily-committed database grows without bound and yields no readable diffs.
+
+At the measured volume — ~800 KB/year, ~8 MB/decade (§5.5) — plain text produces
+a one-line-per-day diff that can be audited or repaired by hand and stays useful
+in any tool that reads CSV.
+
+- **CSV** for dense date-keyed series (one row per date).
+- **NDJSON** for dimensional data with multiple rows per date.
+
+### 3.3 Orphan data branch, with the same protection as the CLA branch
+
+Daily commits to `main` would add ~365 noise commits per year and, without path
+filtering, trigger CI on every one. An orphan `metrics-data` branch isolates
+them, mirroring the pattern `cla.yml` already established for CLA signatures.
+
+That precedent carries a second, load-bearing half the first draft omitted:
+`cla-signatures` has a live ruleset (`deletion`, `non_fast_forward`, zero bypass
+actors) so the record cannot be rewritten. `metrics-data` **must get the matching
+ruleset** — it would otherwise be the one branch in this repo holding genuinely
+irreplaceable data with no deletion or force-push protection, while the
+reconstructable CLA record is locked down. Tracked in §11 and §12.
+
+Note the ruleset must **not** require PRs or status checks: the collector commits
+directly, which is the exact failure mode `cla.yml`'s header comment documents.
+
+Caveat worth stating: the orphan branch isolates history noise from `main`, but
+`git clone` fetches all branches, so contributors still download the archive.
+At 8 MB/decade this is acceptable.
+
+### 3.4 uPlot for time series, hand-rolled CSS/SVG for the rest
+
+Most v1 charts are time series. uPlot is ~45 KB, renders to canvas, and provides
+drag-to-zoom plus a cursor synchronised across stacked charts — the feature that
+makes a dense dashboard readable rather than a wall of graphs. It is themeable,
+so it takes Aether Drift colours cleanly.
+
+ECharts (~1 MB) was rejected: its advantage is exotic chart types, but for
+referrer and path data a ranked bar list is more legible than a treemap, and
+those are ~30 lines of CSS matching the design system better than any library
+default. Hand-rolling everything was rejected because synchronised cursors,
+brush-to-zoom, and range selection are where the real work and the real bugs are.
+
+### 3.5 Vendored, but dependency-tracked
+
+`site/index.html` loads **zero** third-party assets (verified: 10 absolute URLs,
+all navigation). Preserving that means no visitor IP leaks to a third party, no
+CDN supply-chain surface inside the page origin, and no external point of
+failure. It would also be incoherent to SHA-pin every CI action and then pull
+unpinned JavaScript from a CDN at runtime.
+
+But a hand-copied vendored file rots silently — no scanner sees it, no Dependabot
+PR updates it. Resolution:
+
+- `uplot` is a `devDependency` of `@backspace/metrics`, so Dependabot (whose npm
+  entry at `/` already covers new workspaces) and OSV-Scanner track it normally.
+- `vendor:sync` copies it from `node_modules` into `site/insights/assets/`.
+- `vendor:check` asserts the committed copy matches byte-for-byte.
+
+`vendor:check` runs **inside the package's `test` script**, not as a separate CI
+step — see §3.6. A Dependabot bump then fails `pnpm -r test` until `vendor:sync`
+is re-run, which is the desired forcing function.
+
+### 3.6 CI wiring: fold everything into `test`
+
+The first draft claimed the workspace addition meant "CI covers it with no
+workflow change." **That was false.** `ci.yml` runs `pnpm build` (filtered to
+shared/server/web), `pnpm --filter @backspace/desktop build:ts`, and
+`pnpm -r test`. It **never runs `pnpm -r typecheck`** — the root script exists but
+nothing invokes it.
+
+So the metrics package's `test` script is:
+
+```
+tsc --noEmit && vitest run && node --experimental-strip-types vendor-check.ts
+```
+
+This makes the existing `pnpm -r test` step genuinely cover types, unit tests,
+and vendor drift with no `ci.yml` change. `pnpm-workspace.yaml` gains
+`scripts/metrics` specifically, not `scripts/*`, so unrelated future scripts are
+not swept into the workspace.
+
+### 3.7 TypeScript via Node type stripping — and its real constraints
+
+The collector is TypeScript with **zero runtime dependencies** (`fetch` and
+`node:` builtins only), executed directly by Node with no build step, keeping the
+daily job at roughly 20 seconds.
+
+Corrections to the first draft: type stripping has been unflagged since **v22.18
+/ v23.6** and stable since **v24.12** — so the "root `engines` permits Node 20,
+which cannot do this" framing was a non-issue. The package declares
+`engines: >=22.18`; the **workflow** pins `node-version: 24`. Tests import modules
+directly through vitest and never shell out to `node src/*.ts`, so the Node 20 leg
+of `ci.yml` is unaffected. There is no `.npmrc`, so `engine-strict` is off; if
+anyone enables it later, this is the package that will complain first.
+
+The constraints that actually shape the code, all omitted from v1:
+
+- **`import type` is mandatory** for type-only imports. Without it Node treats the
+  import as a value import and throws `SyntaxError` **at runtime**. Since §4 has a
+  dedicated `types.ts`, the failure mode is a green typecheck and a red 03:00
+  cron. This is the single most likely way this system breaks.
+- **File extensions are mandatory:** `import './series.ts'`, never `'./series'`.
+- **Unsupported:** enums, namespaces with runtime code, parameter properties,
+  import aliases, decorators.
+
+Mitigation is compiler-enforced, not discipline-enforced: the package tsconfig
+sets `erasableSyntaxOnly`, `verbatimModuleSyntax`, and
+`rewriteRelativeImportExtensions`, so `tsc --noEmit` — which now runs in CI via
+§3.6 — rejects every one of these at review time rather than at 03:00.
+
+---
+
+## 4. Architecture
+
+```
+.github/workflows/metrics.yml        daily cron -> collect -> commit -> deploy
+.github/workflows/backfill.yml       workflow_dispatch only
+.github/workflows/deploy-pages.yml   extended: workflow_call + data bundling
+
+scripts/metrics/                     @backspace/metrics (new workspace package)
+  tsconfig.json      extends repo strict config; erasableSyntaxOnly etc (§3.7)
+  src/
+    github.ts        API client: auth, pagination, 202 retry, error handling
+    series.ts        CSV/NDJSON read, upsert, sorted write
+    collect.ts       daily snapshot entrypoint
+    backfill.ts      historical reconstruction entrypoint
+    bundle.ts        data branch -> site/insights/data.json
+    types.ts         shared types (import type only — see §3.7)
+  test/              vitest, fixture-driven, no network
+
+site/insights/
+  index.html         dashboard (Aether Drift, self-contained)
+  assets/uplot.*     vendored, dependency-tracked
+
+branch: metrics-data (orphan, ruleset-protected)
+  traffic/views.csv, clones.csv, referrers.ndjson, paths.ndjson
+  stars.csv, forks.csv, releases.csv, contributors.csv, repo.csv
+  meta.json
+```
+
+Both new workflows follow house convention without exception: a header comment
+explaining *why* (including the two-token split, the caller-permission cap, and
+the 60-day hazard), `step-security/harden-runner` with `egress-policy: audit`,
+and every `uses:` pinned to a full SHA with a trailing `# vX.Y.Z`. The
+`deploy-pages.yml` edit preserves its existing pins and **adds** harden-runner,
+which it is currently the only workflow to lack.
+
+### 4.1 Data flow
+
+1. Cron fires `metrics.yml` at 03:00 UTC.
+2. **Bootstrap check before checkout.** `git ls-remote --exit-code --heads origin
+   metrics-data` determines whether the branch exists; if absent, it is created
+   with `git switch --orphan` plus an empty commit. This ordering is mandatory:
+   `actions/checkout` with a nonexistent `ref` hard-fails the job, so a bootstrap
+   *step* placed after checkout can never run.
+3. Checkout `main` (scripts) and `metrics-data` into `./.metrics-data`
+   (gitignored, so `git status` on the main checkout stays clean).
+4. `collect.ts` fetches **every** series into memory first (§5.2 atomicity).
+5. On full success: upsert, rewrite sorted, commit, push with `GITHUB_TOKEN`.
+   Pushes made with `GITHUB_TOKEN` do not create workflow runs (`workflow_dispatch`
+   and `repository_dispatch` are the only exceptions, neither of which applies),
+   so there is no collection loop.
+6. An `if: always()` step commits `meta.json` alone, recording `last_run` and any
+   error, so failures are visible on the data branch rather than only in the
+   Actions tab.
+7. A `gh workflow enable` call keeps the schedule alive (§10, 60-day hazard).
+8. The deploy job calls `deploy-pages.yml` via `workflow_call`.
+
+### 4.2 Token model
+
+Two tokens. The split is **forced, not preferred**: there is no `administration`
+key in the `permissions:` vocabulary at all, so no `GITHUB_TOKEN` configuration
+can reach the traffic endpoints.
+
+| Token | Scope | Used for |
+|---|---|---|
+| `secrets.METRICS_TOKEN` | Fine-grained PAT, this repo only. **Administration: read** (verified as the exact documented requirement for all four traffic endpoints) + Contents: read | Traffic, stars, forks, issues, releases, stats |
+| `GITHUB_TOKEN` | Per-job, see below | Pushing to `metrics-data`; Pages deploy |
+
+**Correction to v1.** A called workflow's permissions can only be *maintained or
+reduced*, never elevated, and unlisted permissions are set to `none`. Since
+`deploy-pages.yml` needs `pages: write` and `id-token: write`, the **calling job
+must declare them too**. Granting the collect job only `contents: write` would
+make every metrics-triggered Pages deploy fail with "Resource not accessible by
+integration."
+
+So permissions are declared per job, not per workflow:
+
+| Job | Permissions |
+|---|---|
+| `collect` | `contents: write` |
+| `deploy` (calls `deploy-pages.yml`) | `contents: read`, `pages: write`, `id-token: write` |
+
+This is weaker than v1 claimed — the deploy job holds the union of what the
+reusable workflow needs — but splitting the jobs keeps the *collect* job at
+`contents: write` only, so the job that touches the archive cannot deploy and the
+job that deploys cannot write the archive. `METRICS_TOKEN` is passed to neither;
+it is read only by `collect`, via `secrets:` on the job, never `secrets: inherit`.
+
+### 4.3 Concurrency
+
+`metrics.yml` and `backfill.yml` write the same files, so both declare:
+
+```yaml
+concurrency:
+  group: metrics-data
+  cancel-in-progress: false
+```
+
+`false` is mandatory: cancelling a collect run loses that day irrecoverably.
+
+If a push is still rejected as non-fast-forward, the job runs `git pull --rebase`,
+re-applies the upsert against the refreshed files, and retries — twice, then
+fails loudly. Traffic's 14-day overlap makes a lost day recoverable; a silent
+clobber is not.
+
+### 4.4 Daily collection sources
+
+`collect.ts` reads exactly these endpoints. Required series abort the write on
+failure (§5.2); optional ones skip, leaving the prior value.
+
+| Endpoint | Writes | Required |
+|---|---|---|
+| `/traffic/views` | `traffic/views.csv` | **Yes** |
+| `/traffic/clones` | `traffic/clones.csv` | **Yes** |
+| `/traffic/popular/referrers` | `traffic/referrers.ndjson` | **Yes** |
+| `/traffic/popular/paths` | `traffic/paths.ndjson` | **Yes** |
+| `/repos/{slug}` | `repo.csv`, `stars.csv`, `forks.csv` (counter fields) | **Yes** |
+| `/releases` | `releases.csv`; `repo.csv.downloads_total` = sum of every asset's `download_count` | No |
+| `/stats/contributors` | `contributors.csv` | No — 202-prone (§6.1) |
+
+Traffic is required because it is the only irreplaceable data. Releases and stats
+are optional because both are reconstructable at any later date, so losing a day
+of them costs nothing and neither should be able to block a traffic write.
+
+`stars.csv` and `forks.csv` are written daily from the **repo object's counters**
+(`stargazers_count`, `forks_count`), not by listing stargazers. That is a
+point-in-time measurement which correctly reflects unstars. §6's backfill
+reconstructs the same series from `starred_at`, which cannot see unstars — which
+is precisely why backfill is write-if-absent (§5.2).
+
+---
+
+## 5. Data Model
+
+All files live on `metrics-data`, sorted ascending on write so diffs are stable
+and append-only in the common case.
+
+### 5.1 Date-keyed series (CSV, header row, one row per UTC date)
+
+```
+traffic/views.csv     date,count,uniques
+traffic/clones.csv    date,count,uniques
+stars.csv             date,total
+forks.csv             date,total
+releases.csv          date,tag,name          # published_at; drives §7 annotations
+contributors.csv      date,total             # daily, 202-prone (§6.1); backfilled once
+repo.csv              date,subscribers,open_issues,downloads_total
+```
+
+Three v1 columns are gone. `size_kb` appeared on no chart. `issues.csv` and
+`prs.csv` are cut with the Health section (§2). `releases.ndjson` is replaced by
+`releases.csv` plus a single `downloads_total` column — v1 snapshotted all 22
+assets of every release every day, which alone was 760 KB/year and grew ~20
+rows/day per additional release, for a Distribution chart that is now deferred.
+
+`repo.csv.subscribers` is deliberately **not** named `watchers`: GitHub's
+`watchers_count` is a duplicate of `stargazers_count` (live: both 56), and the
+real watcher count is `subscribers_count` (live: 1). Reading the obviously-named
+field would have silently duplicated the star series.
+
+### 5.2 Write semantics
+
+**Fetched values win, with three guards:**
+
+1. **Atomicity.** Every series is fetched into memory before anything is written.
+   Any required fetch failing aborts the whole write — no commit, `last_success`
+   untouched. A half-failed run must never produce a file the next run treats as
+   authoritative.
+2. **Backfill is write-if-absent.** Backfill may only fill dates with no existing
+   row; it never overwrites a collector-written value. Without this rule, running
+   backfill six months in would overwrite six months of correctly measured daily
+   star counts with values reconstructed from the *current* stargazer list — which
+   is systematically wrong, because anyone who starred and later unstarred is
+   invisible to `/stargazers`. Same hazard for forks. Asserted by test (§9).
+3. **No zero-filling.** The traffic API returns quiet days explicitly as
+   `count: 0` (verified live against a zero-traffic repo), so a missing date means
+   "not collected", never "zero". Absent dates stay absent, and `bundle.ts` emits
+   `null` for them so uPlot breaks the line rather than drawing a false zero.
+
+Properties this yields:
+
+- **Idempotent.** Re-running produces no duplicates and no drift.
+- **Self-healing.** The traffic window is 14 buckets wide, so any gap of **≤13
+  full days** is silently repaired by the next successful run. A missed cron costs
+  nothing.
+
+**Correction to v1: the current UTC day is often absent, not partial.** Measured
+at 14:51 UTC on a repo averaging ~50 views/day, the window ended `2026-08-24`
+with no row for today at all — while other repos the same minute *did* include
+today. The window's end date is not deterministic and does not track wall-clock
+UTC. The collector must therefore never assume `views[last].date === today`, and
+never interpret a missing today-row as zero traffic. Bucket timestamps themselves
+are reliably UTC-midnight aligned (`2026-08-11T00:00:00Z`), as documented.
+
+### 5.3 Aggregate-window series (NDJSON) — and an honest limitation
+
+`/traffic/popular/referrers` and `/popular/paths` return a **single aggregate
+covering the trailing 14 days**, top 10 only (verified live: paths returned
+exactly 10). Daily referrer counts are not reconstructable — not here, not
+anywhere. GitHub does not expose them.
+
+What is achievable is snapshotting the aggregate daily, tagged with fetch date:
+
+```
+traffic/referrers.ndjson  {"snapshot_date":"2026-08-25","referrer":"news.ycombinator.com","count":118,"uniques":94}
+traffic/paths.ndjson      {"snapshot_date":"2026-08-25","path":"/TheZwiss/backspace","title":"…","count":402,"uniques":161}
+```
+
+Each row means "in the 14 days ending on `snapshot_date`". The dashboard labels
+these sections as trailing-14-day figures so the weaker resolution is never
+presented as something it is not.
+
+- Upsert key: `(snapshot_date, dimension)`.
+- Written by **full rewrite each run**, sorted `(snapshot_date asc, count desc,
+  dimension asc)` — specified because the alternative (append, or a different
+  secondary sort) churns the whole file on every commit and defeats §3.2's
+  one-line-per-day diff rationale entirely.
+- A dimension absent from a snapshot means "outside the top 10", i.e. *≤ the #10
+  count* — **not zero**. §7 renders it as a break in the line. Plotting zero would
+  be a lie.
+
+### 5.4 Collector state (`meta.json`)
+
+```json
+{
+  "last_run": "2026-08-25T03:00:41Z",
+  "last_success": "2026-08-25T03:00:41Z",
+  "error": null,
+  "series_last_date": { "traffic/views.csv": "2026-08-24", "stars.csv": "2026-08-25" }
+}
+```
+
+`series_last_date` keys are exact file paths. `last_run` is written on every
+attempt via the `if: always()` step (§4.1.6); `last_success` and `error` only on
+completion. The dashboard header renders staleness from `last_success` and warns
+visibly past 48 hours. This is the detection mechanism referenced in §10 — without
+it a dead collector looks identical to a quiet week. `schema_version` is dropped:
+one version, no migration path, no reader that branches on it.
+
+### 5.5 Volume
+
+Measured by serialising today's real API responses into these exact shapes:
+
+| Series | bytes/day | KB/year |
+|---|---|---|
+| `paths.ndjson` (10 rows) | 1,437 | 512 |
+| `referrers.ndjson` (8 rows, 10 max) | 640 | 228 |
+| all CSVs combined | ~210 | 75 |
+| **total** | | **~815 KB/yr** |
+
+**~8 MB/decade.** v1's "300 KB/year, under 5 MB/decade" was ~5× low and rested
+on a `releases.ndjson` shape now cut (§5.1). §3.2's conclusion against SQLite
+still holds comfortably; the margin is simply narrower than first stated.
+
+### 5.6 Field-name traps to record in `metrics.md`
+
+- `watchers_count` = stars. Use `subscribers_count` for watchers.
+- The repo object's `open_issues` **includes open PRs**. `repo.csv.open_issues`
+  carries that meaning and the dashboard labels it "open issues and PRs".
+- `/stargazers` listing became **admin/collaborator-gated in July 2026**. The
+  `METRICS_TOKEN` satisfies it (`Metadata: read` is implicit on every fine-grained
+  PAT), but it works because the token belongs to a repo admin, not because stars
+  are openly readable.
+
+---
+
+## 6. Backfill
+
+`backfill.yml`, `workflow_dispatch` only, never on cron. **Write-if-absent
+throughout** (§5.2), so a re-run can never overwrite measured data.
+
+**Files backfill may touch, exhaustively:** `stars.csv`, `forks.csv`,
+`releases.csv`, `contributors.csv`. Nothing else. It never opens `traffic/*` or
+`repo.csv` — the latter carries `subscribers`, which no API can reconstruct
+historically, so a stray rewrite would be permanent loss with nothing to restore
+from.
+
+| Series | Method |
+|---|---|
+| Stars | Paginate `/stargazers` with `Accept: application/vnd.github.star+json`, bucket `starred_at` by UTC day, accumulate |
+| Forks | Paginate `/forks?sort=oldest`, bucket `created_at` |
+| Releases | `/releases` → `published_at`, `tag_name`, `name` |
+| Contributors | `/stats/contributors` weekly buckets → count of distinct contributors whose first commit week is on or before each date (cumulative distinct, not an interpolation of weekly totals) |
+
+`/issues` is no longer used: the Health section is deferred (§2).
+
+### 6.1 The 202 problem
+
+`/stats/contributors` returns **HTTP 202 with an empty body** while GitHub
+computes statistics — verified live, first call `202 {}`, second call minutes
+later `200` with 4 contributors across 28 weeks. Critically, **the stats cache is
+keyed by the default branch SHA and reset by every push to `main`**, so an active
+repo hits this routinely rather than rarely.
+
+Under a naive `await res.json()`, that `{}` becomes `contributors = 0` and,
+under fetch-wins, corrupts the series. Required handling:
+
+- Retry with backoff on 202.
+- A persistent 202 is a **skip**, leaving the prior value — never a zero.
+- Treated as non-required for atomicity (§5.2): a stats timeout must not abort
+  the traffic write, since traffic is the irreplaceable part.
+
+`/stats/commit_activity` and `/stats/code_frequency` behave identically. They are
+not collected in v1, which is one reason the commit-activity chart is deferred.
+
+### 6.2 Rate limits
+
+Standard 5,000/hr; no special or secondary limit applies to traffic or stats
+endpoints, and a handful of daily requests is three orders of magnitude clear.
+v1's sleep-until-`x-ratelimit-reset` loop and its fixture test are **cut** — at 56
+stargazers (one page) that code would be written, tested, and never executed.
+Fail loudly on 429/403 and re-dispatch instead.
+
+Pagination is still implemented properly (`per_page=100`), since it is cheap and
+correct. One caveat to re-check if the repo ever crosses ~40k stars: a listing
+ceiling is widely cited but could not be confirmed in current docs. Also note
+that `GITHUB_TOKEN` carries a **1,000 req/hr per-repository** limit rather than
+5,000 — backfill must run under `METRICS_TOKEN`.
+
+---
+
+## 7. Dashboard
+
+`site/insights/index.html`. Aether Drift tokens reused from the landing page,
+copy in the same voice. Self-contained: no external asset requests. Responsive.
+
+One shared time-range control (30d / 90d / 1y / all) and one shared hover cursor
+drive every time-series chart simultaneously.
+
+**Five sections in v1** (Health, Distribution, and Activity deferred per §2):
+
+| Section | Content |
+|---|---|
+| Header | Stars, forks, watchers, views and clones **since collection began**, contributors, total downloads — each with a 30-day delta |
+| Reach | Views and clones with uniques; drag-to-zoom; the core archive view |
+| Growth | Star and fork history, all-time, **with release tags annotated on the time axis** (sourced from `releases.csv`) |
+| Where people come from | Ranked referrer bars, trailing 14 days, labelled as such; plus top-5 referrer trajectories |
+| What they look at | Ranked popular-path bars, same labelling |
+
+The release annotation is the highest-value element: it turns "stars went up in
+July" into "the v1 release drove that", and is only possible because release
+dates and star history live in the same archive. v1 of this spec claimed it while
+persisting no release date at all — `releases.csv` (§5.1) exists to fix that.
+
+**Honest labelling is a requirement, not a nicety.** The header says "Views since
+2026-08-25", never "all-time", because §2 establishes that earlier traffic is
+unrecoverable. Before 30 days of data exist, deltas render as "—", not as a
+spuriously large percentage.
+
+**Referrer trajectories are differenced, not raw.** Consecutive snapshots share 13
+of their 14 days, so a raw trajectory is a rolling sum that reads as smooth growth
+when nothing changed. A missing dimension renders as a break, never zero (§5.3).
+
+### 7.1 Data delivery and empty states
+
+Data loads as one `data.json` bundle generated at deploy time, so the page makes a
+single request. Pages serves it gzipped. **Budget: 2 MB uncompressed.** Past that,
+the `all` range downsamples to weekly buckets. `bundle.ts` fails the build if the
+budget is exceeded, so the regression surfaces in CI rather than in first paint.
+
+`site/insights/data.json` is a **build artifact, never committed** — added to
+`.gitignore` under a labelled section. The data branch is the single source of
+truth; committing a derived copy invites the two to disagree. Consequently the
+page must handle a 404 on `data.json` gracefully, which is the same empty-state
+path as a missing data branch: render the shell with an explanatory message, not
+a broken chart.
+
+### 7.2 Pages deployment change
+
+`deploy-pages.yml` gains `workflow_call` alongside its existing triggers, plus
+`setup-node` and `pnpm` (it currently has neither), a conditional checkout of
+`metrics-data`, and a `bundle.ts` step.
+
+**The metrics-data checkout must be conditional and non-fatal.** That workflow
+today deploys the landing page on every `site/**` push. An unconditional checkout
+of a branch that does not yet exist would fail *every landing-page deploy* until
+the metrics branch is created, and permanently if it is ever deleted — a live
+regression to working production. `bundle.ts` emits a valid empty `data.json`
+when the branch or any file is missing.
+
+Two more unstated pieces: the workflow's `paths:` filter must gain
+`scripts/metrics/**` (otherwise a bundler change never redeploys), and the
+`github-pages` environment has a branch policy allowing only `main` and
+`gh-pages` — so a `workflow_dispatch` run from a feature branch is blocked at the
+environment gate. Worth one line in the runbook.
+
+**Concurrency correction.** v1 said the existing
+`concurrency: { group: pages, cancel-in-progress: true }` "correctly serialises"
+a metrics deploy against a site push. It does the opposite — it **cancels** the
+in-flight deploy. GitHub's own Pages starter workflow comments this explicitly:
+*"do NOT cancel in-progress runs as we want to allow these production deployments
+to complete."* Cancelling `actions/deploy-pages` mid-flight also strands an
+in-progress deployment in the `github-pages` environment that blocks the next one.
+
+This is a pre-existing bug in `deploy-pages.yml`, not one this project
+introduces — but adding a second trigger source turns collisions from theoretical
+into routine. **Flip it to `cancel-in-progress: false`** as part of WS2. Also note
+that workflow-level `concurrency` in a *called* workflow is not reliably honoured;
+the group belongs on the calling job.
+
+---
+
+## 8. Workstreams & Sequencing
+
+Sequencing is load-bearing. **Every day without a running collector destroys
+traffic data permanently**, so WS1 ships alone, first. A half-finished dashboard
+blocking a working collector would be an unforced, unrecoverable loss.
+
+Each workstream becomes its own plan file, following the precedent of the
+security spec (whose workstreams became `plan-a-…`, `plan-b-…`, `plan-d-…`). Two
+workstreams, not more: a separate plan file buys a fresh execution session and a
+real stop-and-reconsider gate, which fits WS1 (must ship alone, must ship first,
+independently valuable) and does not fit any split within the dashboard.
+Documentation is folded into each rather than deferred to a workstream of its own,
+where it would simply be skipped.
+
+### WS1 → `plan-a-metrics-collection.md`
+The package, workspace and tsconfig wiring (§3.6, §3.7), `github.ts`, `series.ts`,
+`collect.ts`, `meta.json`, `metrics.yml`, `backfill.yml`, `METRICS_TOKEN`, the
+branch ruleset, orphan bootstrap, concurrency, and the §9 tests. Includes
+`docs/systems/metrics.md` and the `security-scanning.md` checklist entry, because
+the PAT setup and the 60-day hazard need documenting the moment the pipeline
+exists. Backfill lands here too — it shares `series.ts` and is ~¼ the size of the
+other workstreams.
+
+**Done when data has been committed on two consecutive days and a re-run is
+proven byte-identical for all dates before the current UTC day.** Independently
+valuable with no dashboard: the archive is accruing.
+
+### WS2 → `plan-b-metrics-dashboard.md`
+`bundle.ts` and the data contract, the empty-archive path, the `deploy-pages.yml`
+extension, the `cancel-in-progress` fix, `site/insights/index.html`, uPlot
+vendoring, and `vendor:sync`/`vendor:check`. For scale: `site/index.html` is
+1,082 lines.
+
+An earlier draft split the deploy-pages edit into a third workstream, on the
+grounds that it touches a **currently working production deploy** and carries the
+regression risk in §7.2. That risk is real, but a separate plan file is not what
+isolates it — every task already lands as its own commit behind its own review
+gate. The edit is therefore the **first task** of this workstream, reviewed on its
+own before any chart code exists, which achieves the same isolation without a
+third plan.
+
+The bundler and the page are not separable in any case: a bundler with no page to
+read it, and a page with no data to render, are each useless. They ship together.
+
+**Done when `data.json` appears in the Pages artifact, the landing page still
+deploys with the metrics branch both present and absent, and the five sections in
+§7 render.**
+
+---
+
+## 9. Testing Strategy
+
+Vitest, fixture-driven, **no network in any test**. Tests import modules directly
+and never shell out to `node src/*.ts`, so the Node 20 leg of `ci.yml` passes.
+Coverage reaches CI through the package `test` script (§3.6).
+
+| Area | Assertions |
+|---|---|
+| Upsert | Overlapping windows produce no duplicates; fetched values win; output sorted; re-run byte-identical for dates before today |
+| **Backfill safety** | Backfill never modifies a date that already has a row; never opens `traffic/*` or `repo.csv` |
+| Atomicity | A failed fetch of any required series produces no write and no `last_success` update |
+| Boundary | A window ending before today is handled; a missing today-row is never written as zero; UTC bucketing has no off-by-one at midnight |
+| Gaps | A 10-day gap is fully repaired by one run; a 14-day gap leaves absent rows, and the bundler emits `null` for them |
+| **202 handling** | 202 retries with backoff; a persistent 202 skips rather than writing zero; a stats 202 does not abort the traffic write |
+| CSV/NDJSON | Round-trip lossless; commas and quotes in paths and titles escaped; NDJSON secondary sort is `count desc, dimension asc` |
+| Backfill math | Cumulative star counts from a fixture `starred_at` list; multi-page pagination |
+| Bundle | Malformed rows rejected loudly; missing branch yields a valid empty bundle; the 2 MB budget fails the build |
+| **Erasable syntax** | `tsc --noEmit` with `erasableSyntaxOnly` + `verbatimModuleSyntax` rejects a value-import of a type and any non-erasable construct (§3.7) |
+| Dependency guard | The collector imports nothing outside `node:` builtins |
+| Vendor guard | `vendor:check` fails when the committed uPlot copy diverges |
+
+---
+
+## 10. Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| **Scheduled workflows auto-disable after 60 days of no repository activity** | High | v1's mitigation was detection-only and rested on an unexamined assumption. Bot commits do appear to count as activity, but **whether a push to a non-default branch counts is undocumented**, and every keepalive tool commits to the default branch — while this collector commits only to an orphan branch. Mitigation is therefore active, not passive: an idempotent `gh workflow enable` step in the job itself, plus the `last_success` staleness warning in the dashboard header as a backstop |
+| **`import type` omitted → runtime `SyntaxError` in the cron** | High | `erasableSyntaxOnly` + `verbatimModuleSyntax` in the package tsconfig, enforced by `tsc --noEmit` inside `pnpm -r test` (§3.6, §3.7) |
+| **Backfill overwrites measured history** | High | Write-if-absent rule (§5.2) with an explicit allowed-files list (§6) and a dedicated test |
+| **`deploy-pages.yml` edit breaks the live landing page** | High | Conditional, non-fatal metrics-data checkout; empty-bundle path; WS2 reviewed in isolation with "landing page still deploys, branch absent" in its done criteria |
+| `metrics-data` deleted or force-pushed | High | Matching ruleset (`deletion`, `non_fast_forward`, no bypass), per §3.3 |
+| PAT expires, is revoked, or the repo is transferred | High | Job fails loudly rather than skipping. A gap ≤13 days is fully recoverable, giving a two-week window to notice. A transfer to another owner invalidates a repo-scoped fine-grained PAT and needs it re-issued |
+| Stats endpoints return 202 | Medium | Retry, then skip — never zero (§6.1) |
+| Pages deploy cancelled mid-flight, stranding the environment | Medium | `cancel-in-progress: false` (§7.2) |
+| Collect and backfill race | Medium | Shared `metrics-data` concurrency group, `cancel-in-progress: false`, rebase-and-retry on rejected push (§4.3) |
+| Cron delayed or dropped by GitHub | Low | Absorbed by the ≤13-day overlap |
+| Data branch missing on first run | Low | `git ls-remote` check **before** checkout (§4.1) |
+| Repo renamed | Low | Slug read from `github.repository`, never hardcoded |
+| Vendored uPlot rots | Low | Real devDependency; `vendor:check` inside `pnpm -r test` |
+| Publishing traffic numbers publicly | Accepted | Explicit decision; transparency judged worth more than concealment |
+| Referrer resolution weaker than daily | Accepted | Upstream limitation; labelled explicitly in the UI |
+
+---
+
+## 11. Documentation
+
+Per CLAUDE.md's documentation rule this is structural — new workflows, a new data
+store, a new UI surface — so docs are required:
+
+- **New:** `docs/systems/metrics.md` — collection pipeline, data schemas, upsert
+  and write-if-absent semantics, backfill procedure, PAT scopes, the 202 problem,
+  the field-name traps in §5.6, the 60-day hazard, the `github-pages` branch
+  policy, and dashboard architecture.
+- **Updated:** CLAUDE.md subsystem table gains a `metrics.md` row.
+- **Updated:** CLAUDE.md monorepo structure gains `scripts/`, noting the subsystem
+  spans `scripts/metrics` (a workspace package) and `site/insights` (not one).
+- **Updated:** `docs/systems/security-scanning.md` — its existing "Maintainer
+  checklist (one-time GitHub settings — NOT code)" gains two entries: create the
+  `METRICS_TOKEN` secret with fine-grained repo-scoped `Administration: read`, and
+  create the `metrics-data` ruleset.
+
+v1 listed `docs/systems/deployment.md`; that file contains **zero** mentions of
+Pages or `site/`, so there is nothing there to update. Dropped.
+
+---
+
+## 12. Definition of Done
+
+1. `metrics.yml` runs daily, collects every series in §5, and commits to
+   `metrics-data`.
+2. Backfill has been run once; stars, forks, releases, and contributors carry
+   history from 2026-02-18, and a second run provably changes nothing.
+3. The dashboard is live at `thezwiss.github.io/backspace/insights/`, renders all
+   five sections in §7, and makes zero third-party requests.
+4. Two consecutive daily runs produce correct, duplicate-free data, and a re-run
+   is **byte-identical for all dates before the current UTC day** (not a no-op —
+   today's row legitimately changes, per §5.2).
+5. `pnpm -r test` passes, covering types, unit tests, and `vendor:check` (§3.6).
+6. `METRICS_TOKEN` exists with fine-grained, repo-scoped, read-only permissions.
+7. The `metrics-data` ruleset blocks deletion and force-push, with no bypass
+   actors and no PR or status-check requirement.
+8. The landing page still deploys from a `site/**` push, verified with the
+   metrics branch both present and absent.
+9. Documentation in §11 is written and committed.

--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -1,0 +1,297 @@
+# Repository Metrics Archive
+
+Source files:
+- `scripts/metrics/src/types.ts` -- Shared row shapes (`TrafficPoint`, `CountPoint`, `ReleaseRow`, `RepoPoint`, `DimensionRow`)
+- `scripts/metrics/src/github.ts` -- GitHub API client: auth, pagination (`Link: rel="next"`), `/stats/*` 202 retry
+- `scripts/metrics/src/series.ts` -- CSV/NDJSON parse + format, date-keyed upsert, dimensional upsert
+- `scripts/metrics/src/store.ts` -- Filesystem layer: atomic per-file writes (temp + rename), `meta.json` read/write, path containment
+- `scripts/metrics/src/collect.ts` -- Daily snapshot entrypoint (`collect()`)
+- `scripts/metrics/src/backfill.ts` -- One-shot historical reconstruction entrypoint (`backfill()`)
+- `scripts/metrics/src/cli-collect.ts` -- `process.env`/clock-reading wrapper invoked by `metrics.yml`
+- `scripts/metrics/src/cli-backfill.ts` -- `process.env`-reading wrapper invoked by `backfill.yml`
+- `scripts/metrics/src/cli-support.ts` -- Env validation, token safety check, timestamp derivation, log formatting
+- `.github/workflows/metrics.yml` -- Daily cron: collect, commit, push, `gh workflow enable`
+- `.github/workflows/backfill.yml` -- `workflow_dispatch`-only backfill runner
+
+**Out of scope:** the public dashboard. Section 11 below explains why — it is a separate, not-yet-built workstream. This document covers only the collection pipeline: the `scripts/metrics` package, the two workflows, and the orphan `metrics-data` branch they write to.
+
+---
+
+## 1. Why this exists
+
+GitHub's Insights → Traffic panel (views, clones, referrers, popular paths) retains data for **14 days only**, then discards it. No API reconstructs a day once it has aged out of that window. Every day this collector does not run is a day of traffic history destroyed permanently, with no recovery path.
+
+Everything else GitHub tracks about the repo (stars, forks, issues, releases, contributors) is retrievable at any later date from permanent, timestamped API data — so it only needs to be captured once, not daily.
+
+### What is and is not recoverable
+
+| Data | Retention | Action |
+|---|---|---|
+| Traffic: views, clones, referrers, popular paths | **14 days, then destroyed** | **Snapshot daily** |
+| Release asset download counts | Live cumulative total, no time series | **Snapshot daily** |
+| Stars | Permanent — `/stargazers` returns `starred_at` | Backfill once |
+| Forks | Permanent — `created_at` | Backfill once |
+| Releases | Permanent — `published_at` | Backfill once |
+| Contributors | Permanent — `/stats/contributors` | Backfill once |
+
+Issues/PRs and commit/code-frequency history are not collected at all — no chart in this codebase consumes them, so there is nothing here to seed for them.
+
+---
+
+## 2. Architecture
+
+```
+scripts/metrics/                     @backspace/metrics (pnpm workspace package)
+  package.json      zero runtime dependencies; scripts: typecheck, test
+  tsconfig.json      extends the repo's strict base config, plus erasableSyntaxOnly,
+                      verbatimModuleSyntax, rewriteRelativeImportExtensions
+  src/
+    types.ts          shared row shapes (import type only)
+    github.ts         API client
+    series.ts         CSV/NDJSON codec + upsert
+    store.ts           filesystem layer, meta.json
+    collect.ts         daily snapshot
+    backfill.ts         historical reconstruction
+    cli-collect.ts      env/clock wrapper for metrics.yml
+    cli-backfill.ts     env wrapper for backfill.yml
+    cli-support.ts      shared CLI helpers
+    *.test.ts           vitest, no network, no filesystem outside a per-test tmpdir
+
+.github/workflows/metrics.yml        daily cron -> collect -> commit -> push
+.github/workflows/backfill.yml       workflow_dispatch only
+
+branch: metrics-data (orphan, intended to be ruleset-protected — see §8)
+  traffic/views.csv, traffic/clones.csv
+  traffic/referrers.ndjson, traffic/paths.ndjson
+  stars.csv, forks.csv, releases.csv, contributors.csv, repo.csv
+  meta.json
+```
+
+The collector is plain TypeScript executed directly by Node's native type stripping — no build step, no transpiler, no `dist/`. `pnpm-workspace.yaml` lists `scripts/metrics` explicitly (not `scripts/*`), so unrelated future scripts under `scripts/` are not swept into the workspace by accident.
+
+### The two workflows
+
+Both `metrics.yml` and `backfill.yml`:
+- Declare `concurrency: { group: metrics-data, cancel-in-progress: false }`. This shared group name is the **only** thing preventing the daily cron and a dispatched backfill from racing on the same branch — they queue instead of running concurrently, and neither is ever cancelled mid-write, since cancelling a collection run loses that day irrecoverably.
+- Skip entirely on a fork (`if: ${{ !github.event.repository.fork }}`), because `METRICS_TOKEN` is a repository secret and does not propagate to forks — without this guard a fork's own scheduled run would fail every day with nothing the fork owner could do about it.
+- Bootstrap the `metrics-data` branch via `git ls-remote --exit-code --heads origin metrics-data` **before** any `actions/checkout` step references it. `actions/checkout` hard-fails the job if given a nonexistent `ref`, so the check has to run first. If the branch is absent, both workflows create it with `git worktree add --orphan` into a scratch directory (`.metrics-init`), commit an empty initial commit, push, and remove the worktree — never touching the primary checkout, so an early exit can't leave that tree modified.
+- Check out `metrics-data` into `./.metrics-data` (gitignored — see `.gitignore`'s `.metrics-data/` entry — so `git status` on the main checkout stays clean) and pin `actions/setup-node` to `node-version: 24`.
+- Run `step-security/harden-runner` with `egress-policy: audit`, and pin every `uses:` to a full commit SHA with a trailing `# vX.Y.Z` comment, per this repo's standing CI convention (see `docs/systems/security-scanning.md`).
+
+`metrics.yml` runs `collect` (`node scripts/metrics/src/cli-collect.ts`); `backfill.yml` runs `backfill` (`node scripts/metrics/src/cli-backfill.ts`). Both jobs declare only `contents: write` (plus `actions: write` on `metrics.yml`, for the schedule-keepalive step in §9) — there is no separate deploy job in this codebase today, because there is no dashboard to deploy (§11).
+
+---
+
+## 3. Data schemas
+
+All files live at the root of the `metrics-data` branch. CSVs are sorted ascending on their first (date) column on every write; NDJSON files are sorted `(snapshot_date asc, count desc, dimension asc)`. Both orderings are fixed by `series.ts` (`formatCsv`, `compareDimensionRows`) so that re-running the collector against unchanged upstream data produces a byte-identical file — the property that keeps daily commits to one line of diff.
+
+### 3.1 Date-keyed series (CSV, header row, one row per UTC date)
+
+| File | Columns | One row means |
+|---|---|---|
+| `traffic/views.csv` | `date,count,uniques` | Total views and unique visitors on that UTC date |
+| `traffic/clones.csv` | `date,count,uniques` | Total clones and unique cloners on that UTC date |
+| `stars.csv` | `date,total` | The repo's live `stargazers_count` as read on that date (a point-in-time snapshot, not a delta) |
+| `forks.csv` | `date,total` | The repo's live `forks_count` as read on that date |
+| `releases.csv` | `date,tag,name` | A release published on that UTC date (`date` = `published_at`'s UTC day) |
+| `contributors.csv` | `date,total` | Cumulative distinct-contributor count, where a contributor counts from the UTC date of the start of their first commit week onward |
+| `repo.csv` | `date,subscribers,open_issues,downloads_total` | The repo object's counters as read on that date, plus the sum of every release asset's `download_count` |
+
+`repo.csv.downloads_total` is a `number | null` in memory (`RepoPoint` in `types.ts`) and is written as a **blank CSV field**, never `0`, whenever the optional `/releases` fetch fails that run (see §5). `subscribers` and `open_issues` are never blank — they come from the required `/repos/{slug}` fetch, which has already succeeded by the time `repo.csv` is written.
+
+### 3.2 Aggregate-window series (NDJSON, one JSON object per line)
+
+| File | Fields | One row means |
+|---|---|---|
+| `traffic/referrers.ndjson` | `snapshot_date, dimension, title, count, uniques` | In the trailing 14 days ending on `snapshot_date`, referrer host `dimension` sent `count` views (`uniques` unique visitors) |
+| `traffic/paths.ndjson` | `snapshot_date, dimension, title, count, uniques` | In the trailing 14 days ending on `snapshot_date`, path `dimension` (with page `title`) received `count` views |
+
+`/traffic/popular/referrers` and `/traffic/popular/paths` each return a single **trailing-14-day aggregate, top 10 only** — there is no per-day breakdown and none is obtainable by any means. Each row is that aggregate tagged with the day it was fetched. `dimension` is the referrer host on `referrers.ndjson` and the page path on `paths.ndjson`; `title` is always `''` on `referrers.ndjson` (the API doesn't return a referrer title) and the page title on `paths.ndjson`.
+
+`upsertDimensional` in `series.ts` keys on `(snapshot_date, dimension)` and rewrites the whole file every run — there is no append mode for this format. **A dimension absent from a given `snapshot_date`'s rows means "outside the top 10 that day," never zero.** If referrer X drops out of the top 10, its row for that date simply doesn't exist; nothing writes a `count: 0` row for it.
+
+### 3.3 Collector state (`meta.json`)
+
+```json
+{
+  "last_run": "2026-08-25T03:00:41Z",
+  "last_success": "2026-08-25T03:00:41Z",
+  "error": null,
+  "series_last_date": { "traffic/views.csv": "2026-08-24", "stars.csv": "2026-08-25" }
+}
+```
+
+`series_last_date` keys are exact file paths (only the `.csv` files collected this run are recorded; NDJSON files are not). There are **two independent writers** of this file, and reading it correctly means knowing both:
+
+1. `collect()` (`collect.ts`) writes it last, once every other file for the run has landed — see §5's atomicity guarantee. On a required-fetch failure, `collect()` throws before this write ever happens, so this internal write only ever records success.
+2. The workflow's own **"Record run outcome"** step (`metrics.yml`, `if: always()`) runs after the commit-and-push step regardless of whether `collect` succeeded. It reads whatever `meta.json` is currently on the branch, refreshes `last_run` to its own timestamp, and — if the job's overall status was not `success` — sets `error` to `` `run failed: ${job.status}` `` (leaving `last_success` and `series_last_date` untouched, since those describe the last run that actually completed). If the job did succeed, it sets `last_success` again (to a slightly later timestamp than `collect()`'s own write) and clears `error`. This step commits and pushes `meta.json` **on its own**, as a second commit, separate from the data commit — with a failure to push swallowed to a `::warning::` annotation rather than failing the job, so a metadata-push hiccup can never mask a successful collection.
+
+The practical upshot: a normal successful day produces **two** commits on `metrics-data` (the data snapshot, then the run-outcome record), and `error` is the field to check for "did last night's run actually work" — `last_run` alone updates even on failure.
+
+---
+
+## 4. Write semantics
+
+**Fetched values win. Three guards make that safe.**
+
+### 4.1 Atomicity
+
+`collect()` fetches every **required** series (`views`, `clones`, `referrers`, `paths`, the repo object) via a single `Promise.all` before writing anything. If any of those rejects, the function throws before a single `store.write*` call happens — the data directory and `meta.json` are left completely untouched, and the next run treats the previous data as still authoritative. This is asserted directly by a test (`collect.test.ts`, "aborts the entire write when a required traffic fetch fails"), which checks that `traffic/views.csv`, `stars.csv`, and `meta.json` are all still empty/absent after a failed clones fetch.
+
+Once the write phase starts, every `store.write*` call in it is synchronous with no `await` between them, so there is no point where a second run (or anything else) could interleave. `meta.json` is written last of all, so its presence is a completion marker.
+
+**The honest limit on this guarantee:** it is atomicity within one process's happy path, not a transaction. A synchronous run of `writeFileSync`/`renameSync` calls still issues one OS syscall at a time — a hard kill (`SIGKILL`, OOM) or an OS-level error (`ENOSPC`, a permissions change) between two of those calls can leave some files updated to today and others holding yesterday's content, with `meta.json` never reaching its update in that case (so it still points at the last run that *did* complete). **This torn-cross-file state does not self-heal for `stars.csv`, `forks.csv`, or `repo.csv`.** Those three files only ever write **today's** row each run — there is no retry logic that revisits a skipped or partially-written prior date for them. `traffic/*` is different: because the API returns a rolling 14-day window, a gap in the traffic files left by a torn run is silently repaired the next time collection succeeds (see §4.4). A torn `stars.csv`/`forks.csv`/`repo.csv` is not repaired by anything except a future day's row simply continuing forward from wherever it was left.
+
+### 4.2 Backfill is write-if-absent
+
+`backfill()` (`backfill.ts`) merges every series it touches with `upsertByDate(existing, incoming, 'if-absent')` — an existing row for a date is never replaced by a reconstructed one. This is a structural requirement, not a style choice: the daily collector writes `stars.csv`/`forks.csv` from the repo object's **live counters** (`stargazers_count`, `forks_count`), which correctly reflect someone who starred and later unstarred. Backfill reconstructs the same series from `/stargazers`' `starred_at` field, which lists only **current** stargazers — anyone who starred and later unstarred is permanently invisible to it. The two methods measure the same date differently by construction, and the collector's measured value is the one that was actually true on that date. Running backfill against an archive with months of collector-written history therefore changes nothing for any date the collector already covered; it only fills dates neither process has ever recorded. This is the one property `backfill.test.ts` exists to pin down.
+
+`backfill()` is permitted to touch exactly `stars.csv`, `forks.csv`, and `releases.csv` (the `WRITABLE` constant in `backfill.ts`). It never opens `traffic/*` (no historical traffic API exists at all) or `repo.csv` (`subscribers` has no historical API either — a stray rewrite there would be a permanent, unrecoverable loss) or `contributors.csv` (the `/stats/contributors` weekly buckets the daily collector reads already cover all of history whenever that endpoint answers, so there is no gap for a one-shot backfill to fill).
+
+### 4.3 No zero-filling
+
+Nothing in this package ever writes `0` to stand in for "not measured." `repo.csv.downloads_total` is left as a blank CSV field (`null` in memory) when the optional `/releases` fetch fails, specifically so a missing measurement can never be mistaken for a real zero download count. A version that instead carried the previous run's value forward under today's date was considered and rejected during review: a flat line in that case would be indistinguishable from a genuinely quiet day, whereas a hole in the data is visible and honestly represents "we don't know." The same principle governs the dimensional files (§3.2, a dropped-out referrer is an absent row, never a zero) and `getStats()` (§6, a persistent 202 is `null`, never a zero).
+
+### 4.4 Self-healing (traffic only)
+
+The traffic window is 14 buckets wide, so any gap of **≤13 full days** without a successful run is silently repaired the next time `collect()` runs — the next successful fetch's window simply covers the missed dates again, and `upsertByDate`'s overwrite mode fills them in. A missed cron, a transient API outage, or a rejected push therefore costs nothing as long as the next run succeeds within two weeks. As established in §4.1, this self-healing property belongs to `traffic/*` specifically and does not extend to `stars.csv`, `forks.csv`, or `repo.csv`.
+
+---
+
+## 5. The 202 problem
+
+`GET /repos/{slug}/stats/contributors` computes its answer asynchronously. While GitHub is still building the statistic, the endpoint answers `202` with an effectively empty body rather than `200`. `github.ts`'s `getStats()` is the only client method built to handle this:
+
+- On a `202`, it retries with a backoff (`2000 * (attempt + 1)` ms between attempts, up to `statsAttempts` times — 5 by default) and never parses the placeholder body.
+- If every attempt still comes back `202`, `getStats()` returns `null`. **`null` is the only way this method reports "not available yet"** — the success branch only ever produces a value by parsing a genuine `200` body, so there is no path from an in-progress computation to a zero-shaped result.
+- In `collect()`, a `null` from `getStats()` causes `contributors.csv` to be skipped for that run, leaving whatever value the file already holds untouched. It is treated as optional for atomicity purposes (§4.1): a stats timeout must never abort the traffic write, since traffic is the irreplaceable series.
+
+GitHub's `/stats/*` cache is keyed by the default branch's current commit and is invalidated by every push to it — so on an actively-developed repo, hitting a `202` is routine, not an edge case, and every collection run should be expected to occasionally skip `contributors.csv` for a day.
+
+---
+
+## 6. Field-name traps
+
+These are documented because reading the obviously-named GitHub field would silently produce wrong data, and nothing in the type system catches it:
+
+- **`watchers_count` is a duplicate of `stargazers_count`, not the watcher count.** `repo.csv`'s `subscribers` column is populated from `subscribers_count`, the actually-correct field — the collector never reads `watchers_count` at all (`RepoResponse` in `collect.ts` declares only `stargazers_count`, `forks_count`, `subscribers_count`, and `open_issues_count`).
+- **The repo object's `open_issues_count` includes open PRs.** `repo.csv.open_issues` carries that combined meaning — GitHub does not separate the two in this field.
+- **`/stargazers` requires the custom media type to return `starred_at` at all.** `backfill.ts` requests it with `Accept: application/vnd.github.star+json`; without that header the endpoint returns bare user objects with no timestamp, and `toDate()` would throw on every entry. Listing stargazers at all is gated to repo admins/collaborators as of a GitHub platform change — `METRICS_TOKEN` satisfies this because it belongs to a repo admin, not because star lists are openly public.
+
+---
+
+## 7. Token setup (not yet done — read this before the workflow first fails)
+
+**Neither the `METRICS_TOKEN` secret nor the `metrics-data` branch ruleset exists yet.** Both are one-time, manual GitHub settings that no code in this repository can create. Until a maintainer does this, `metrics.yml` and `backfill.yml` will fail on every run.
+
+1. **Create a fine-grained personal access token**, scoped to this repository only, with:
+   - **Administration: read** — the traffic endpoints (`/traffic/views`, `/traffic/clones`, `/traffic/popular/referrers`, `/traffic/popular/paths`) require this permission specifically, and it is the exact documented requirement for all of them.
+   - **Contents: read** — needed to read the repo object and its release/star/fork data.
+2. **Store it as the `METRICS_TOKEN` repository secret** (Settings → Secrets and variables → Actions → New repository secret).
+3. **Create a branch protection ruleset on `metrics-data`** blocking **deletion** and **force-push (non-fast-forward)**, with **no bypass actors**, mirroring the existing `cla-signatures` ruleset (`gh ruleset list` on this repo shows `Protect CLA signature store` as the precedent to copy). Do **not** require pull requests or status checks — both workflows commit directly to the branch, and requiring a PR would break every run. This branch is the only place in the repository holding genuinely irreplaceable data (the traffic history), so it is the one branch that most needs this protection and currently has none.
+
+**Why `GITHUB_TOKEN` cannot substitute for `METRICS_TOKEN`:** there is no `administration` key in the Actions `permissions:` vocabulary at all — not "read" nor any other level — so no configuration of the built-in token can reach the traffic endpoints. The split is forced by GitHub's own permission model, not a security preference that could be relaxed.
+
+`cli-support.ts`'s `assertHeaderSafeToken()` validates the token for control characters (a stray newline, tab, or other C0/DEL byte) **before** it is ever used to build an HTTP header. This exists because a malformed token reaching Node's `fetch`/`Headers` implementation throws a `TypeError` whose message embeds the entire broken header value — including the secret — verbatim, and this CLI's top-level catch prints whatever any thrown error says to the (public) Actions log. If `metrics.yml` fails immediately with a message about a "control character," the token was pasted with a trailing newline or similar and needs to be re-entered as the secret's raw value.
+
+---
+
+## 8. The 60-day schedule hazard
+
+GitHub disables a repository's scheduled workflows after 60 days with no activity on the repository. This collector's own commits do not reliably reset that timer: they land on the orphan `metrics-data` branch (not the default branch) and are made with `GITHUB_TOKEN`, and whether a non-default-branch push counts as "activity" for this purpose is undocumented. Every commonly-suggested keepalive trick assumes commits to the default branch, which this workflow deliberately never makes.
+
+The mitigation is active rather than passive: the final step of `metrics.yml`'s `collect` job runs
+
+```yaml
+gh workflow enable metrics.yml --repo "${{ github.repository }}" || true
+```
+
+unconditionally (`if: always()`), on every run, using `GITHUB_TOKEN` with `actions: write` permission. This is idempotent — re-enabling an already-enabled workflow is a no-op — and the `|| true` means a permissions problem with this specific call can never fail the whole run over what is meant to be a self-heal step (though it does mean a failure here is silent unless someone is watching the step log).
+
+There is currently **no dashboard** to carry a staleness warning as a backstop (see §11) — the only backstop today is checking `meta.json`'s `last_success` field by hand, or scripting a check against it.
+
+---
+
+## 9. Operations
+
+### Running collection locally
+
+```bash
+METRICS_TOKEN=<fine-grained PAT> \
+GITHUB_REPOSITORY=TheZwiss/backspace \
+METRICS_DATA_DIR=/path/to/a/checkout/of/metrics-data \
+node scripts/metrics/src/cli-collect.ts
+```
+
+All three environment variables are required (`requiredEnv` in `cli-support.ts` throws immediately if any is missing, empty, or whitespace-only). `METRICS_DATA_DIR` must point at a directory containing (or where you want created) the series files described in §3 — normally a local checkout of the `metrics-data` branch. Requires Node ≥22.18 for unflagged type stripping (the package's `engines` field); the workflow itself pins Node 24. This has not been exercised against the live API as part of writing this document — it is a direct read of what `cli-collect.ts` requires, not a verified live run.
+
+### Running a backfill
+
+Either dispatch `backfill.yml` from the Actions tab (or `gh workflow run backfill.yml`), or run it locally the same way as collection:
+
+```bash
+METRICS_TOKEN=<fine-grained PAT> \
+GITHUB_REPOSITORY=TheZwiss/backspace \
+METRICS_DATA_DIR=/path/to/a/checkout/of/metrics-data \
+node scripts/metrics/src/cli-backfill.ts
+```
+
+Safe to run at any time, including repeatedly — every write is if-absent (§4.2), so a rerun against an already-seeded archive changes nothing. The CLI's summary line is deliberately phrased "backfill target files (write-if-absent, listed whether or not they changed this run)" rather than "wrote," because `backfill()`'s `written` result is the fixed, exhaustive list of files it is *permitted* to touch, not the set that actually gained a row this run — see `formatBackfillSummary` in `cli-support.ts`.
+
+### Recovering from a gap
+
+A gap of **13 days or fewer** in traffic data self-heals automatically the next time `collect()` succeeds — no action needed (§4.4). A gap of **14 days or more** in traffic is permanent; there is nothing to backfill it with. A gap in `stars.csv`/`forks.csv`/`releases.csv` (however it happened) can be recovered by dispatching `backfill.yml`, since those are the exact three files it reconstructs. A gap in `repo.csv` (`subscribers`) or `contributors.csv` cannot be backfilled at all — the next successful collection run simply resumes from wherever it left off, with no way to fill the missed dates retroactively.
+
+### What a rejected push means
+
+`metrics.yml`'s commit-and-push step retries a rejected (non-fast-forward) push up to three times, running `git pull --rebase origin metrics-data` between attempts, and fails the job loudly if all three are rejected. `backfill.yml`'s commit-and-push step does **not** have this retry loop — it pushes once and fails on rejection. This asymmetry is intentional given the shared `concurrency: { group: metrics-data, cancel-in-progress: false }` on both workflows: that group already serializes the two workflows so they never run at the same time, which is the scenario the retry loop exists to survive. A push rejection on `metrics.yml` in practice means something *external* to these two workflows wrote to `metrics-data` (a manual commit, a ruleset bypass, direct API use) between checkout and push; a rejection on `backfill.yml` means the same, and the fix in both cases is to re-run the workflow.
+
+### Reading `meta.json`
+
+See §3.3 for the two-writer mechanics. In short: fetch `meta.json` from the tip of `metrics-data` and check `error` — `null` means the last run recorded there completed with `last_success` set to that run's timestamp; any other value is the string `run failed: <job status>` from the most recent run that did not succeed, and `last_success`/`series_last_date` still reflect the last run that *did*. `series_last_date` gives the newest date present in each `.csv` file at the end of that successful run, which is a faster way to spot a stalled series than diffing the files themselves.
+
+---
+
+## 10. Testing
+
+`scripts/metrics`'s `test` script is `tsc --noEmit && vitest run` — it runs through the existing root `pnpm -r test` step with no `ci.yml` change required, and covers both types and behavior in one script. All tests are fixture-driven and touch no network; filesystem tests use a per-test `mkdtempSync` directory, cleaned up in `afterEach`. As of this writing there are **141 tests across 7 files**, all passing:
+
+```
+src/no-runtime-deps.test.ts   6
+src/series.test.ts           41
+src/cli-support.test.ts      28
+src/github.test.ts           16
+src/store.test.ts            23
+src/backfill.test.ts          9
+src/collect.test.ts          18
+```
+
+`no-runtime-deps.test.ts` is worth calling out specifically: it regex-scans every non-test source file in `src/` and fails if any import specifier is not a `node:` builtin or a relative path, if any relative import omits its `.ts` extension, or if any import of `types.ts` omits the `import type` keyword. This is the enforcement mechanism behind two of Node's type-stripping constraints (§12) — without `import type`, Node treats a type-only import as a value import and throws `SyntaxError` **at runtime**, which for this package means a red 03:00 cron rather than a red `tsc --noEmit`. `erasableSyntaxOnly` and `verbatimModuleSyntax` in `tsconfig.json` catch the same class of mistake at typecheck time for constructs `no-runtime-deps.test.ts` doesn't scan for (enums, namespaces with runtime code, parameter properties, decorators).
+
+---
+
+## 11. Adding a repo
+
+The repository slug is never hardcoded: `collect()` and `backfill()` both take `slug` as a parameter, and both CLI wrappers derive it from the `GITHUB_REPOSITORY` environment variable, which GitHub Actions populates from `github.repository`. Nothing in the package assumes `TheZwiss/backspace` specifically.
+
+That said, adding a second repo is not a matter of pointing a second workflow at it. Every file in §3 lives at a **flat path** at the root of `metrics-data` (`stars.csv`, not `<repo>/stars.csv`) — the schema has no per-repo namespacing at all. A second repo needs a file-layout decision made first (a subdirectory per repo slug is the obvious candidate, but it hasn't been decided or built), plus its own `METRICS_TOKEN`-equivalent PAT scoped to that repo, before any workflow could safely write its data without colliding with the first repo's files.
+
+---
+
+## 12. Why TypeScript with no build step
+
+The collector has **zero runtime dependencies** — only `fetch` and `node:` builtins — and is executed directly by Node via native TypeScript type stripping, with no `tsc` build step in the run path (`tsc --noEmit` runs only for typechecking, in `test`/`typecheck`). `scripts/metrics/package.json` declares `"engines": { "node": ">=22.18" }`; the workflow's `setup-node` step pins `node-version: 24`.
+
+Two constraints this creates are compiler-enforced (`tsconfig.json`'s `erasableSyntaxOnly` + `verbatimModuleSyntax` + `rewriteRelativeImportExtensions`) and test-enforced (`no-runtime-deps.test.ts`, §10) rather than left to discipline:
+
+- **`import type` is mandatory** for any type-only import. Omitting it makes Node treat the import as a value import, which throws `SyntaxError` at runtime — the single most likely way this system could break, since a missing `import type` still passes a typecheck that isn't checking for it.
+- **Relative import specifiers must carry the `.ts` extension** (`import './series.ts'`, never `'./series'`).
+
+Unsupported by type stripping and therefore avoided throughout the package: enums, namespaces with runtime code, parameter properties, import aliases, decorators.
+
+---
+
+## 13. Volume
+
+Not independently re-measured for this document; carried forward from the design spec's measurement against the real API responses at the time it was written (`docs/superpowers/specs/2026-08-25-repo-metrics-design.md`, §5.5): roughly 815 KB/year across all files combined, dominated by the two NDJSON files. At that rate the archive stays well under a size where the plain-text-over-SQLite tradeoff (§2) needs revisiting.

--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -137,7 +137,7 @@ There are **two writers** of this file, one per outcome, never both in the same 
 1. **On success**, `collect()` (`collect.ts`) is the only writer. It writes `meta.json` last of all, once every other file for the run has landed — see §5's atomicity guarantee — and it is the only place `series_last_date` is ever advanced to a fresh date. Building that map is itself two steps: `collect()` first reads the *previous* `meta.json` via `store.readMeta()` (synchronously, as the write phase's first action — a corrupt existing `meta.json` therefore throws before any file changes this run, the same all-or-nothing guarantee a required-fetch failure already has) and seeds `series_last_date` from it, then overwrites only the keys for series actually written this run. A first-ever run (`readMeta()` returns `null`) seeds from `{}`. On a required-fetch failure, `collect()` throws before any of this, so this writer only ever records a genuine success.
 2. **On failure**, `recordFailure()` (`cli-support.ts`, invoked by `cli-record-failure.ts` from `metrics.yml`'s "Record failure" step, `if: failure()`) is the only writer. It reads whatever `meta.json` currently exists (or `null` — legitimate on a run that fails before `collect()` has ever written one), refreshes `last_run` to its own timestamp, and sets `error` to a description of what failed (currently `` `run failed: ${job.status}` ``, passed in via the `METRICS_RUN_OUTCOME` environment variable — never interpolated into the workflow's `run:` string). It leaves **`last_success` and `series_last_date` completely untouched** — not merged, not partially updated, byte-for-byte whatever `collect()` (or a previous failure record) last wrote — because `last_success` is this archive's "last known good" signal and a failure must never move it, and a failed run measured nothing, so it must never edit `series_last_date` either. A "Commit and push failure record" step, mirroring the success path's commit-and-push, then commits and pushes just `meta.json`, with a failed push swallowed to a `::warning::` annotation rather than failing the (already-failed) job.
 
-The practical upshot: a normal successful day produces **exactly one** commit on `metrics-data` (the data snapshot, `meta.json` included via that step's `git add -A`) — there is no second, redundant metadata commit on success anymore. A failed day produces at most one commit too (the failure record; there is no data commit to accompany it unless `collect()` itself succeeded but a later step, e.g. the push, failed — see §9). `error` is the field to check for "did last night's run actually work" — `last_run` alone updates even on failure.
+The practical upshot: a normal successful day produces **exactly one** commit on `metrics-data` (the data snapshot, `meta.json` included via that step's `git add -A`) — there is no second, redundant metadata commit on success anymore. A failed day produces at most one commit too (the failure record; there is no data commit to accompany it unless `collect()` itself succeeded but a later step, e.g. the push, failed — see §9). Check `error` **and** `last_run` together for "did last night's run actually work": `error` distinguishes a failed run from a successful one, but only a run that reached one of the two writers sets it at all. A cancelled or timed-out job sets neither, so a stale `last_run` is the signal that catches those. See §9.
 
 ---
 
@@ -271,6 +271,21 @@ This is not a defect in `backfill()` itself: reconstructing pre-collection histo
 ### Reading `meta.json`
 
 See §3.3 for the two-writer (one per outcome) mechanics. In short: fetch `meta.json` from the tip of `metrics-data` and check `error` — `null` means `collect()` itself last wrote this file, with `last_success` set to that run's timestamp; any other value is the string `run failed: <job status>` recorded by the failure path (`recordFailure()`/`cli-record-failure.ts`) for the most recent run that did not succeed, and `last_success`/`series_last_date` in that case still reflect whatever the last *successful* `collect()` run left them at — the failure path never touches either. `series_last_date` gives the newest date present in each `.csv` file as of the last run that actually wrote it (a written series advances to today; a skipped one keeps its previous entry — see §3.3), which is a faster way to spot a stalled series than diffing the files themselves.
+
+**`error` alone is not sufficient — always read it together with `last_run`.** The failure path runs
+under `if: failure()`, which does not cover a job that was **cancelled or hit its timeout**. Those runs
+leave `meta.json` completely untouched: `error` stays whatever it was, so a run that never happened can
+read as `null` — "last night succeeded" — when in fact nothing ran at all. The reliable check is
+`last_run` against the current date. If `last_run` is not from the most recent scheduled window, that
+run did not complete, regardless of what `error` says.
+
+A second case where `meta.json` cannot tell you what went wrong: if `meta.json` itself is corrupt, both
+writers refuse it. `collect()` reads it through the same validator before writing anything, and
+`recordFailure()` reads it the same way — so neither can record "meta.json is corrupt" *inside*
+`meta.json` without performing exactly the unvalidated rewrite this design exists to prevent. The
+symptom on the data branch is only that `last_run` stops advancing; the cause is visible in the Actions
+tab, where both steps go red every day. This is a deliberate consequence of failing loudly rather than
+fabricating a replacement, not an oversight.
 
 One case worth naming explicitly: `error` can be non-null while `last_success` is recent. That happens when `collect()` itself succeeds but a later step in the same job fails (e.g. the data commit/push, after all three retry attempts) — the failure path still runs and records `error`, but `last_success`/`series_last_date` correctly show that the measurement itself landed; only getting it committed and pushed did not.
 

--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -3,7 +3,7 @@
 Source files:
 - `scripts/metrics/src/types.ts` -- Shared row shapes (`TrafficPoint`, `CountPoint`, `ReleaseRow`, `RepoPoint`, `DimensionRow`)
 - `scripts/metrics/src/github.ts` -- GitHub API client: auth, pagination (`Link: rel="next"`), `/stats/*` 202 retry
-- `scripts/metrics/src/series.ts` -- CSV/NDJSON parse + format, date-keyed upsert, dimensional upsert
+- `scripts/metrics/src/series.ts` -- CSV/NDJSON parse + format, date-keyed upsert, explicit-key upsert (releases), dimensional upsert
 - `scripts/metrics/src/store.ts` -- Filesystem layer: atomic per-file writes (temp + rename), `meta.json` read/write, path containment
 - `scripts/metrics/src/collect.ts` -- Daily snapshot entrypoint (`collect()`)
 - `scripts/metrics/src/backfill.ts` -- One-shot historical reconstruction entrypoint (`backfill()`)
@@ -84,21 +84,25 @@ Both `metrics.yml` and `backfill.yml`:
 
 ## 3. Data schemas
 
-All files live at the root of the `metrics-data` branch. CSVs are sorted ascending on their first (date) column on every write; NDJSON files are sorted `(snapshot_date asc, count desc, dimension asc)`. Both orderings are fixed by `series.ts` (`formatCsv`, `compareDimensionRows`) so that re-running the collector against unchanged upstream data produces a byte-identical file — the property that keeps daily commits to one line of diff.
+All files live at the root of the `metrics-data` branch. CSVs are sorted ascending on their first (date) column on every write; NDJSON files are sorted `(snapshot_date asc, count desc, dimension asc)`. Both orderings are fixed by `series.ts` (`formatCsv`, `compareDimensionRows`) so that re-running the collector against unchanged upstream data produces a byte-identical file — the property that keeps daily commits to one line of diff. `releases.csv` additionally fixes a tie-break within a shared date, `tag` ascending (`compareReleaseRows`, applied by the `upsertByKey` merge described in §3.1's caveat below), since it is the one CSV where more than one row can share a date.
 
-### 3.1 Date-keyed series (CSV, header row, one row per UTC date)
+### 3.1 CSV series
 
 | File | Columns | One row means |
 |---|---|---|
 | `traffic/views.csv` | `date,count,uniques` | Total views and unique visitors on that UTC date |
 | `traffic/clones.csv` | `date,count,uniques` | Total clones and unique cloners on that UTC date |
-| `stars.csv` | `date,total` | The repo's live `stargazers_count` as read on that date (a point-in-time snapshot, not a delta) |
-| `forks.csv` | `date,total` | The repo's live `forks_count` as read on that date |
-| `releases.csv` | `date,tag,name` | A release published on that UTC date (`date` = `published_at`'s UTC day) |
-| `contributors.csv` | `date,total` | Cumulative distinct-contributor count, where a contributor counts from the UTC date of the start of their first commit week onward |
+| `stars.csv` | `date,total` | The repo's live `stargazers_count` as read on that date (a point-in-time snapshot, not a delta) — see the caveat below the table |
+| `forks.csv` | `date,total` | The repo's live `forks_count` as read on that date — see the caveat below the table |
+| `releases.csv` | `date,tag,name` | A release published on that UTC date (`date` = `published_at`'s UTC day) — see the caveat below the table |
+| `contributors.csv` | `date,total` | Cumulative distinct-contributor count, where a contributor counts from the UTC date of the start of their first commit week onward. Capped: see the note below the table |
 | `repo.csv` | `date,subscribers,open_issues,downloads_total` | The repo object's counters as read on that date, plus the sum of every release asset's `download_count` |
 
 `repo.csv.downloads_total` is a `number | null` in memory (`RepoPoint` in `types.ts`) and is written as a **blank CSV field**, never `0`, whenever the optional `/releases` fetch fails that run (see §5). `subscribers` and `open_issues` are never blank — they come from the required `/repos/{slug}` fetch, which has already succeeded by the time `repo.csv` is written.
+
+**`stars.csv`/`forks.csv` are one row per UTC date only for half of what writes them.** The daily collector (`collect.ts`) does write exactly one row per date — every run appends today's row from the repo object's live counter, so a run either produces that day's row or (on a required-fetch failure) writes nothing at all. `backfill()`, reconstructing the same files from `starred_at`/`created_at` timestamps, is **sparse by construction**: `cumulativeByDay` (`backfill.ts`) only emits a row for a UTC date on which at least one star/fork event actually happened, so a quiet day between two event days gets no row from backfill at all — the reader is expected to carry the previous row's `total` forward as "unchanged" rather than read absence as zero or as a gap. Nothing recorded on disk distinguishes which of the two writers produced a given row — both write through the same `upsertByDate`/CSV format, and a row looks identical regardless of its origin — so there is no way to tell, from the file alone, whether a given date's absence means "the collector never ran that far back" or "backfill correctly found no event that day."
+
+**`releases.csv` is keyed on `tag`, not `date`.** Unlike every other series in this table, more than one row can legitimately share a `date`: two releases published the same UTC day are two distinct rows, merged by `upsertByKey` (`series.ts`) keyed on `tag` and sorted `(date asc, tag asc)` for byte-stable output. Both `collect.ts` (`'overwrite'` mode — the day's live fetch is authoritative) and `backfill.ts` (`'if-absent'` mode — a reconstruction must never replace a value the collector already measured) merge through this same keyed function, so the two writers can no longer disagree about which same-day release survives.
 
 ### 3.2 Aggregate-window series (NDJSON, one JSON object per line)
 
@@ -145,7 +149,7 @@ Once the write phase starts, every `store.write*` call in it is synchronous with
 
 ### 4.2 Backfill is write-if-absent
 
-`backfill()` (`backfill.ts`) merges every series it touches with `upsertByDate(existing, incoming, 'if-absent')` — an existing row for a date is never replaced by a reconstructed one. This is a structural requirement, not a style choice: the daily collector writes `stars.csv`/`forks.csv` from the repo object's **live counters** (`stargazers_count`, `forks_count`), which correctly reflect someone who starred and later unstarred. Backfill reconstructs the same series from `/stargazers`' `starred_at` field, which lists only **current** stargazers — anyone who starred and later unstarred is permanently invisible to it. The two methods measure the same date differently by construction, and the collector's measured value is the one that was actually true on that date. Running backfill against an archive with months of collector-written history therefore changes nothing for any date the collector already covered; it only fills dates neither process has ever recorded. This is the one property `backfill.test.ts` exists to pin down.
+`backfill()` (`backfill.ts`) merges every series it touches in `'if-absent'` mode — an existing row is never replaced by a reconstructed one. `stars.csv`/`forks.csv` go through `upsertByDate(existing, incoming, 'if-absent')`, keyed on `date`; `releases.csv` goes through `upsertByKey(existing, incoming, (row) => row.tag, 'if-absent', compareReleaseRows)`, keyed on `tag` instead (see §3.1's caveat on why releases needs a different key). Both share the same `'if-absent'` guarantee regardless of key. This is a structural requirement, not a style choice: the daily collector writes `stars.csv`/`forks.csv` from the repo object's **live counters** (`stargazers_count`, `forks_count`), which correctly reflect someone who starred and later unstarred. Backfill reconstructs the same series from `/stargazers`' `starred_at` field, which lists only **current** stargazers — anyone who starred and later unstarred is permanently invisible to it. The two methods measure the same date differently by construction, and the collector's measured value is the one that was actually true on that date. Running backfill against an archive with months of collector-written history therefore changes nothing for any date (or, for `releases.csv`, any tag) the collector already covered; it only fills gaps neither process has ever recorded. This is the one property `backfill.test.ts` exists to pin down.
 
 `backfill()` is permitted to touch exactly `stars.csv`, `forks.csv`, and `releases.csv` (the `WRITABLE` constant in `backfill.ts`). It never opens `traffic/*` (no historical traffic API exists at all) or `repo.csv` (`subscribers` has no historical API either — a stray rewrite there would be a permanent, unrecoverable loss) or `contributors.csv` (the `/stats/contributors` weekly buckets the daily collector reads already cover all of history whenever that endpoint answers, so there is no gap for a one-shot backfill to fill).
 
@@ -168,6 +172,8 @@ The traffic window is 14 buckets wide, so any gap of **≤13 full days** without
 - In `collect()`, a `null` from `getStats()` causes `contributors.csv` to be skipped for that run, leaving whatever value the file already holds untouched. It is treated as optional for atomicity purposes (§4.1): a stats timeout must never abort the traffic write, since traffic is the irreplaceable series.
 
 GitHub's `/stats/*` cache is keyed by the default branch's current commit and is invalidated by every push to it — so on an actively-developed repo, hitting a `202` is routine, not an edge case, and every collection run should be expected to occasionally skip `contributors.csv` for a day.
+
+**`/stats/contributors` returns at most 100 contributors.** This is undocumented behavior of the GitHub endpoint itself, not of anything in this package: once a repo has more than 100 total contributors, the 101st and beyond simply never appear in the response, and `contributors.csv`'s cumulative count silently stops increasing at 100 forever — indistinguishable on the chart from a genuine plateau in new-contributor growth. There is no workaround; the endpoint has no pagination for this list.
 
 ---
 
@@ -241,7 +247,16 @@ Safe to run at any time, including repeatedly — every write is if-absent (§4.
 
 ### Recovering from a gap
 
-A gap of **13 days or fewer** in traffic data self-heals automatically the next time `collect()` succeeds — no action needed (§4.4). A gap of **14 days or more** in traffic is permanent; there is nothing to backfill it with. A gap in `stars.csv`/`forks.csv`/`releases.csv` (however it happened) can be recovered by dispatching `backfill.yml`, since those are the exact three files it reconstructs. A gap in `repo.csv` (`subscribers`) or `contributors.csv` cannot be backfilled at all — the next successful collection run simply resumes from wherever it left off, with no way to fill the missed dates retroactively.
+A gap of **13 days or fewer** in traffic data self-heals automatically the next time `collect()` succeeds — no action needed (§4.4). A gap of **14 days or more** in traffic is permanent; there is nothing to backfill it with.
+
+A gap in `releases.csv` (however it happened) can be recovered by dispatching `backfill.yml`: `published_at` is a permanent, immutable timestamp on every release, so reconstructing from `/releases` produces the exact same rows the collector would have written, for any date range.
+
+**A collector-era gap in `stars.csv`/`forks.csv` is *not* recoverable, and dispatching `backfill.yml` will not fill it correctly — despite `backfill.yml` being permitted to write both files.** Two separate problems make this true, and both are inherent to the reconstruction, not implementation bugs to be fixed later:
+
+- `cumulativeByDay` (`backfill.ts`) writes a row only on a UTC date on which a star/fork event actually happened. A gap that spans a quiet day — no stars, no forks — gets **no row at all** from backfill, so the gap is not filled, merely left exactly as absent as it was before the dispatch.
+- Where backfill *does* write a row, the value comes from `/stargazers`/`/forks`, which list only **currently** starred/forked state. Anyone who starred and later unstarred (or forked and later deleted the fork) is invisible to it. The collector's original row — lost in the gap — measured the live counter as it stood on that date, which can only be greater than or equal to what a reconstruction sees. A backfilled row for a gap date is therefore, at best, an undercount, and at worst a value that makes an otherwise-monotonic series dip on a chart — reading as genuinely measured history rather than as the reconstruction gap it actually is.
+
+This is not a defect in `backfill()` itself: reconstructing pre-collection history (seeding the archive before `collect()` ever ran) is exactly what it is for, and it does that correctly. The hazard is specifically in treating it as a generic gap-repair tool for `stars.csv`/`forks.csv` after the fact — it is not one, for either of the two reasons above. A gap in `repo.csv` (`subscribers`) or `contributors.csv` cannot be backfilled at all — the next successful collection run simply resumes from wherever it left off, with no way to fill the missed dates retroactively.
 
 ### What a rejected push means
 

--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -7,10 +7,11 @@ Source files:
 - `scripts/metrics/src/store.ts` -- Filesystem layer: atomic per-file writes (temp + rename), `meta.json` read/write, path containment
 - `scripts/metrics/src/collect.ts` -- Daily snapshot entrypoint (`collect()`)
 - `scripts/metrics/src/backfill.ts` -- One-shot historical reconstruction entrypoint (`backfill()`)
-- `scripts/metrics/src/cli-collect.ts` -- `process.env`/clock-reading wrapper invoked by `metrics.yml`
+- `scripts/metrics/src/cli-collect.ts` -- `process.env`/clock-reading wrapper invoked by `metrics.yml`'s "Collect" step
 - `scripts/metrics/src/cli-backfill.ts` -- `process.env`-reading wrapper invoked by `backfill.yml`
-- `scripts/metrics/src/cli-support.ts` -- Env validation, token safety check, timestamp derivation, log formatting
-- `.github/workflows/metrics.yml` -- Daily cron: collect, commit, push, `gh workflow enable`
+- `scripts/metrics/src/cli-record-failure.ts` -- `process.env`/clock-reading wrapper invoked by `metrics.yml`'s "Record failure" step (`if: failure()` only)
+- `scripts/metrics/src/cli-support.ts` -- Env validation, token safety check, timestamp derivation, failure recording, log formatting
+- `.github/workflows/metrics.yml` -- Daily cron: collect, commit, push; on failure, record and push the failure to `meta.json`; `gh workflow enable`
 - `.github/workflows/backfill.yml` -- `workflow_dispatch`-only backfill runner
 
 **Out of scope:** the public dashboard. Section 11 below explains why — it is a separate, not-yet-built workstream. This document covers only the collection pipeline: the `scripts/metrics` package, the two workflows, and the orphan `metrics-data` branch they write to.
@@ -52,8 +53,9 @@ scripts/metrics/                     @backspace/metrics (pnpm workspace package)
     store.ts           filesystem layer, meta.json
     collect.ts         daily snapshot
     backfill.ts         historical reconstruction
-    cli-collect.ts      env/clock wrapper for metrics.yml
+    cli-collect.ts      env/clock wrapper for metrics.yml's "Collect" step
     cli-backfill.ts     env wrapper for backfill.yml
+    cli-record-failure.ts  env/clock wrapper for metrics.yml's "Record failure" step
     cli-support.ts      shared CLI helpers
     *.test.ts           vitest, no network, no filesystem outside a per-test tmpdir
 
@@ -79,6 +81,8 @@ Both `metrics.yml` and `backfill.yml`:
 - Run `step-security/harden-runner` with `egress-policy: audit`, and pin every `uses:` to a full commit SHA with a trailing `# vX.Y.Z` comment, per this repo's standing CI convention (see `docs/systems/security-scanning.md`).
 
 `metrics.yml` runs `collect` (`node scripts/metrics/src/cli-collect.ts`); `backfill.yml` runs `backfill` (`node scripts/metrics/src/cli-backfill.ts`). Both jobs declare only `contents: write` (plus `actions: write` on `metrics.yml`, for the schedule-keepalive step in §9) — there is no separate deploy job in this codebase today, because there is no dashboard to deploy (§11).
+
+`metrics.yml` additionally runs a failure path that `backfill.yml` does not have: a "Record failure" step (`node scripts/metrics/src/cli-record-failure.ts`, `if: failure()`) followed by a "Commit and push failure record" step, both gated to run only when something earlier in the job failed. See §3.3 for what this writes and why `backfill.yml` doesn't need the equivalent — a failed backfill dispatch is visible in the Actions tab for whoever ran it, with no unattended schedule depending on it the way the daily cron does.
 
 ---
 
@@ -126,12 +130,14 @@ All files live at the root of the `metrics-data` branch. CSVs are sorted ascendi
 }
 ```
 
-`series_last_date` keys are exact file paths (only the `.csv` files collected this run are recorded; NDJSON files are not). There are **two independent writers** of this file, and reading it correctly means knowing both:
+`series_last_date` keys are exact file paths (only the `.csv` files collected this run are recorded; NDJSON files are not). **A key is added the first time a series is ever written and, from then on, is never removed** — a run that skips a series (an optional fetch failed, or the series simply wasn't touched) leaves that key exactly as the last successful run left it, so the field goes *stale* (a date that stops advancing) rather than *disappearing*. A vanished key would be far easier to miss than a date that stopped moving, which is the whole reason this field exists (see §9).
 
-1. `collect()` (`collect.ts`) writes it last, once every other file for the run has landed — see §5's atomicity guarantee. On a required-fetch failure, `collect()` throws before this write ever happens, so this internal write only ever records success.
-2. The workflow's own **"Record run outcome"** step (`metrics.yml`, `if: always()`) runs after the commit-and-push step regardless of whether `collect` succeeded. It reads whatever `meta.json` is currently on the branch, refreshes `last_run` to its own timestamp, and — if the job's overall status was not `success` — sets `error` to `` `run failed: ${job.status}` `` (leaving `last_success` and `series_last_date` untouched, since those describe the last run that actually completed). If the job did succeed, it sets `last_success` again (to a slightly later timestamp than `collect()`'s own write) and clears `error`. This step commits and pushes `meta.json` **on its own**, as a second commit, separate from the data commit — with a failure to push swallowed to a `::warning::` annotation rather than failing the job, so a metadata-push hiccup can never mask a successful collection.
+There are **two writers** of this file, one per outcome, never both in the same run:
 
-The practical upshot: a normal successful day produces **two** commits on `metrics-data` (the data snapshot, then the run-outcome record), and `error` is the field to check for "did last night's run actually work" — `last_run` alone updates even on failure.
+1. **On success**, `collect()` (`collect.ts`) is the only writer. It writes `meta.json` last of all, once every other file for the run has landed — see §5's atomicity guarantee — and it is the only place `series_last_date` is ever advanced to a fresh date. Building that map is itself two steps: `collect()` first reads the *previous* `meta.json` via `store.readMeta()` (synchronously, as the write phase's first action — a corrupt existing `meta.json` therefore throws before any file changes this run, the same all-or-nothing guarantee a required-fetch failure already has) and seeds `series_last_date` from it, then overwrites only the keys for series actually written this run. A first-ever run (`readMeta()` returns `null`) seeds from `{}`. On a required-fetch failure, `collect()` throws before any of this, so this writer only ever records a genuine success.
+2. **On failure**, `recordFailure()` (`cli-support.ts`, invoked by `cli-record-failure.ts` from `metrics.yml`'s "Record failure" step, `if: failure()`) is the only writer. It reads whatever `meta.json` currently exists (or `null` — legitimate on a run that fails before `collect()` has ever written one), refreshes `last_run` to its own timestamp, and sets `error` to a description of what failed (currently `` `run failed: ${job.status}` ``, passed in via the `METRICS_RUN_OUTCOME` environment variable — never interpolated into the workflow's `run:` string). It leaves **`last_success` and `series_last_date` completely untouched** — not merged, not partially updated, byte-for-byte whatever `collect()` (or a previous failure record) last wrote — because `last_success` is this archive's "last known good" signal and a failure must never move it, and a failed run measured nothing, so it must never edit `series_last_date` either. A "Commit and push failure record" step, mirroring the success path's commit-and-push, then commits and pushes just `meta.json`, with a failed push swallowed to a `::warning::` annotation rather than failing the (already-failed) job.
+
+The practical upshot: a normal successful day produces **exactly one** commit on `metrics-data` (the data snapshot, `meta.json` included via that step's `git add -A`) — there is no second, redundant metadata commit on success anymore. A failed day produces at most one commit too (the failure record; there is no data commit to accompany it unless `collect()` itself succeeded but a later step, e.g. the push, failed — see §9). `error` is the field to check for "did last night's run actually work" — `last_run` alone updates even on failure.
 
 ---
 
@@ -143,7 +149,7 @@ The practical upshot: a normal successful day produces **two** commits on `metri
 
 `collect()` fetches every **required** series (`views`, `clones`, `referrers`, `paths`, the repo object) via a single `Promise.all` before writing anything. If any of those rejects, the function throws before a single `store.write*` call happens — the data directory and `meta.json` are left completely untouched, and the next run treats the previous data as still authoritative. This is asserted directly by a test (`collect.test.ts`, "aborts the entire write when a required traffic fetch fails"), which checks that `traffic/views.csv`, `stars.csv`, and `meta.json` are all still empty/absent after a failed clones fetch.
 
-Once the write phase starts, every `store.write*` call in it is synchronous with no `await` between them, so there is no point where a second run (or anything else) could interleave. `meta.json` is written last of all, so its presence is a completion marker.
+Once the write phase starts, its very first action is a synchronous read, not a write: `store.readMeta()`, which seeds `series_last_date` from the previous run (§3.3). Placed there — before the first `store.write*` call — rather than later alongside the read-back-after-write calls that finish assembling `meta.json`, a corrupt existing `meta.json` throws before any file changes this run, extending the same all-or-nothing guarantee above to this failure mode too. `readMeta()` is `readFileSync` + `JSON.parse`, both synchronous, so it introduces no `await`. Every `store.write*` call that follows is likewise synchronous with no `await` between any of them, so there is no point where a second run (or anything else) could interleave. `meta.json` is written last of all, so its presence is a completion marker.
 
 **The honest limit on this guarantee:** it is atomicity within one process's happy path, not a transaction. A synchronous run of `writeFileSync`/`renameSync` calls still issues one OS syscall at a time — a hard kill (`SIGKILL`, OOM) or an OS-level error (`ENOSPC`, a permissions change) between two of those calls can leave some files updated to today and others holding yesterday's content, with `meta.json` never reaching its update in that case (so it still points at the last run that *did* complete). **This torn-cross-file state does not self-heal for `stars.csv`, `forks.csv`, or `repo.csv`.** Those three files only ever write **today's** row each run — there is no retry logic that revisits a skipped or partially-written prior date for them. `traffic/*` is different: because the API returns a rolling 14-day window, a gap in the traffic files left by a torn run is silently repaired the next time collection succeeds (see §4.4). A torn `stars.csv`/`forks.csv`/`repo.csv` is not repaired by anything except a future day's row simply continuing forward from wherever it was left.
 
@@ -264,23 +270,27 @@ This is not a defect in `backfill()` itself: reconstructing pre-collection histo
 
 ### Reading `meta.json`
 
-See §3.3 for the two-writer mechanics. In short: fetch `meta.json` from the tip of `metrics-data` and check `error` — `null` means the last run recorded there completed with `last_success` set to that run's timestamp; any other value is the string `run failed: <job status>` from the most recent run that did not succeed, and `last_success`/`series_last_date` still reflect the last run that *did*. `series_last_date` gives the newest date present in each `.csv` file at the end of that successful run, which is a faster way to spot a stalled series than diffing the files themselves.
+See §3.3 for the two-writer (one per outcome) mechanics. In short: fetch `meta.json` from the tip of `metrics-data` and check `error` — `null` means `collect()` itself last wrote this file, with `last_success` set to that run's timestamp; any other value is the string `run failed: <job status>` recorded by the failure path (`recordFailure()`/`cli-record-failure.ts`) for the most recent run that did not succeed, and `last_success`/`series_last_date` in that case still reflect whatever the last *successful* `collect()` run left them at — the failure path never touches either. `series_last_date` gives the newest date present in each `.csv` file as of the last run that actually wrote it (a written series advances to today; a skipped one keeps its previous entry — see §3.3), which is a faster way to spot a stalled series than diffing the files themselves.
+
+One case worth naming explicitly: `error` can be non-null while `last_success` is recent. That happens when `collect()` itself succeeds but a later step in the same job fails (e.g. the data commit/push, after all three retry attempts) — the failure path still runs and records `error`, but `last_success`/`series_last_date` correctly show that the measurement itself landed; only getting it committed and pushed did not.
 
 ---
 
 ## 10. Testing
 
-`scripts/metrics`'s `test` script is `tsc --noEmit && vitest run` — it runs through the existing root `pnpm -r test` step with no `ci.yml` change required, and covers both types and behavior in one script. All tests are fixture-driven and touch no network; filesystem tests use a per-test `mkdtempSync` directory, cleaned up in `afterEach`. As of this writing there are **141 tests across 7 files**, all passing:
+`scripts/metrics`'s `test` script is `tsc --noEmit && vitest run` — it runs through the existing root `pnpm -r test` step with no `ci.yml` change required, and covers both types and behavior in one script. All tests are fixture-driven and touch no network; filesystem tests use a per-test `mkdtempSync` directory, cleaned up in `afterEach`. As of this writing there are **168 tests across 7 files**, all passing:
 
 ```
-src/no-runtime-deps.test.ts   6
-src/series.test.ts           41
-src/cli-support.test.ts      28
-src/github.test.ts           16
+src/no-runtime-deps.test.ts   9
+src/series.test.ts           47
+src/cli-support.test.ts      35
+src/github.test.ts           17
 src/store.test.ts            23
-src/backfill.test.ts          9
-src/collect.test.ts          18
+src/backfill.test.ts         12
+src/collect.test.ts          25
 ```
+
+`cli-record-failure.ts` has no dedicated `.test.ts` of its own, matching `cli-collect.ts` and `cli-backfill.ts` — all three are thin `process.env`/clock-reading wrappers with no branching logic of their own to unit-test. Its testable core, `recordFailure()`, is covered in `cli-support.test.ts` alongside the module's other shared helpers; `collect.ts`'s corresponding `series_last_date`-seeding logic is covered in `collect.test.ts`.
 
 `no-runtime-deps.test.ts` is worth calling out specifically: it regex-scans every non-test source file in `src/` and fails if any import specifier is not a `node:` builtin or a relative path, if any relative import omits its `.ts` extension, or if any import of `types.ts` omits the `import type` keyword. This is the enforcement mechanism behind two of Node's type-stripping constraints (§12) — without `import type`, Node treats a type-only import as a value import and throws `SyntaxError` **at runtime**, which for this package means a red 03:00 cron rather than a red `tsc --noEmit`. `erasableSyntaxOnly` and `verbatimModuleSyntax` in `tsconfig.json` catch the same class of mistake at typecheck time for constructs `no-runtime-deps.test.ts` doesn't scan for (enums, namespaces with runtime code, parameter properties, decorators).
 

--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -44,7 +44,7 @@ Issues/PRs and commit/code-frequency history are not collected at all — no cha
 scripts/metrics/                     @backspace/metrics (pnpm workspace package)
   package.json      zero runtime dependencies; scripts: typecheck, test
   tsconfig.json      extends the repo's strict base config, plus erasableSyntaxOnly,
-                      verbatimModuleSyntax, rewriteRelativeImportExtensions
+                      verbatimModuleSyntax, allowImportingTsExtensions
   src/
     types.ts          shared row shapes (import type only)
     github.ts         API client
@@ -283,10 +283,10 @@ That said, adding a second repo is not a matter of pointing a second workflow at
 
 The collector has **zero runtime dependencies** — only `fetch` and `node:` builtins — and is executed directly by Node via native TypeScript type stripping, with no `tsc` build step in the run path (`tsc --noEmit` runs only for typechecking, in `test`/`typecheck`). `scripts/metrics/package.json` declares `"engines": { "node": ">=22.18" }`; the workflow's `setup-node` step pins `node-version: 24`.
 
-Two constraints this creates are compiler-enforced (`tsconfig.json`'s `erasableSyntaxOnly` + `verbatimModuleSyntax` + `rewriteRelativeImportExtensions`) and test-enforced (`no-runtime-deps.test.ts`, §10) rather than left to discipline:
+Two constraints this creates are enforced rather than left to discipline, but by different mechanisms — worth knowing, because only one of them fails at typecheck time:
 
-- **`import type` is mandatory** for any type-only import. Omitting it makes Node treat the import as a value import, which throws `SyntaxError` at runtime — the single most likely way this system could break, since a missing `import type` still passes a typecheck that isn't checking for it.
-- **Relative import specifiers must carry the `.ts` extension** (`import './series.ts'`, never `'./series'`).
+- **`import type` is mandatory** for any type-only import. Omitting it makes Node treat the import as a value import, which throws `SyntaxError` at runtime. `verbatimModuleSyntax` in `scripts/metrics/tsconfig.json` catches this at typecheck time, and `no-runtime-deps.test.ts` catches it again.
+- **Relative import specifiers must carry the `.ts` extension** (`import './series.ts'`, never `'./series'`). This one has **no compiler enforcement**: `allowImportingTsExtensions` permits the extension but does not require it, so a missing `.ts` typechecks cleanly and only fails when Node runs the file. The regex scan in `no-runtime-deps.test.ts` (§10) is the only thing that catches it before then.
 
 Unsupported by type stripping and therefore avoided throughout the package: enums, namespaces with runtime code, parameter properties, import aliases, decorators.
 

--- a/docs/systems/security-scanning.md
+++ b/docs/systems/security-scanning.md
@@ -56,3 +56,14 @@ merge-blocking, Dependabot alerts, and native secret-scanning are GitHub *settin
       `image:` pins — update `caddy` and `livekit/livekit-server` by hand when new
       releases ship. (Renovate, which parses compose, is an optional future
       alternative.)
+- [ ] Create a fine-grained PAT scoped to this repository only, with
+      **Administration: read** and **Contents: read**, and store it as the
+      `METRICS_TOKEN` repository secret. Traffic endpoints are unreachable
+      without it — there is no `administration` key in the Actions
+      `permissions:` vocabulary, so `GITHUB_TOKEN` cannot substitute. See
+      `docs/systems/metrics.md`.
+- [ ] Create a ruleset on the `metrics-data` branch blocking **deletion** and
+      **force-push**, with no bypass actors, matching the existing
+      `cla-signatures` ruleset. Do NOT require pull requests or status checks:
+      the collector commits directly. This branch holds the only irreplaceable
+      data in the repository.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,18 @@ importers:
         specifier: ^7.4.0
         version: 7.4.0
 
+  scripts/metrics:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@24.12.0)(jiti@1.21.7)(jsdom@28.1.0)(terser@5.46.0)(tsx@4.21.0)
+
 packages:
 
   7zip-bin@5.2.0:
@@ -7241,7 +7253,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 20.19.33
+      '@types/node': 24.12.0
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -7267,7 +7279,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 24.12.0
 
   '@types/hast@3.0.4':
     dependencies:
@@ -7282,7 +7294,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 24.12.0
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -7302,7 +7314,7 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 24.12.0
       xmlbuilder: 15.1.1
     optional: true
 
@@ -7323,7 +7335,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 24.12.0
 
   '@types/trusted-types@2.0.7': {}
 
@@ -7340,7 +7352,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 24.12.0
     optional: true
 
   '@ungap/structured-clone@1.3.0': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 packages:
   - "packages/*"
+  # Repo tooling that needs typecheck + tests, listed explicitly rather than as
+  # `scripts/*` so unrelated one-off scripts (gen-icons.mjs) stay out of the
+  # workspace. See docs/systems/metrics.md.
+  - "scripts/metrics"

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@backspace/metrics",
+  "version": "1.0.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "author": "Jannis Braun",
+  "type": "module",
+  "engines": {
+    "node": ">=22.18"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "tsc --noEmit && vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0",
+    "vitest": "^4.0.18",
+    "@types/node": "^24.0.0"
+  }
+}

--- a/scripts/metrics/src/backfill.test.ts
+++ b/scripts/metrics/src/backfill.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createStore } from './store.ts';
+import { backfill } from './backfill.ts';
+import type { GitHubClient } from './github.ts';
+
+let dir = '';
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'metrics-backfill-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const STARGAZERS = [
+  { starred_at: '2026-02-20T10:00:00Z' },
+  { starred_at: '2026-02-20T18:00:00Z' },
+  { starred_at: '2026-03-01T09:00:00Z' },
+];
+const FORKS = [{ created_at: '2026-03-05T09:00:00Z' }];
+const RELEASES = [
+  { tag_name: 'v1.0.0', name: 'Backspace 1.0.0', published_at: '2026-08-01T10:00:00Z' },
+];
+
+function fakeClient(pages: Record<string, unknown[]> = {}): GitHubClient {
+  const routes: Record<string, unknown[]> = {
+    '/repos/o/r/stargazers': STARGAZERS,
+    '/repos/o/r/forks?sort=oldest': FORKS,
+    '/repos/o/r/releases': RELEASES,
+    ...pages,
+  };
+  return {
+    async get<T>(p: string): Promise<T> {
+      throw new Error(`backfill must paginate, not get: ${p}`);
+    },
+    async getStats<T>(): Promise<T | null> {
+      return null;
+    },
+    async paginate<T>(p: string): Promise<T[]> {
+      const value = routes[p];
+      if (value === undefined) throw new Error(`unexpected paginate ${p}`);
+      return value as T[];
+    },
+  };
+}
+
+const base = { slug: 'o/r' };
+
+describe('backfill', () => {
+  it('accumulates stars cumulatively by the UTC day of starred_at', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('stars.csv')).toEqual([
+      { date: '2026-02-20', total: '2' },
+      { date: '2026-03-01', total: '3' },
+    ]);
+  });
+
+  it('accumulates forks cumulatively by created_at', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('forks.csv')).toEqual([{ date: '2026-03-05', total: '1' }]);
+  });
+
+  it('records release dates', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'Backspace 1.0.0' },
+    ]);
+  });
+
+  it('NEVER overwrites a date the collector already measured', async () => {
+    const store = createStore(dir);
+    // The collector measured 1 star on 2026-03-01, because someone unstarred.
+    // The reconstruction from /stargazers cannot see that and would say 3.
+    store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-03-01', total: 1 }]);
+    await backfill({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('stars.csv');
+    expect(rows.find((r) => r.date === '2026-03-01')?.total).toBe('1');
+  });
+
+  it('still fills dates the collector never saw', async () => {
+    const store = createStore(dir);
+    store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-03-01', total: 1 }]);
+    await backfill({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('stars.csv');
+    expect(rows.find((r) => r.date === '2026-02-20')?.total).toBe('2');
+  });
+
+  it('never touches traffic files or repo.csv', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(existsSync(path.join(dir, 'traffic'))).toBe(false);
+    expect(existsSync(path.join(dir, 'repo.csv'))).toBe(false);
+  });
+
+  it('reports exactly the files it may write', async () => {
+    const store = createStore(dir);
+    const result = await backfill({ client: fakeClient(), store, ...base });
+    expect(result.written.sort()).toEqual(['forks.csv', 'releases.csv', 'stars.csv']);
+  });
+
+  it('is idempotent across repeated runs', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    const first = store.readCsv('stars.csv');
+    await backfill({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('stars.csv')).toEqual(first);
+  });
+
+  it('handles multi-page stargazer results', async () => {
+    const many = Array.from({ length: 150 }, (_, i) => ({
+      starred_at: `2026-04-${String((i % 28) + 1).padStart(2, '0')}T00:00:00Z`,
+    }));
+    const store = createStore(dir);
+    await backfill({ client: fakeClient({ '/repos/o/r/stargazers': many }), store, ...base });
+    const rows = store.readCsv('stars.csv');
+    expect(rows[rows.length - 1]?.total).toBe('150');
+  });
+});

--- a/scripts/metrics/src/backfill.test.ts
+++ b/scripts/metrics/src/backfill.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createStore } from './store.ts';
 import { backfill } from './backfill.ts';
+import { collect } from './collect.ts';
 import type { GitHubClient } from './github.ts';
 
 let dir = '';
@@ -71,6 +72,98 @@ describe('backfill', () => {
     await backfill({ client: fakeClient(), store, ...base });
     expect(store.readCsv('releases.csv')).toEqual([
       { date: '2026-08-01', tag: 'v1.0.0', name: 'Backspace 1.0.0' },
+    ]);
+  });
+
+  it('keeps both releases when two are published on the same UTC day', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({
+      '/repos/o/r/releases': [
+        { tag_name: 'v1.0.1', name: 'v1.0.1', published_at: '2026-08-01T18:00:00Z' },
+        { tag_name: 'v1.0.0', name: 'v1.0.0', published_at: '2026-08-01T09:00:00Z' },
+      ],
+    });
+    await backfill({ client, store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'v1.0.0' },
+      { date: '2026-08-01', tag: 'v1.0.1', name: 'v1.0.1' },
+    ]);
+  });
+
+  it('is idempotent for same-day releases across repeated runs', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({
+      '/repos/o/r/releases': [
+        { tag_name: 'v1.0.1', name: 'v1.0.1', published_at: '2026-08-01T18:00:00Z' },
+        { tag_name: 'v1.0.0', name: 'v1.0.0', published_at: '2026-08-01T09:00:00Z' },
+      ],
+    });
+    await backfill({ client, store, ...base });
+    const first = store.readCsv('releases.csv');
+    await backfill({ client, store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual(first);
+  });
+
+  it('never alters a release the collector already wrote, even under a different name', async () => {
+    // collect() and backfill() both write releases.csv, keyed on tag. If
+    // collect() ran first and recorded a release, a later backfill() dispatch
+    // reconstructing the same tag from /releases (a raw list, not filtered to
+    // "new since last run") must not clobber it — matching the if-absent
+    // guarantee stars.csv/forks.csv already have, now extended to the
+    // tag-keyed merge.
+    const store = createStore(dir);
+    const collectClient: GitHubClient = {
+      async get<T>(p: string): Promise<T> {
+        const routes: Record<string, unknown> = {
+          '/repos/o/r/traffic/views': { views: [] },
+          '/repos/o/r/traffic/clones': { clones: [] },
+          '/repos/o/r/traffic/popular/referrers': [],
+          '/repos/o/r/traffic/popular/paths': [],
+          '/repos/o/r': {
+            stargazers_count: 1,
+            forks_count: 1,
+            subscribers_count: 1,
+            open_issues_count: 1,
+          },
+        };
+        const value = routes[p];
+        if (value === undefined) throw new Error(`unexpected GET ${p}`);
+        return value as T;
+      },
+      async getStats<T>(): Promise<T | null> {
+        return null;
+      },
+      async paginate<T>(p: string): Promise<T[]> {
+        if (p !== '/repos/o/r/releases') throw new Error(`unexpected paginate ${p}`);
+        return [
+          {
+            tag_name: 'v1.0.0',
+            name: 'Collector name',
+            published_at: '2026-08-01T10:00:00Z',
+            assets: [],
+          },
+        ] as T[];
+      },
+    };
+    await collect({
+      client: collectClient,
+      store,
+      slug: 'o/r',
+      today: '2026-08-25',
+      now: '2026-08-25T03:00:00Z',
+    });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'Collector name' },
+    ]);
+
+    const backfillClient = fakeClient({
+      '/repos/o/r/releases': [
+        { tag_name: 'v1.0.0', name: 'Reconstructed name', published_at: '2026-08-01T10:00:00Z' },
+      ],
+    });
+    await backfill({ client: backfillClient, store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'Collector name' },
     ]);
   });
 

--- a/scripts/metrics/src/backfill.ts
+++ b/scripts/metrics/src/backfill.ts
@@ -111,6 +111,15 @@ function cumulativeByDay(dates: readonly IsoDate[]): CountPoint[] {
  * date it wrote itself on a previous run is "absent" to nothing on the next
  * one, so nothing changes.
  */
+/**
+ * The returned `written` lists the files backfill is PERMITTED to write —
+ * `WRITABLE` verbatim — not the files that gained a row on this run. Because
+ * every write is if-absent, a rerun legitimately writes nothing new while
+ * still reporting the same list. This differs deliberately from
+ * `CollectResult.written` in `collect.ts`, which lists only files that
+ * actually received a write, so do not compare the two fields as if they
+ * meant the same thing.
+ */
 export async function backfill(options: BackfillOptions): Promise<{ written: string[] }> {
   const { client, store, slug } = options;
   const repoPath = `/repos/${slug}`;

--- a/scripts/metrics/src/backfill.ts
+++ b/scripts/metrics/src/backfill.ts
@@ -1,4 +1,4 @@
-import { upsertByDate } from './series.ts';
+import { upsertByDate, upsertByKey, compareReleaseRows } from './series.ts';
 import type { GitHubClient } from './github.ts';
 import type { Store } from './store.ts';
 import type { CountPoint, IsoDate, ReleaseRow } from './types.ts';
@@ -187,7 +187,27 @@ export async function backfill(options: BackfillOptions): Promise<{ written: str
       tag: release.tag_name,
       name: release.name ?? release.tag_name,
     }));
-  mergeIfAbsent('releases.csv', ['date', 'tag', 'name'], releaseRows);
+
+  // Not `mergeIfAbsent`: `releases.csv` is keyed on `tag`, not `date` — see
+  // `upsertByKey` in series.ts for why a date-keyed merge silently collapses
+  // two releases published on the same UTC day into one row. Still
+  // if-absent, matching every other write in this function: a tag the
+  // collector already recorded (with `collect.ts`'s own `upsertByKey`
+  // 'overwrite' merge, which is authoritative because it comes from the
+  // day's live fetch) must never be replaced by this reconstruction.
+  const existingReleases = store.readCsv('releases.csv') as unknown as ReleaseRow[];
+  const mergedReleases = upsertByKey(
+    existingReleases,
+    releaseRows,
+    (row) => row.tag,
+    'if-absent',
+    compareReleaseRows,
+  );
+  store.writeCsv(
+    'releases.csv',
+    ['date', 'tag', 'name'],
+    mergedReleases as unknown as Array<Record<string, string | number>>,
+  );
 
   return { written: [...WRITABLE] };
 }

--- a/scripts/metrics/src/backfill.ts
+++ b/scripts/metrics/src/backfill.ts
@@ -1,0 +1,184 @@
+import { upsertByDate } from './series.ts';
+import type { GitHubClient } from './github.ts';
+import type { Store } from './store.ts';
+import type { CountPoint, IsoDate, ReleaseRow } from './types.ts';
+
+interface StargazerResponse {
+  starred_at: string;
+}
+interface ForkResponse {
+  created_at: string;
+}
+interface ReleaseResponse {
+  tag_name: string;
+  name: string | null;
+  published_at: string | null;
+}
+
+export interface BackfillOptions {
+  client: GitHubClient;
+  store: Store;
+  /** `owner/repo`, from `github.repository`. */
+  slug: string;
+}
+
+/**
+ * Files backfill is permitted to write. Exhaustive and deliberately short.
+ *
+ * `traffic/*` is excluded because GitHub exposes no historical traffic API —
+ * a 14-day trailing window is all that has ever existed for it, so there is
+ * nothing to reconstruct. `repo.csv` is excluded because `subscribers` has
+ * no historical API either: a stray rewrite there would be a permanent loss
+ * with nothing to restore from. `contributors.csv` is likewise excluded —
+ * the `/stats/contributors` weekly buckets already cover all of history
+ * whenever the daily collector can fetch them, so there is no gap for a
+ * one-shot backfill to fill, and no cheaper reconstruction exists.
+ */
+const WRITABLE = ['stars.csv', 'forks.csv', 'releases.csv'] as const;
+
+/**
+ * Converts an ISO timestamp to its UTC calendar date. Mirrors `collect.ts`'s
+ * `toDate` exactly: both modules read the same kind of GitHub timestamp
+ * field and must fail the same way on the same malformed input, rather than
+ * diverging into two silently-different notions of "the date" for what is
+ * conceptually one archive. A timestamp that fails this check — including a
+ * `starred_at` that is `undefined` because the stargazer request was made
+ * without the `star+json` media type, so GitHub silently omitted the field —
+ * throws immediately instead of being sliced into a garbage date that would
+ * land silently in the archive.
+ */
+function toDate(timestamp: string): IsoDate {
+  const date = timestamp.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Unparseable timestamp from the API: ${timestamp}`);
+  }
+  return date;
+}
+
+/**
+ * Turns a list of already-validated event dates into a cumulative daily
+ * running total.
+ *
+ * This is deliberately the same *quantity* the daily collector writes to
+ * `stars.csv`/`forks.csv`: `collect.ts` reads the repo object's live
+ * `stargazers_count`/`forks_count` — a running total as of the day it was
+ * read, not a per-day delta — and appends one row carrying that total under
+ * today's date. A per-day delta series and a running-total series are not
+ * interchangeable: mixing them in one file would make consecutive rows mean
+ * two different things depending on which process wrote them. Reconstructing
+ * from `starred_at`/`created_at` timestamps means counting events per UTC
+ * day and then running a cumulative sum forward through calendar order, so
+ * a date with no events keeps the running total from the day before it
+ * rather than resetting — matching what the live counter would have read
+ * had it been sampled that day.
+ */
+function cumulativeByDay(dates: readonly IsoDate[]): CountPoint[] {
+  const perDay = new Map<IsoDate, number>();
+  for (const date of dates) {
+    perDay.set(date, (perDay.get(date) ?? 0) + 1);
+  }
+  const days = [...perDay.keys()].sort((a, b) => a.localeCompare(b));
+  let running = 0;
+  return days.map((date) => {
+    running += perDay.get(date) ?? 0;
+    return { date, total: running };
+  });
+}
+
+/**
+ * Reconstructs the history GitHub's permanent per-item timestamps make
+ * recoverable — stars (via `starred_at` on each stargazer), forks (via
+ * `created_at` on each fork), and release dates (via `published_at` on each
+ * release) — to seed the archive with the past before daily collection
+ * began. Traffic (views/clones/referrers/paths) has no equivalent: GitHub
+ * only ever exposes a trailing 14-day window for it, so nothing before this
+ * package's own first run can ever be recovered, and this function does not
+ * try.
+ *
+ * Every write goes through `upsertByDate(existing, incoming, 'if-absent')`,
+ * never `'overwrite'`. That is the one property this function exists to
+ * guarantee, and the reason is structural, not a style preference:
+ * `/stargazers` lists only *current* stargazers, so a person who starred and
+ * later unstarred is permanently invisible to it, while the daily
+ * collector's `stars.csv` row for that same date came from the repo
+ * object's live counter, which saw the unstar. The two series measure the
+ * same date differently by construction, and the collector's value is the
+ * one that was actually true on that date — a reconstruction can only ever
+ * approximate it from below-or-equal, never correct it. So a date the
+ * collector has already written must never be replaced by a reconstructed
+ * guess; only a date neither process has ever recorded may be filled. The
+ * same property makes repeated runs of this function idempotent for free: a
+ * date it wrote itself on a previous run is "absent" to nothing on the next
+ * one, so nothing changes.
+ */
+export async function backfill(options: BackfillOptions): Promise<{ written: string[] }> {
+  const { client, store, slug } = options;
+  const repoPath = `/repos/${slug}`;
+
+  // The stargazers list is the one genuinely long paginated call this
+  // package makes. Reading `starred_at` at all requires this custom Accept
+  // media type — without it GitHub's stargazers endpoint returns bare user
+  // objects with no timestamp field whatsoever, and `toDate` below would
+  // throw on every entry rather than silently reconstructing nothing.
+  const stargazers = await client.paginate<StargazerResponse>(
+    `${repoPath}/stargazers`,
+    'application/vnd.github.star+json',
+  );
+  const forks = await client.paginate<ForkResponse>(`${repoPath}/forks?sort=oldest`);
+  const releases = await client.paginate<ReleaseResponse>(`${repoPath}/releases`);
+
+  /**
+   * Reads `file`, merges `incoming` into it with `'if-absent'`, and writes
+   * the result back. Generic over `T` — inferred from `incoming` at each
+   * call site — so `existing`, cast once through `unknown` from the store's
+   * untyped `Record<string, string>[]`, is unified with the SAME type
+   * `incoming` carries rather than a narrower structural type that would
+   * discard fields `upsertByDate` never touches (e.g. `total`, `tag`,
+   * `name`) but `store.writeCsv` still needs to serialise. This mirrors
+   * `collect.ts`'s `writeCsvSeries` exactly, down to the reason for the
+   * cast: neither `CountPoint` nor `ReleaseRow` declares an index signature,
+   * so TypeScript does not accept either as a `Record<string, string |
+   * number>` structurally, even though every field on both is in fact a
+   * `string | number`.
+   */
+  function mergeIfAbsent<T extends { date: IsoDate }>(
+    file: string,
+    header: readonly string[],
+    incoming: readonly T[],
+  ): void {
+    const existing = store.readCsv(file) as unknown as T[];
+    const merged = upsertByDate(existing, incoming, 'if-absent');
+    store.writeCsv(file, header, merged as unknown as Array<Record<string, string | number>>);
+  }
+
+  mergeIfAbsent(
+    'stars.csv',
+    ['date', 'total'],
+    cumulativeByDay(stargazers.map((item) => toDate(item.starred_at))),
+  );
+  mergeIfAbsent(
+    'forks.csv',
+    ['date', 'total'],
+    cumulativeByDay(forks.map((item) => toDate(item.created_at))),
+  );
+
+  // A draft release carries `published_at: null` and is excluded: it has no
+  // publish date to record, and being unpublished, it is not yet a public
+  // fact this archive should be recording at all. The type guard (rather
+  // than an `as string` cast after the filter) keeps the narrowing honest —
+  // if this predicate is ever loosened, the compiler, not a runtime
+  // `.slice()` on `null`, is what catches it.
+  const releaseRows: ReleaseRow[] = releases
+    .filter(
+      (release): release is ReleaseResponse & { published_at: string } =>
+        release.published_at !== null,
+    )
+    .map((release) => ({
+      date: toDate(release.published_at),
+      tag: release.tag_name,
+      name: release.name ?? release.tag_name,
+    }));
+  mergeIfAbsent('releases.csv', ['date', 'tag', 'name'], releaseRows);
+
+  return { written: [...WRITABLE] };
+}

--- a/scripts/metrics/src/backfill.ts
+++ b/scripts/metrics/src/backfill.ts
@@ -77,7 +77,10 @@ function cumulativeByDay(dates: readonly IsoDate[]): CountPoint[] {
   for (const date of dates) {
     perDay.set(date, (perDay.get(date) ?? 0) + 1);
   }
-  const days = [...perDay.keys()].sort((a, b) => a.localeCompare(b));
+  // Byte comparison, matching `series.ts`'s compareStrings — see its comment:
+  // localeCompare's collation is ICU-version dependent and can silently
+  // reorder a committed file after a Node upgrade.
+  const days = [...perDay.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   let running = 0;
   return days.map((date) => {
     running += perDay.get(date) ?? 0;

--- a/scripts/metrics/src/backfill.ts
+++ b/scripts/metrics/src/backfill.ts
@@ -1,4 +1,4 @@
-import { upsertByDate, upsertByKey, compareReleaseRows } from './series.ts';
+import { upsertByDate, upsertByKey, compareReleaseRows, compareStrings } from './series.ts';
 import type { GitHubClient } from './github.ts';
 import type { Store } from './store.ts';
 import type { CountPoint, IsoDate, ReleaseRow } from './types.ts';
@@ -77,10 +77,10 @@ function cumulativeByDay(dates: readonly IsoDate[]): CountPoint[] {
   for (const date of dates) {
     perDay.set(date, (perDay.get(date) ?? 0) + 1);
   }
-  // Byte comparison, matching `series.ts`'s compareStrings — see its comment:
-  // localeCompare's collation is ICU-version dependent and can silently
-  // reorder a committed file after a Node upgrade.
-  const days = [...perDay.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  // Shares `series.ts`'s comparator rather than inlining a second copy: the
+  // entire point of byte ordering here is that everything in the archive sorts
+  // the same way, which two independent implementations cannot promise.
+  const days = [...perDay.keys()].sort(compareStrings);
   let running = 0;
   return days.map((date) => {
     running += perDay.get(date) ?? 0;

--- a/scripts/metrics/src/cli-backfill.ts
+++ b/scripts/metrics/src/cli-backfill.ts
@@ -9,7 +9,7 @@ import {
 } from './cli-support.ts';
 
 /**
- * Entrypoint invoked by `.github/workflows/metrics.yml` as
+ * Entrypoint invoked by `.github/workflows/backfill.yml` as
  * `node scripts/metrics/src/cli-backfill.ts`, a one-shot (or safely
  * re-runnable) job that seeds history `backfill.ts` can reconstruct from
  * GitHub's permanent per-item timestamps.

--- a/scripts/metrics/src/cli-backfill.ts
+++ b/scripts/metrics/src/cli-backfill.ts
@@ -1,0 +1,44 @@
+import { createClient } from './github.ts';
+import { createStore } from './store.ts';
+import { backfill } from './backfill.ts';
+import {
+  requiredEnv,
+  assertHeaderSafeToken,
+  formatBackfillSummary,
+  describeFailure,
+} from './cli-support.ts';
+
+/**
+ * Entrypoint invoked by `.github/workflows/metrics.yml` as
+ * `node scripts/metrics/src/cli-backfill.ts`, a one-shot (or safely
+ * re-runnable) job that seeds history `backfill.ts` can reconstruct from
+ * GitHub's permanent per-item timestamps.
+ *
+ * This file and `cli-collect.ts` are deliberately the only two files in
+ * this package that read `process.env` or the system clock — `backfill`
+ * itself needs no clock input at all (every date it writes comes from a
+ * GitHub timestamp, never "today"), which is why, unlike `cli-collect.ts`,
+ * this file never calls `new Date()`.
+ */
+async function main(): Promise<void> {
+  const token = requiredEnv(process.env, 'METRICS_TOKEN');
+  assertHeaderSafeToken(token);
+  const slug = requiredEnv(process.env, 'GITHUB_REPOSITORY');
+  const dataDir = requiredEnv(process.env, 'METRICS_DATA_DIR');
+
+  const result = await backfill({
+    client: createClient(token),
+    store: createStore(dataDir),
+    slug,
+  });
+
+  console.log(formatBackfillSummary(result));
+}
+
+// See `cli-collect.ts` for why this is `main().catch(...)` with
+// `process.exitCode = 1` rather than a bare top-level `await` or a forced
+// `process.exit(1)`.
+main().catch((error: unknown) => {
+  console.error(describeFailure(error));
+  process.exitCode = 1;
+});

--- a/scripts/metrics/src/cli-backfill.ts
+++ b/scripts/metrics/src/cli-backfill.ts
@@ -14,11 +14,12 @@ import {
  * re-runnable) job that seeds history `backfill.ts` can reconstruct from
  * GitHub's permanent per-item timestamps.
  *
- * This file and `cli-collect.ts` are deliberately the only two files in
- * this package that read `process.env` or the system clock — `backfill`
- * itself needs no clock input at all (every date it writes comes from a
- * GitHub timestamp, never "today"), which is why, unlike `cli-collect.ts`,
- * this file never calls `new Date()`.
+ * This file, `cli-collect.ts`, and `cli-record-failure.ts` are deliberately
+ * the only three files in this package that read `process.env` or the
+ * system clock — `backfill` itself needs no clock input at all (every date
+ * it writes comes from a GitHub timestamp, never "today"), which is why,
+ * unlike `cli-collect.ts` and `cli-record-failure.ts`, this file never
+ * calls `new Date()`.
  */
 async function main(): Promise<void> {
   const token = requiredEnv(process.env, 'METRICS_TOKEN');

--- a/scripts/metrics/src/cli-collect.ts
+++ b/scripts/metrics/src/cli-collect.ts
@@ -13,11 +13,12 @@ import {
  * Entrypoint invoked by `.github/workflows/metrics.yml` as
  * `node scripts/metrics/src/cli-collect.ts`, once per scheduled run.
  *
- * This file and `cli-backfill.ts` are deliberately the only two files in
- * this package that read `process.env` or the system clock — every other
- * module takes those as injected values (see `CollectOptions` in
- * `collect.ts`), which is what makes the rest of the package testable
- * without touching the network, the filesystem, or real time.
+ * This file, `cli-backfill.ts`, and `cli-record-failure.ts` are
+ * deliberately the only three files in this package that read `process.env`
+ * or the system clock — every other module takes those as injected values
+ * (see `CollectOptions` in `collect.ts`), which is what makes the rest of
+ * the package testable without touching the network, the filesystem, or
+ * real time.
  */
 async function main(): Promise<void> {
   const token = requiredEnv(process.env, 'METRICS_TOKEN');

--- a/scripts/metrics/src/cli-collect.ts
+++ b/scripts/metrics/src/cli-collect.ts
@@ -1,0 +1,55 @@
+import { createClient } from './github.ts';
+import { createStore } from './store.ts';
+import { collect } from './collect.ts';
+import {
+  requiredEnv,
+  assertHeaderSafeToken,
+  deriveRunTimestamps,
+  formatCollectSummary,
+  describeFailure,
+} from './cli-support.ts';
+
+/**
+ * Entrypoint invoked by `.github/workflows/metrics.yml` as
+ * `node scripts/metrics/src/cli-collect.ts`, once per scheduled run.
+ *
+ * This file and `cli-backfill.ts` are deliberately the only two files in
+ * this package that read `process.env` or the system clock — every other
+ * module takes those as injected values (see `CollectOptions` in
+ * `collect.ts`), which is what makes the rest of the package testable
+ * without touching the network, the filesystem, or real time.
+ */
+async function main(): Promise<void> {
+  const token = requiredEnv(process.env, 'METRICS_TOKEN');
+  assertHeaderSafeToken(token);
+  const slug = requiredEnv(process.env, 'GITHUB_REPOSITORY');
+  const dataDir = requiredEnv(process.env, 'METRICS_DATA_DIR');
+
+  const { now, today } = deriveRunTimestamps(new Date());
+
+  const result = await collect({
+    client: createClient(token),
+    store: createStore(dataDir),
+    slug,
+    today,
+    now,
+  });
+
+  for (const line of formatCollectSummary(result)) {
+    console.log(line);
+  }
+}
+
+// `main().catch(...)` rather than a bare top-level `await main()`: this is a
+// scheduled workflow with no one watching it interactively, so a failure
+// must exit non-zero and say why, in one deliberate place, rather than rely
+// on Node's default unhandled-rejection handler (which does also exit
+// non-zero on this Node version, but dumps its own generic framing rather
+// than a message this package controls and can guarantee is token-free).
+// `process.exitCode = 1` — not `process.exit(1)` — so the `console.error`
+// write above is allowed to actually flush before the process exits; a
+// forced immediate exit can truncate output piped into a CI log collector.
+main().catch((error: unknown) => {
+  console.error(describeFailure(error));
+  process.exitCode = 1;
+});

--- a/scripts/metrics/src/cli-record-failure.ts
+++ b/scripts/metrics/src/cli-record-failure.ts
@@ -1,0 +1,63 @@
+import { createStore } from './store.ts';
+import {
+  requiredEnv,
+  deriveRunTimestamps,
+  recordFailure,
+  formatRecordFailureSummary,
+  describeFailure,
+} from './cli-support.ts';
+
+/**
+ * Entrypoint invoked by `.github/workflows/metrics.yml`'s "Record failure"
+ * step, `if: failure()` — i.e. only on the path where something upstream in
+ * the job already failed (a required GitHub API fetch, or the data
+ * commit/push). It records that failure into `meta.json` so a stalled
+ * collector is visible on the data branch itself, not only in the Actions
+ * tab.
+ *
+ * `collect()` (via `cli-collect.ts`) remains the only writer of `meta.json`
+ * on the success path — it already writes a complete, correct `meta.json`
+ * as the last step of its own atomic write phase, so there is nothing left
+ * for this entrypoint to do when the run actually succeeded, which is
+ * exactly why the workflow step invoking this file is `if: failure()` and
+ * not `if: always()`. See docs/systems/metrics.md §3.3.
+ *
+ * This file, `cli-collect.ts`, and `cli-backfill.ts` are deliberately the
+ * only three files in this package that read `process.env` or the system
+ * clock — every other module takes those as injected values, which is what
+ * makes the rest of the package testable without touching the network, the
+ * filesystem, or real time. Unlike the other two, this entrypoint makes no
+ * GitHub API call at all, so it needs no `METRICS_TOKEN` and never touches
+ * `assertHeaderSafeToken` — there is no token here to be unsafe.
+ */
+async function main(): Promise<void> {
+  const dataDir = requiredEnv(process.env, 'METRICS_DATA_DIR');
+  // The reason this run failed, e.g. `run failed: failure`. Read from the
+  // environment rather than interpolated into the workflow's `run:` string:
+  // `job.status` is not a secret, but it is still attacker/environment-
+  // influenced text by the time it reaches a shell, and this package's
+  // standing convention (see `cli-collect.ts`/`cli-backfill.ts`) is that
+  // every value crossing from the workflow into this process's control flow
+  // does so via `env:`, never via `${{ }}` spliced into `run:`.
+  const reason = requiredEnv(process.env, 'METRICS_RUN_OUTCOME');
+
+  const store = createStore(dataDir);
+  const { now } = deriveRunTimestamps(new Date());
+
+  const meta = recordFailure(store, now, reason);
+
+  console.log(formatRecordFailureSummary(meta));
+}
+
+// `main().catch(...)` rather than a bare top-level `await main()`: see
+// `cli-collect.ts` for the full rationale (flush-safe `process.exitCode`
+// over a forced `process.exit`, a token-free error message this package
+// controls). One subtlety specific to this entrypoint: it runs BECAUSE the
+// job already failed, so a non-zero exit here means recording the failure
+// itself failed (e.g. a corrupt `meta.json`, or a filesystem error), not
+// that the underlying run failed — that fact is already known and is the
+// very reason this script was invoked.
+main().catch((error: unknown) => {
+  console.error(describeFailure(error));
+  process.exitCode = 1;
+});

--- a/scripts/metrics/src/cli-support.test.ts
+++ b/scripts/metrics/src/cli-support.test.ts
@@ -1,11 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { GitHubError } from './github.ts';
+import { createStore } from './store.ts';
 import {
   requiredEnv,
   assertHeaderSafeToken,
   deriveRunTimestamps,
   formatCollectSummary,
   formatBackfillSummary,
+  recordFailure,
+  formatRecordFailureSummary,
   describeFailure,
 } from './cli-support.ts';
 
@@ -146,6 +152,109 @@ describe('formatBackfillSummary', () => {
   it('does not use the word "wrote", so it cannot be misread the way collect\'s summary is read', () => {
     const line = formatBackfillSummary({ written: ['stars.csv'] });
     expect(line).not.toContain('wrote:');
+  });
+});
+
+describe('recordFailure', () => {
+  let dir = '';
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'metrics-record-failure-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('produces a valid initial Meta when no meta.json has ever been written', () => {
+    const store = createStore(dir);
+    expect(store.readMeta()).toBeNull();
+    const meta = recordFailure(store, '2026-08-25T03:00:41Z', 'run failed: failure');
+    expect(meta).toEqual({
+      last_run: '2026-08-25T03:00:41Z',
+      last_success: null,
+      error: 'run failed: failure',
+      series_last_date: {},
+    });
+    expect(store.readMeta()).toEqual(meta);
+  });
+
+  it('preserves last_success and series_last_date from an existing meta.json, refreshing last_run and setting error', () => {
+    const store = createStore(dir);
+    store.writeMeta({
+      last_run: '2026-08-24T03:00:00Z',
+      last_success: '2026-08-24T03:00:00Z',
+      error: null,
+      series_last_date: { 'traffic/views.csv': '2026-08-23', 'stars.csv': '2026-08-24' },
+    });
+    const meta = recordFailure(store, '2026-08-25T03:00:41Z', 'run failed: failure');
+    expect(meta.last_run).toBe('2026-08-25T03:00:41Z');
+    expect(meta.last_success).toBe('2026-08-24T03:00:00Z');
+    expect(meta.error).toBe('run failed: failure');
+    expect(meta.series_last_date).toEqual({
+      'traffic/views.csv': '2026-08-23',
+      'stars.csv': '2026-08-24',
+    });
+    expect(store.readMeta()).toEqual(meta);
+  });
+
+  it('never touches last_success — the "last known good" signal a failure must not move', () => {
+    const store = createStore(dir);
+    store.writeMeta({
+      last_run: '2026-08-20T03:00:00Z',
+      last_success: '2026-08-20T03:00:00Z',
+      error: null,
+      series_last_date: {},
+    });
+    recordFailure(store, '2026-08-21T03:00:00Z', 'run failed: failure');
+    recordFailure(store, '2026-08-22T03:00:00Z', 'run failed: failure');
+    const meta = store.readMeta();
+    expect(meta?.last_success).toBe('2026-08-20T03:00:00Z');
+    expect(meta?.last_run).toBe('2026-08-22T03:00:00Z');
+  });
+
+  it('never edits series_last_date — a failed run measured nothing', () => {
+    const store = createStore(dir);
+    store.writeMeta({
+      last_run: '2026-08-20T03:00:00Z',
+      last_success: '2026-08-20T03:00:00Z',
+      error: null,
+      series_last_date: { 'releases.csv': '2026-07-01' },
+    });
+    const meta = recordFailure(store, '2026-08-21T03:00:00Z', 'run failed: failure');
+    expect(meta.series_last_date).toEqual({ 'releases.csv': '2026-07-01' });
+  });
+
+  it('propagates the failure, and does not write, when the existing meta.json is corrupt', () => {
+    const store = createStore(dir);
+    writeFileSync(path.join(dir, 'meta.json'), '{ not valid json', 'utf8');
+    expect(() => recordFailure(store, '2026-08-25T03:00:41Z', 'run failed: failure')).toThrow();
+    // The corrupt file must be left exactly as it was — a failure to read
+    // must never be papered over by writing a fresh-looking meta.json in
+    // its place.
+    expect(() => store.readMeta()).toThrow();
+  });
+});
+
+describe('formatRecordFailureSummary', () => {
+  it('reports the failure reason and the last known-good timestamp', () => {
+    const line = formatRecordFailureSummary({
+      last_run: '2026-08-25T03:00:41Z',
+      last_success: '2026-08-24T03:00:12Z',
+      error: 'run failed: failure',
+      series_last_date: {},
+    });
+    expect(line).toBe('recorded failure: run failed: failure (last_success: 2026-08-24T03:00:12Z)');
+  });
+
+  it('renders "never" when nothing has ever succeeded', () => {
+    const line = formatRecordFailureSummary({
+      last_run: '2026-08-25T03:00:41Z',
+      last_success: null,
+      error: 'run failed: failure',
+      series_last_date: {},
+    });
+    expect(line).toBe('recorded failure: run failed: failure (last_success: never)');
   });
 });
 

--- a/scripts/metrics/src/cli-support.test.ts
+++ b/scripts/metrics/src/cli-support.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { GitHubError } from './github.ts';
+import {
+  requiredEnv,
+  assertHeaderSafeToken,
+  deriveRunTimestamps,
+  formatCollectSummary,
+  formatBackfillSummary,
+  describeFailure,
+} from './cli-support.ts';
+
+describe('requiredEnv', () => {
+  it('returns the value when present', () => {
+    expect(requiredEnv({ FOO: 'bar' }, 'FOO')).toBe('bar');
+  });
+
+  it('trims surrounding whitespace, e.g. a trailing newline from a prior CI step', () => {
+    expect(requiredEnv({ FOO: '  bar\n' }, 'FOO')).toBe('bar');
+  });
+
+  it('throws when the variable is absent', () => {
+    expect(() => requiredEnv({}, 'FOO')).toThrow('Missing required environment variable FOO');
+  });
+
+  it('throws when the variable is the empty string', () => {
+    expect(() => requiredEnv({ FOO: '' }, 'FOO')).toThrow(/FOO/);
+  });
+
+  it('throws when the variable is whitespace-only', () => {
+    expect(() => requiredEnv({ FOO: '   \n\t  ' }, 'FOO')).toThrow(/FOO/);
+  });
+
+  it('names the specific missing variable, not a generic message', () => {
+    expect(() => requiredEnv({}, 'METRICS_TOKEN')).toThrow(/METRICS_TOKEN/);
+    expect(() => requiredEnv({}, 'GITHUB_REPOSITORY')).toThrow(/GITHUB_REPOSITORY/);
+  });
+});
+
+describe('assertHeaderSafeToken', () => {
+  it('accepts an ordinary token', () => {
+    expect(() => assertHeaderSafeToken('ghp_abcdefg1234567890')).not.toThrow();
+  });
+
+  it('rejects a token containing a newline', () => {
+    expect(() => assertHeaderSafeToken('ghp_abc\ndef')).toThrow();
+  });
+
+  it('rejects a token containing a tab', () => {
+    expect(() => assertHeaderSafeToken('ghp_abc\tdef')).toThrow();
+  });
+
+  it('rejects a token containing a DEL byte', () => {
+    expect(() => assertHeaderSafeToken('ghp_abc\x7fdef')).toThrow();
+  });
+
+  it('never echoes the rejected token value in its error message', () => {
+    // Regression test for a real, verified leak: Node's fetch/undici throws
+    // `Headers.append: "Bearer <the whole broken value>" is an invalid
+    // header value.` when a header value contains a control character —
+    // meaning the secret would otherwise land verbatim in the thrown
+    // error's message, and from there in this CLI's stderr, and from there
+    // in a public CI log. This guard must reject the value BEFORE it ever
+    // reaches `fetch`, with a message that names the problem without
+    // repeating the secret.
+    const secret = 'ghp_SECRETVALUE1234\nINJECTED';
+    let thrown: unknown;
+    try {
+      assertHeaderSafeToken(secret);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).not.toContain('SECRETVALUE1234');
+    expect((thrown as Error).message).not.toContain(secret);
+  });
+});
+
+describe('deriveRunTimestamps', () => {
+  it('returns the full ISO timestamp as `now`', () => {
+    const { now } = deriveRunTimestamps(new Date('2026-03-14T09:26:53.589Z'));
+    expect(now).toBe('2026-03-14T09:26:53.589Z');
+  });
+
+  it('derives `today` as the UTC calendar date, not a local one', () => {
+    const { today } = deriveRunTimestamps(new Date('2026-03-14T09:26:53.589Z'));
+    expect(today).toBe('2026-03-14');
+  });
+
+  it('stays on the correct UTC day for an instant near UTC midnight, regardless of host TZ', () => {
+    // 23:59:59.999 UTC on the 31st is still the 1st in several timezones
+    // east of UTC, and still the 31st (barely) in several west of it. Only
+    // the UTC day is correct for this archive; a local-time derivation
+    // would disagree with this assertion in at least one direction.
+    const instant = new Date('2026-01-31T23:59:59.999Z');
+    const originalTz = process.env['TZ'];
+    try {
+      process.env['TZ'] = 'Pacific/Kiritimati'; // UTC+14
+      expect(deriveRunTimestamps(instant).today).toBe('2026-01-31');
+      process.env['TZ'] = 'Etc/GMT+12'; // UTC-12
+      expect(deriveRunTimestamps(instant).today).toBe('2026-01-31');
+    } finally {
+      if (originalTz === undefined) {
+        delete process.env['TZ'];
+      } else {
+        process.env['TZ'] = originalTz;
+      }
+    }
+  });
+
+  it('produces a `today` that is a strict prefix of `now`', () => {
+    const { now, today } = deriveRunTimestamps(new Date('2026-07-04T00:00:00.000Z'));
+    expect(now.startsWith(today)).toBe(true);
+  });
+});
+
+describe('formatCollectSummary', () => {
+  it('reports only the written line when nothing was skipped', () => {
+    expect(formatCollectSummary({ written: ['stars.csv', 'forks.csv'], skipped: [] })).toEqual([
+      'wrote: stars.csv, forks.csv',
+    ]);
+  });
+
+  it('adds a skipped line, distinct from the written line, when something was skipped', () => {
+    const lines = formatCollectSummary({
+      written: ['stars.csv'],
+      skipped: ['releases.csv', 'contributors.csv'],
+    });
+    expect(lines).toEqual([
+      'wrote: stars.csv',
+      'skipped (left at previous value): releases.csv, contributors.csv',
+    ]);
+  });
+
+  it('renders an empty written list rather than omitting the line', () => {
+    expect(formatCollectSummary({ written: [], skipped: [] })).toEqual(['wrote: ']);
+  });
+});
+
+describe('formatBackfillSummary', () => {
+  it('lists the permitted target files', () => {
+    expect(formatBackfillSummary({ written: ['stars.csv', 'forks.csv', 'releases.csv'] })).toBe(
+      'backfill target files (write-if-absent, listed whether or not they changed this run): stars.csv, forks.csv, releases.csv',
+    );
+  });
+
+  it('does not use the word "wrote", so it cannot be misread the way collect\'s summary is read', () => {
+    const line = formatBackfillSummary({ written: ['stars.csv'] });
+    expect(line).not.toContain('wrote:');
+  });
+});
+
+describe('describeFailure', () => {
+  it('renders a plain Error, including its stack', () => {
+    const error = new Error('disk is full');
+    const rendered = describeFailure(error);
+    expect(rendered).toContain('disk is full');
+  });
+
+  it('surfaces the numeric status of a thrown GitHubError', () => {
+    const error = new GitHubError(404, 'Not Found');
+    const rendered = describeFailure(error);
+    expect(rendered).toContain('404');
+    expect(rendered).toContain('Not Found');
+  });
+
+  it('surfaces the status distinctly enough to grep for it (not just buried in prose)', () => {
+    const error = new GitHubError(401, 'Bad credentials');
+    expect(describeFailure(error)).toMatch(/status 401/);
+  });
+
+  it('walks the full `cause` chain', () => {
+    const inner = new Error('ENOSPC: no space left on device');
+    const outer = new Error('Store: failed to write "stars.csv"', { cause: inner });
+    const rendered = describeFailure(outer);
+    expect(rendered).toContain('failed to write "stars.csv"');
+    expect(rendered).toContain('ENOSPC');
+    expect(rendered).toContain('Caused by:');
+  });
+
+  it('renders a non-Error thrown value without crashing', () => {
+    expect(describeFailure('a bare string was thrown')).toContain('a bare string was thrown');
+  });
+
+  it('renders a thrown undefined without crashing', () => {
+    expect(() => describeFailure(undefined)).not.toThrow();
+  });
+
+  it('does not loop forever on a circular cause chain', () => {
+    const a = new Error('a');
+    const b = new Error('b', { cause: a });
+    a.cause = b;
+    expect(() => describeFailure(a)).not.toThrow();
+    expect(describeFailure(a)).toContain('circular');
+  });
+
+  it('has no access to process.env, so it cannot itself introduce a leak', () => {
+    // Structural guarantee, exercised rather than merely asserted: build an
+    // error whose message contains a value that looks like a secret, and
+    // confirm describeFailure's output contains exactly that value and
+    // nothing appended from the environment.
+    const originalToken = process.env['METRICS_TOKEN'];
+    process.env['METRICS_TOKEN'] = 'ghp_shouldNeverAppearHere';
+    try {
+      const rendered = describeFailure(new Error('unrelated failure'));
+      expect(rendered).not.toContain('ghp_shouldNeverAppearHere');
+    } finally {
+      if (originalToken === undefined) {
+        delete process.env['METRICS_TOKEN'];
+      } else {
+        process.env['METRICS_TOKEN'] = originalToken;
+      }
+    }
+  });
+});

--- a/scripts/metrics/src/cli-support.ts
+++ b/scripts/metrics/src/cli-support.ts
@@ -1,0 +1,163 @@
+import { GitHubError } from './github.ts';
+import type { CollectResult } from './collect.ts';
+import type { IsoDate } from './types.ts';
+
+/**
+ * Reads and validates one required environment variable.
+ *
+ * Rejects `undefined`, the empty string, and a whitespace-only value alike —
+ * a workflow-injected secret with a stray trailing newline, or a step that
+ * exports an empty string instead of omitting the variable entirely, must
+ * fail here with a clear message rather than flow into
+ * `createClient`/`createStore` and produce a stream of 401s or `ENOENT`
+ * errors that read like an unrelated outage. The returned value is trimmed:
+ * the only realistic way whitespace reaches a GitHub Actions env var is
+ * accidental (a trailing newline picked up from a prior step's output),
+ * never a value where the whitespace is meaningful.
+ *
+ * Takes `env` as a parameter rather than reading `process.env` itself so
+ * this function stays a pure, unit-testable helper — `cli-collect.ts` and
+ * `cli-backfill.ts` are the only two places in this package allowed to read
+ * the real `process.env`, and both do so by passing it in here.
+ */
+export function requiredEnv(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string {
+  const raw = env[name];
+  if (raw === undefined) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  const value = raw.trim();
+  if (value === '') {
+    throw new Error(
+      `Missing required environment variable ${name} (present but empty or whitespace-only)`,
+    );
+  }
+  return value;
+}
+
+/** Matches any C0 control character or DEL — none of which are legal in an HTTP header value. */
+const HEADER_UNSAFE_RE = /[\x00-\x1f\x7f]/;
+
+/**
+ * Rejects a token containing control characters (a newline, a tab, or any
+ * other C0/DEL byte) before it can ever reach
+ * `Authorization: Bearer <token>`.
+ *
+ * This is not a hypothetical concern. Verified directly against this
+ * package's own Node version: a newline embedded in a header value makes
+ * `fetch`'s underlying `Headers` implementation throw a `TypeError` whose
+ * *message* is `Headers.append: "Bearer <the entire broken value>" is an
+ * invalid header value.` — the secret, verbatim, inside the exception text.
+ * `github.ts`'s `createClient` builds exactly that header from the raw
+ * token, and this CLI's top-level catch prints whatever any thrown error
+ * says. Without this guard, a malformed `METRICS_TOKEN` would put the
+ * secret straight into a public CI log via that one code path. This check
+ * exists so that path is never reached: a malformed token fails here first,
+ * with a message that names the problem without repeating the value.
+ */
+export function assertHeaderSafeToken(token: string): void {
+  if (HEADER_UNSAFE_RE.test(token)) {
+    throw new Error(
+      'METRICS_TOKEN contains a control character (e.g. a newline or tab) and cannot be sent as an HTTP header value',
+    );
+  }
+}
+
+/**
+ * Derives this run's `now` and `today` from the system clock, both UTC.
+ *
+ * `Date#toISOString` is always UTC by spec, independent of the host's local
+ * timezone or `process.env.TZ`, so slicing its first 10 characters already
+ * is the correct UTC calendar day — no explicit UTC getters are needed, and
+ * none should be added. `getDate()`/`getMonth()`/`getFullYear()` (and
+ * anything built on them, e.g. `toLocaleDateString`) read the LOCAL
+ * calendar day and would silently misfile a run's data under the wrong
+ * date for any host not running in UTC — exactly the failure `collect.ts`
+ * requires `today` never suffer from, since the archive treats every date
+ * as a UTC calendar day.
+ */
+export function deriveRunTimestamps(date: Date): { now: string; today: IsoDate } {
+  const now = date.toISOString();
+  const today: IsoDate = now.slice(0, 10);
+  return { now, today };
+}
+
+/** Formats `collect`'s result as the lines a maintainer reading the run log should see. */
+export function formatCollectSummary(result: CollectResult): string[] {
+  const lines = [`wrote: ${result.written.join(', ')}`];
+  if (result.skipped.length > 0) {
+    lines.push(`skipped (left at previous value): ${result.skipped.join(', ')}`);
+  }
+  return lines;
+}
+
+/**
+ * Formats `backfill`'s result for the run log.
+ *
+ * Deliberately does not call this list "written" the way `collect`'s output
+ * does: `backfill`'s `written` field is the fixed, exhaustive set of files
+ * it is PERMITTED to touch (`WRITABLE` in `backfill.ts`), not the set that
+ * actually changed on this run — every write there is if-absent, so a
+ * rerun against an already-seeded archive legitimately reports the same
+ * list while changing nothing on disk. Phrasing it as "target files" here,
+ * with the if-absent caveat spelled out, keeps a maintainer from reading
+ * this line the same way they'd read `collect`'s `wrote:` line and
+ * concluding new history was recovered when none was.
+ */
+export function formatBackfillSummary(result: { written: string[] }): string {
+  return `backfill target files (write-if-absent, listed whether or not they changed this run): ${result.written.join(', ')}`;
+}
+
+/**
+ * Renders a thrown value, and its full `cause` chain, for a CI log.
+ *
+ * Takes only `error: unknown` — never `process.env` or any credential — so
+ * this function is structurally incapable of printing a secret: there is
+ * nothing here for it to read one from. The only way a token could reach
+ * this function's output is if it were already embedded in a thrown error's
+ * `message` upstream, which is exactly what `assertHeaderSafeToken` exists
+ * to prevent before any request is ever made.
+ *
+ * Walks `.cause` (as `Store` and `GitHubClient` both use it to wrap lower-
+ * level failures — a raw `ENOSPC`, an unparseable response body) so a
+ * maintainer sees every layer, not just the outermost message. Bounded to
+ * 10 levels and tracked with a `seen` set purely as a defensive backstop
+ * against a pathological or circular `cause` chain looping this function
+ * forever in a scheduled job with no one watching it; no code in this
+ * package is expected to ever produce one.
+ */
+export function describeFailure(error: unknown): string {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  let guard = 0;
+
+  while (guard < 10) {
+    guard += 1;
+    if (typeof current === 'object' && current !== null) {
+      if (seen.has(current)) {
+        parts.push('[circular cause reference — stopping]');
+        break;
+      }
+      seen.add(current);
+    }
+
+    if (current instanceof GitHubError) {
+      parts.push(`GitHub API error (status ${current.status}): ${current.stack ?? current.message}`);
+    } else if (current instanceof Error) {
+      parts.push(current.stack ?? current.message);
+    } else {
+      parts.push(`Non-Error value thrown: ${String(current)}`);
+      break;
+    }
+
+    const cause = current instanceof Error ? current.cause : undefined;
+    if (cause === undefined) break;
+    parts.push('Caused by:');
+    current = cause;
+  }
+
+  return parts.join('\n');
+}

--- a/scripts/metrics/src/cli-support.ts
+++ b/scripts/metrics/src/cli-support.ts
@@ -1,5 +1,6 @@
 import { GitHubError } from './github.ts';
 import type { CollectResult } from './collect.ts';
+import type { Meta, Store } from './store.ts';
 import type { IsoDate } from './types.ts';
 
 /**
@@ -108,6 +109,74 @@ export function formatCollectSummary(result: CollectResult): string[] {
  */
 export function formatBackfillSummary(result: { written: string[] }): string {
   return `backfill target files (write-if-absent, listed whether or not they changed this run): ${result.written.join(', ')}`;
+}
+
+/**
+ * Records that a run did not complete successfully, by reading the existing
+ * `meta.json` (through `store`) and writing a new one that reflects the
+ * failure.
+ *
+ * This is the testable core behind `cli-record-failure.ts`, which is
+ * invoked by `metrics.yml`'s "Record failure" step — the third and final
+ * writer this package needs, on the one path where `collect()`'s own
+ * atomic write never ran at all (a required fetch failed, or a later step
+ * such as the data commit/push failed after `collect()` succeeded).
+ *
+ * Two fields are refreshed to reflect THIS failure:
+ * - `last_run` becomes `now`, unconditionally — every invocation of this
+ *   package, successful or not, updates it.
+ * - `error` becomes `reason` — the caller's description of what failed.
+ *
+ * Two fields are carried forward from `previous` completely UNCHANGED,
+ * never merged or partially updated:
+ * - `last_success` is the archive's "last known good" signal (see
+ *   `collect.ts`, which is the only place that ever advances it). A failed
+ *   run did not succeed, so this function must never write a new value
+ *   into it, not even `now` — that would make a failure look like a
+ *   success to anything reading `meta.json`.
+ * - `series_last_date` records what was actually measured on the last
+ *   successful run. A failed run measured nothing, so it must not add,
+ *   remove, or alter a single key — doing so would fabricate a
+ *   measurement that never happened, exactly the "plausible-looking data"
+ *   this whole package's fail-loud contract exists to prevent.
+ *
+ * `previous === null` is the legitimate first-run-ever-fails case (a run
+ * can fail before `collect()` has ever written a `meta.json`, e.g. the very
+ * first scheduled run hits a required-fetch error): `last_success: null`
+ * ("nothing has ever succeeded") and `series_last_date: {}` ("nothing has
+ * ever been measured") are the correct initial values here, not
+ * placeholders standing in for a crash.
+ *
+ * A corrupt `meta.json` is NOT handled here — `store.readMeta()` throws
+ * before this function does anything else, and that throw is left to
+ * propagate rather than caught and papered over. Writing a fresh-looking
+ * `meta.json` over a corrupt one the moment this function can't make sense
+ * of it would be exactly the kind of "coerce bad input into something
+ * plausible" this package's fail-loud contract forbids — a corrupt
+ * `meta.json` needs a human, not a silent rewrite.
+ *
+ * Takes a `Store` rather than a `dataDir` string so this stays a pure,
+ * unit-testable function backed by a real per-test store (as every other
+ * store-touching test in this package does) — `cli-record-failure.ts` is
+ * the only place in this package allowed to construct that `Store` from
+ * `process.env`.
+ */
+export function recordFailure(store: Store, now: string, reason: string): Meta {
+  const previous = store.readMeta();
+  const meta: Meta = {
+    last_run: now,
+    last_success: previous?.last_success ?? null,
+    error: reason,
+    series_last_date: previous?.series_last_date ?? {},
+  };
+  store.writeMeta(meta);
+  return meta;
+}
+
+/** Formats `recordFailure`'s result as the line a maintainer reading the run log should see. */
+export function formatRecordFailureSummary(meta: Meta): string {
+  const lastSuccess = meta.last_success ?? 'never';
+  return `recorded failure: ${meta.error ?? ''} (last_success: ${lastSuccess})`;
 }
 
 /**

--- a/scripts/metrics/src/collect.test.ts
+++ b/scripts/metrics/src/collect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -209,11 +209,16 @@ describe('collect', () => {
   // optional-fetch field (downloads_total, from releases) into one row. The
   // naive `releases === null ? 0 : sum(...)` collapse writes a permanent lie
   // — a zero for a download count GitHub simply never returned this run —
-  // into a file that otherwise only ever holds measured values. These cases
-  // pin the corrected behavior: carry the last known value forward when one
-  // exists, and skip the whole row (never invent zero) when none does.
+  // into a file that otherwise only ever holds measured values. Carrying the
+  // last known value forward is not a fix either: it writes yesterday's
+  // measurement under today's date, an undetectable plateau indistinguishable
+  // from a genuinely quiet week. These cases pin the corrected behavior: the
+  // required fields are always written, and an unmeasured `downloads_total`
+  // is left blank — never fabricated, never used as an excuse to discard
+  // `subscribers`/`open_issues`, which were fetched successfully regardless
+  // of what `releases` did.
 
-  it('carries forward the previous downloads_total instead of writing a zero when releases fails', async () => {
+  it('leaves downloads_total blank rather than carrying the previous value forward when releases fails', async () => {
     const store = createStore(dir);
     store.writeCsv(
       'repo.csv',
@@ -222,20 +227,44 @@ describe('collect', () => {
     );
     const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
     const result = await collect({ client, store, ...base });
-    expect(store.readCsv('repo.csv')).toEqual([
+    const rows = store.readCsv('repo.csv');
+    expect(rows).toEqual([
       { date: '2026-08-24', subscribers: '1', open_issues: '10', downloads_total: '25' },
-      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '25' },
+      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '' },
     ]);
+    expect(rows[1]?.downloads_total).toBe('');
+    expect(rows[1]?.subscribers).toBe('1');
+    expect(rows[1]?.open_issues).toBe('13');
     expect(result.skipped).toContain('repo.csv:downloads_total');
+    expect(result.written).toContain('repo.csv');
   });
 
-  it('skips writing repo.csv entirely when releases fails with no prior downloads_total on record', async () => {
+  it('still writes repo.csv with real subscribers/open_issues when releases fails on the very first run', async () => {
     const store = createStore(dir);
     const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
     const result = await collect({ client, store, ...base });
-    expect(store.readCsv('repo.csv')).toEqual([]);
-    expect(result.skipped).toContain('repo.csv');
+    expect(store.readCsv('repo.csv')).toEqual([
+      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '' },
+    ]);
+    expect(result.skipped).toContain('repo.csv:downloads_total');
+    expect(result.skipped).not.toContain('repo.csv');
+    expect(result.written).toContain('repo.csv');
     expect(store.readCsv('stars.csv')).toEqual([{ date: '2026-08-25', total: '56' }]);
+  });
+
+  it('leaves a previously blank downloads_total untouched while the new day carries its real value', async () => {
+    const store = createStore(dir);
+    store.writeCsv(
+      'repo.csv',
+      ['date', 'subscribers', 'open_issues', 'downloads_total'],
+      [{ date: '2026-08-24', subscribers: 1, open_issues: 10, downloads_total: '' }],
+    );
+    const result = await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('repo.csv')).toEqual([
+      { date: '2026-08-24', subscribers: '1', open_issues: '10', downloads_total: '' },
+      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '37' },
+    ]);
+    expect(result.skipped).not.toContain('repo.csv:downloads_total');
   });
 
   it('computes a cumulative contributor count from each contributor first commit week', async () => {

--- a/scripts/metrics/src/collect.test.ts
+++ b/scripts/metrics/src/collect.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createStore } from './store.ts';
 import { collect } from './collect.ts';
+import { createClient } from './github.ts';
 import type { GitHubClient } from './github.ts';
 
 let dir = '';
@@ -67,8 +68,20 @@ function fakeClient(overrides: Partial<Record<string, unknown>> = {}): GitHubCli
       if (p === '/repos/o/r/stats/contributors') return CONTRIBUTORS as T;
       return null;
     },
-    async paginate<T>(): Promise<T[]> {
-      throw new Error('collect must not paginate');
+    async paginate<T>(p: string): Promise<T[]> {
+      // Releases is the one endpoint collect.ts is required to paginate
+      // (GitHub's default page size of 30 would otherwise silently truncate
+      // the release list and undercount downloads_total) — every other
+      // required fetch still goes through plain `get`, and must keep doing
+      // so, so this fake still fails loudly if collect.ts ever starts
+      // paginating something it shouldn't.
+      if (p !== '/repos/o/r/releases') {
+        throw new Error(`collect must not paginate ${p}`);
+      }
+      const value = routes[p];
+      if (value instanceof Error) throw value;
+      if (value === undefined) throw new Error(`unexpected paginate ${p}`);
+      return value as T[];
     },
   };
 }
@@ -133,6 +146,98 @@ describe('collect', () => {
     expect(store.readCsv('releases.csv')).toEqual([
       { date: '2026-08-01', tag: 'v1.0.0', name: 'Backspace 1.0.0' },
     ]);
+  });
+
+  it('sums downloads across every page of a paginated /releases response', async () => {
+    // GitHub's default page size is 30, so a plain (unpaginated) fetch would
+    // silently sum only the 30 most recent releases. Wired through the real
+    // createClient (not the higher-level fakeClient above) so this actually
+    // exercises Link: rel="next" following, not just that collect.ts calls
+    // client.paginate.
+    const store = createStore(dir);
+    const routes: Record<string, unknown> = {
+      'https://api.github.com/repos/o/r/traffic/views': VIEWS,
+      'https://api.github.com/repos/o/r/traffic/clones': CLONES,
+      'https://api.github.com/repos/o/r/traffic/popular/referrers': REFERRERS,
+      'https://api.github.com/repos/o/r/traffic/popular/paths': PATHS,
+      'https://api.github.com/repos/o/r': REPO,
+    };
+    const page1 = [
+      { tag_name: 'v2.0.0', name: 'v2.0.0', published_at: '2026-08-10T00:00:00Z', assets: [{ download_count: 5 }] },
+    ];
+    const page2 = [
+      { tag_name: 'v1.0.0', name: 'v1.0.0', published_at: '2026-08-01T00:00:00Z', assets: [{ download_count: 7 }] },
+    ];
+    const fetchImpl = (async (url: string) => {
+      if (url === 'https://api.github.com/repos/o/r/releases?per_page=100') {
+        return new Response(JSON.stringify(page1), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            link: '<https://api.github.com/repos/o/r/releases?per_page=100&page=2>; rel="next"',
+          },
+        });
+      }
+      if (url === 'https://api.github.com/repos/o/r/releases?per_page=100&page=2') {
+        return new Response(JSON.stringify(page2), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://api.github.com/repos/o/r/stats/contributors') {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      const value = routes[url];
+      if (value === undefined) throw new Error(`unexpected fetch ${url}`);
+      return new Response(JSON.stringify(value), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+    const client = createClient('tok', { fetchImpl, sleep: async () => {} });
+    await collect({ client, store, ...base });
+    const rows = store.readCsv('repo.csv');
+    expect(rows[0]?.downloads_total).toBe('12');
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'v1.0.0' },
+      { date: '2026-08-10', tag: 'v2.0.0', name: 'v2.0.0' },
+    ]);
+  });
+
+  it('keeps both releases when two are published on the same UTC day', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({
+      '/repos/o/r/releases': [
+        {
+          tag_name: 'v1.0.1',
+          name: 'v1.0.1',
+          published_at: '2026-08-01T18:00:00Z',
+          assets: [],
+        },
+        {
+          tag_name: 'v1.0.0',
+          name: 'v1.0.0',
+          published_at: '2026-08-01T09:00:00Z',
+          assets: [],
+        },
+      ],
+    });
+    await collect({ client, store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'v1.0.0' },
+      { date: '2026-08-01', tag: 'v1.0.1', name: 'v1.0.1' },
+    ]);
+  });
+
+  it('is idempotent for releases.csv across repeated runs', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const first = store.readCsv('releases.csv');
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual(first);
   });
 
   it('aborts the entire write when a required traffic fetch fails', async () => {

--- a/scripts/metrics/src/collect.test.ts
+++ b/scripts/metrics/src/collect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createStore } from './store.ts';
@@ -389,5 +389,58 @@ describe('collect', () => {
     const result = await collect({ client, store, ...base });
     expect(store.readCsv('contributors.csv')).toEqual([]);
     expect(result.skipped).toContain('contributors.csv');
+  });
+
+  // --- series_last_date: seeded from the previous meta.json rather than
+  // built solely from `written` (this run's touched files). A skipped
+  // series then keeps its last real date instead of disappearing from the
+  // map entirely — the whole point of the field per
+  // docs/systems/metrics.md, since a disappearance is far harder to notice
+  // than a date that stopped advancing.
+
+  it('keeps a skipped series previous series_last_date entry instead of dropping it', async () => {
+    const store = createStore(dir);
+    store.writeMeta({
+      last_run: '2026-08-24T03:00:00Z',
+      last_success: '2026-08-24T03:00:00Z',
+      error: null,
+      series_last_date: { 'releases.csv': '2026-07-15' },
+    });
+    const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
+    const result = await collect({ client, store, ...base });
+    expect(result.skipped).toContain('releases.csv');
+    expect(store.readMeta()?.series_last_date['releases.csv']).toBe('2026-07-15');
+  });
+
+  it('gives a written series a fresh series_last_date, overwriting any seeded value', async () => {
+    const store = createStore(dir);
+    store.writeMeta({
+      last_run: '2026-08-24T03:00:00Z',
+      last_success: '2026-08-24T03:00:00Z',
+      error: null,
+      series_last_date: { 'stars.csv': '2020-01-01' },
+    });
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readMeta()?.series_last_date['stars.csv']).toBe('2026-08-25');
+  });
+
+  it('produces a well-formed series_last_date on the very first run with no prior meta.json', async () => {
+    const store = createStore(dir);
+    expect(store.readMeta()).toBeNull();
+    const result = await collect({ client: fakeClient(), store, ...base });
+    expect(result.written).toContain('stars.csv');
+    const meta = store.readMeta();
+    expect(meta?.series_last_date['stars.csv']).toBe('2026-08-25');
+    expect(meta?.series_last_date['traffic/views.csv']).toBe('2026-08-24');
+  });
+
+  it('throws before writing anything when the existing meta.json is corrupt', async () => {
+    const store = createStore(dir);
+    writeFileSync(path.join(dir, 'meta.json'), '{ not valid json', 'utf8');
+    const client = fakeClient();
+    await expect(collect({ client, store, ...base })).rejects.toThrow();
+    expect(store.readCsv('traffic/views.csv')).toEqual([]);
+    expect(store.readCsv('stars.csv')).toEqual([]);
+    expect(store.readCsv('repo.csv')).toEqual([]);
   });
 });

--- a/scripts/metrics/src/collect.test.ts
+++ b/scripts/metrics/src/collect.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createStore } from './store.ts';
+import { collect } from './collect.ts';
+import type { GitHubClient } from './github.ts';
+
+let dir = '';
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'metrics-collect-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const VIEWS = {
+  views: [
+    { timestamp: '2026-08-23T00:00:00Z', count: 40, uniques: 12 },
+    { timestamp: '2026-08-24T00:00:00Z', count: 51, uniques: 15 },
+  ],
+};
+const CLONES = {
+  clones: [{ timestamp: '2026-08-24T00:00:00Z', count: 4, uniques: 3 }],
+};
+const REFERRERS = [{ referrer: 'news.ycombinator.com', count: 118, uniques: 94 }];
+const PATHS = [{ path: '/TheZwiss/backspace', title: 'Backspace', count: 402, uniques: 161 }];
+const REPO = {
+  stargazers_count: 56,
+  forks_count: 3,
+  subscribers_count: 1,
+  open_issues_count: 13,
+};
+const RELEASES = [
+  {
+    tag_name: 'v1.0.0',
+    name: 'Backspace 1.0.0',
+    published_at: '2026-08-01T10:00:00Z',
+    assets: [{ download_count: 20 }, { download_count: 17 }],
+  },
+];
+const CONTRIBUTORS = [{ weeks: [{ w: 1771200000, c: 3 }] }, { weeks: [{ w: 1771804800, c: 1 }] }];
+
+function fakeClient(overrides: Partial<Record<string, unknown>> = {}): GitHubClient {
+  const routes: Record<string, unknown> = {
+    '/repos/o/r/traffic/views': VIEWS,
+    '/repos/o/r/traffic/clones': CLONES,
+    '/repos/o/r/traffic/popular/referrers': REFERRERS,
+    '/repos/o/r/traffic/popular/paths': PATHS,
+    '/repos/o/r': REPO,
+    '/repos/o/r/releases': RELEASES,
+    ...overrides,
+  };
+  return {
+    async get<T>(p: string): Promise<T> {
+      const value = routes[p];
+      if (value instanceof Error) throw value;
+      if (value === undefined) throw new Error(`unexpected GET ${p}`);
+      return value as T;
+    },
+    async getStats<T>(p: string): Promise<T | null> {
+      if (Object.prototype.hasOwnProperty.call(overrides, p)) {
+        return overrides[p] as T | null;
+      }
+      if (p === '/repos/o/r/stats/contributors') return CONTRIBUTORS as T;
+      return null;
+    },
+    async paginate<T>(): Promise<T[]> {
+      throw new Error('collect must not paginate');
+    },
+  };
+}
+
+const base = { slug: 'o/r', today: '2026-08-25', now: '2026-08-25T03:00:41Z' };
+
+describe('collect', () => {
+  it('writes traffic keyed by the bucket date, not by today', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('traffic/views.csv')).toEqual([
+      { date: '2026-08-23', count: '40', uniques: '12' },
+      { date: '2026-08-24', count: '51', uniques: '15' },
+    ]);
+  });
+
+  it('does not invent a row for today when the window ends yesterday', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const dates = store.readCsv('traffic/views.csv').map((r) => r.date);
+    expect(dates).not.toContain('2026-08-25');
+  });
+
+  it('tags dimensional snapshots with today', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const rows = store.readNdjson('traffic/referrers.ndjson');
+    expect(rows).toEqual([
+      {
+        snapshot_date: '2026-08-25',
+        dimension: 'news.ycombinator.com',
+        title: '',
+        count: 118,
+        uniques: 94,
+      },
+    ]);
+  });
+
+  it('writes stars and forks from the repo object counters, dated today', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('stars.csv')).toEqual([{ date: '2026-08-25', total: '56' }]);
+    expect(store.readCsv('forks.csv')).toEqual([{ date: '2026-08-25', total: '3' }]);
+  });
+
+  it('sums every asset download count into repo.csv', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('repo.csv')).toEqual([
+      {
+        date: '2026-08-25',
+        subscribers: '1',
+        open_issues: '13',
+        downloads_total: '37',
+      },
+    ]);
+  });
+
+  it('records release publish dates for the growth-chart annotations', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('releases.csv')).toEqual([
+      { date: '2026-08-01', tag: 'v1.0.0', name: 'Backspace 1.0.0' },
+    ]);
+  });
+
+  it('aborts the entire write when a required traffic fetch fails', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({ '/repos/o/r/traffic/clones': new Error('boom') });
+    await expect(collect({ client, store, ...base })).rejects.toThrow('boom');
+    expect(store.readCsv('traffic/views.csv')).toEqual([]);
+    expect(store.readCsv('stars.csv')).toEqual([]);
+    expect(store.readMeta()).toBeNull();
+  });
+
+  it('skips contributors on a persistent 202 without writing a zero', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({ '/repos/o/r/stats/contributors': null });
+    const result = await collect({ client, store, ...base });
+    expect(store.readCsv('contributors.csv')).toEqual([]);
+    expect(result.skipped).toContain('contributors.csv');
+    expect(store.readCsv('traffic/views.csv')).not.toEqual([]);
+  });
+
+  it('preserves a previous contributor value when the stats endpoint is computing', async () => {
+    const store = createStore(dir);
+    store.writeCsv('contributors.csv', ['date', 'total'], [{ date: '2026-08-24', total: 4 }]);
+    const client = fakeClient({ '/repos/o/r/stats/contributors': null });
+    await collect({ client, store, ...base });
+    expect(store.readCsv('contributors.csv')).toEqual([{ date: '2026-08-24', total: '4' }]);
+  });
+
+  it('skips releases without aborting when that optional fetch fails', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
+    const result = await collect({ client, store, ...base });
+    expect(result.skipped).toContain('releases.csv');
+    expect(store.readCsv('traffic/views.csv')).not.toEqual([]);
+  });
+
+  it('is idempotent: a second run over the same data changes nothing', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const first = store.readCsv('traffic/views.csv');
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('traffic/views.csv')).toEqual(first);
+  });
+
+  it('merges a new window over existing history without duplicating dates', async () => {
+    const store = createStore(dir);
+    store.writeCsv(
+      'traffic/views.csv',
+      ['date', 'count', 'uniques'],
+      [
+        { date: '2026-08-01', count: 5, uniques: 2 },
+        { date: '2026-08-23', count: 1, uniques: 1 },
+      ],
+    );
+    await collect({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('traffic/views.csv');
+    expect(rows.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-23', '2026-08-24']);
+    expect(rows[1]?.count).toBe('40');
+  });
+
+  it('writes meta.json with last_success and per-file high-water marks', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const meta = store.readMeta();
+    expect(meta?.last_run).toBe('2026-08-25T03:00:41Z');
+    expect(meta?.last_success).toBe('2026-08-25T03:00:41Z');
+    expect(meta?.error).toBeNull();
+    expect(meta?.series_last_date['traffic/views.csv']).toBe('2026-08-24');
+    expect(meta?.series_last_date['stars.csv']).toBe('2026-08-25');
+  });
+
+  // --- Beyond the brief's given cases: repo.csv bundles a required-fetch
+  // field (subscribers/open_issues, from the repo object) with an
+  // optional-fetch field (downloads_total, from releases) into one row. The
+  // naive `releases === null ? 0 : sum(...)` collapse writes a permanent lie
+  // — a zero for a download count GitHub simply never returned this run —
+  // into a file that otherwise only ever holds measured values. These cases
+  // pin the corrected behavior: carry the last known value forward when one
+  // exists, and skip the whole row (never invent zero) when none does.
+
+  it('carries forward the previous downloads_total instead of writing a zero when releases fails', async () => {
+    const store = createStore(dir);
+    store.writeCsv(
+      'repo.csv',
+      ['date', 'subscribers', 'open_issues', 'downloads_total'],
+      [{ date: '2026-08-24', subscribers: 1, open_issues: 10, downloads_total: 25 }],
+    );
+    const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
+    const result = await collect({ client, store, ...base });
+    expect(store.readCsv('repo.csv')).toEqual([
+      { date: '2026-08-24', subscribers: '1', open_issues: '10', downloads_total: '25' },
+      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '25' },
+    ]);
+    expect(result.skipped).toContain('repo.csv:downloads_total');
+  });
+
+  it('skips writing repo.csv entirely when releases fails with no prior downloads_total on record', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
+    const result = await collect({ client, store, ...base });
+    expect(store.readCsv('repo.csv')).toEqual([]);
+    expect(result.skipped).toContain('repo.csv');
+    expect(store.readCsv('stars.csv')).toEqual([{ date: '2026-08-25', total: '56' }]);
+  });
+
+  it('computes a cumulative contributor count from each contributor first commit week', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('contributors.csv')).toEqual([
+      { date: '2026-02-16', total: '1' },
+      { date: '2026-02-23', total: '2' },
+    ]);
+  });
+
+  it('skips contributors.csv without writing when no contributor has a positive-commit week', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({
+      '/repos/o/r/stats/contributors': [{ weeks: [{ w: 1771200000, c: 0 }] }],
+    });
+    const result = await collect({ client, store, ...base });
+    expect(store.readCsv('contributors.csv')).toEqual([]);
+    expect(result.skipped).toContain('contributors.csv');
+  });
+});

--- a/scripts/metrics/src/collect.ts
+++ b/scripts/metrics/src/collect.ts
@@ -215,6 +215,12 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   // so this merges with `upsertByKey` keyed on `tag` instead, and sorts with
   // `compareReleaseRows` (date, then tag) so the output stays byte-stable
   // regardless of which same-day release the API happened to list first.
+  //
+  // That stability has a second, load-bearing half worth stating: `formatCsv`
+  // re-sorts by the header's first column (`date`) before writing, so the tag
+  // ordering established here survives only because `Array.prototype.sort` is
+  // stable (guaranteed since ES2019). Anyone changing either comparator has to
+  // keep both halves in mind, not just this one.
   function writeReleases(file: string, incoming: readonly ReleaseRow[]): void {
     const existing = store.readCsv(file) as unknown as ReleaseRow[];
     const merged = upsertByKey(existing, incoming, (row) => row.tag, 'overwrite', compareReleaseRows);

--- a/scripts/metrics/src/collect.ts
+++ b/scripts/metrics/src/collect.ts
@@ -82,23 +82,6 @@ function toTraffic(buckets: TrafficBucket[]): TrafficPoint[] {
 }
 
 /**
- * Reads the most recently recorded `downloads_total` from `repo.csv`, or
- * `undefined` when there is no usable prior value (no row yet, or the last
- * row's value doesn't parse as a finite number).
- *
- * Backs the fallback path when the optional `releases` fetch fails: see the
- * long comment on `collect` for why this exists at all rather than the
- * simpler `releases === null ? 0 : sum(...)` this replaced.
- */
-function lastKnownDownloadsTotal(store: Store): number | undefined {
-  const rows = store.readCsv('repo.csv');
-  const last = rows[rows.length - 1];
-  if (last === undefined) return undefined;
-  const value = Number(last['downloads_total']);
-  return Number.isFinite(value) ? value : undefined;
-}
-
-/**
  * Runs the daily collection.
  *
  * Atomicity is the whole design of this function, constructed rather than
@@ -171,15 +154,18 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   // optional `releases` fetch. `releases === null ? 0 : sum(...)` — summing
   // to zero when the fetch failed — would write a permanent lie: a zero
   // recorded for a download count GitHub simply never returned this run,
-  // indistinguishable later from a genuine zero. When `releases` fetched
-  // cleanly the sum is authoritative and always wins. When it didn't, the
-  // last value this file actually recorded is carried forward instead of
-  // invented — mirroring the same "leave the previous value alone" contract
-  // `getStats`'s null already imposes on contributors — and if there is no
-  // prior value to carry (first run, or a fetch failure on day one), the
-  // whole `repo.csv` row is skipped rather than writing an undefined value
-  // as if it were measured.
-  let downloadsTotal: number | undefined;
+  // indistinguishable later from a genuine zero. Carrying the previous run's
+  // value forward under today's date is not a safer alternative: it writes a
+  // plausible, undetectable plateau, worse than the zero it would replace,
+  // since a zero at least self-flags as anomalous for a cumulative counter.
+  // When `releases` fetched cleanly the sum is authoritative and always
+  // wins. When it didn't, `downloads_total` is left `null` — rendered as a
+  // blank CSV field by `formatCsv` — rather than fabricated from history.
+  // `subscribers`/`open_issues` are unaffected either way: they come from
+  // the required repo-object fetch, which has already resolved successfully
+  // by the time this runs, so a `releases` failure never costs the row those
+  // two required fields.
+  let downloadsTotal: number | null;
   if (releases !== null) {
     downloadsTotal = releases.reduce(
       (sum, release) =>
@@ -187,8 +173,8 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
       0,
     );
   } else {
-    downloadsTotal = lastKnownDownloadsTotal(store);
-    if (downloadsTotal !== undefined) skipped.push('repo.csv:downloads_total');
+    downloadsTotal = null;
+    skipped.push('repo.csv:downloads_total');
   }
 
   const written: string[] = [];
@@ -254,24 +240,18 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   writeCsvSeries('stars.csv', ['date', 'total'], [stars]);
   writeCsvSeries('forks.csv', ['date', 'total'], [forks]);
 
-  if (downloadsTotal === undefined) {
-    // No fresh fetch and nothing on record to carry forward: writing a row
-    // here has no genuine value for `downloads_total` to put in it, so the
-    // whole row is skipped this run rather than inventing one.
-    skipped.push('repo.csv');
-  } else {
-    const repoPoint: RepoPoint = {
-      date: today,
-      subscribers: repo.subscribers_count,
-      open_issues: repo.open_issues_count,
-      downloads_total: downloadsTotal,
-    };
-    writeCsvSeries(
-      'repo.csv',
-      ['date', 'subscribers', 'open_issues', 'downloads_total'],
-      [repoPoint],
-    );
-  }
+  // Always written: `subscribers`/`open_issues` are required-fetch fields
+  // that have already resolved successfully by this point, so they are
+  // never held hostage to whether the unrelated optional `releases` fetch
+  // succeeded. `downloads_total` is `null` (blank on disk) exactly when it
+  // wasn't measured this run — see the comment above.
+  const repoPoint: RepoPoint = {
+    date: today,
+    subscribers: repo.subscribers_count,
+    open_issues: repo.open_issues_count,
+    downloads_total: downloadsTotal,
+  };
+  writeCsvSeries('repo.csv', ['date', 'subscribers', 'open_issues', 'downloads_total'], [repoPoint]);
 
   if (releases !== null) {
     const releaseRows: ReleaseRow[] = releases

--- a/scripts/metrics/src/collect.ts
+++ b/scripts/metrics/src/collect.ts
@@ -118,6 +118,23 @@ function toTraffic(buckets: TrafficBucket[]): TrafficPoint[] {
  * never produce a file the next run treats as authoritative. Optional
  * series degrade to a skip instead, because releases and contributor stats
  * are reconstructable at any later date while traffic is not.
+ *
+ * The write phase's own first action is a synchronous read, not a write:
+ * `store.readMeta()`, seeding `series_last_date` from the previous run so a
+ * series this run skips keeps its last real date instead of losing its
+ * entry entirely (see the seeding comment inline, and
+ * docs/systems/metrics.md). Reading before the first `store.write*` call —
+ * rather than later, alongside the read-back-after-write calls that build
+ * the rest of `meta.json` — means a corrupt existing `meta.json` throws
+ * before any file changes this run, extending the same all-or-nothing
+ * guarantee described above to this failure mode too: this package's
+ * fail-loud contract says a corrupt `meta.json` must not be silently
+ * rewritten into something plausible, and failing before any write is
+ * strictly better than failing after several files are already updated to
+ * today while `meta.json` alone is left stale and unreadable. `readMeta()`
+ * is `readFileSync` + `JSON.parse`, both synchronous, so this read
+ * introduces no `await` and does not weaken the no-interleaving guarantee
+ * above.
  */
 export async function collect(options: CollectOptions): Promise<CollectResult> {
   const { client, store, slug, today, now } = options;
@@ -185,6 +202,34 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   }
 
   const written: string[] = [];
+
+  // Seeds `series_last_date` from the previous successful run's meta.json,
+  // rather than building it purely from `written` (the files this run
+  // actually touches, computed below). Without this seed, a skipped
+  // optional series (e.g. `releases.csv` when that fetch fails) has no
+  // entry in `written`, so its key would simply vanish from the map — a
+  // disappearance, which docs/systems/metrics.md documents as far harder
+  // for a maintainer to notice than a date that stopped advancing. Seeding
+  // first and only overwriting keys for files actually written this run
+  // (see the loop that builds `seriesLastDate` further down) makes a
+  // stalled series visibly stall instead.
+  //
+  // Read here — as the first action of the write phase, before the first
+  // `store.write*` call below — rather than folded into the final
+  // `meta.json`-assembly step alongside the read-back-after-write
+  // `lastDate` calls. Placed here, a corrupt existing `meta.json` throws
+  // before ANY file changes this run, preserving the same all-or-nothing
+  // guarantee a required-fetch failure already has (see this function's
+  // top-level doc comment): a corrupt `meta.json` is not fabricatable into
+  // something plausible, so this package's fail-loud contract says to
+  // abort rather than guess, and aborting cleanly (before any write) is
+  // strictly better than aborting after five files are already updated to
+  // today and `meta.json` alone is left stale. `store.readMeta()` is
+  // `readFileSync` + `JSON.parse`, both synchronous — it introduces no
+  // `await`, so it does not break the no-interleaving guarantee the rest
+  // of this write phase depends on.
+  const previousMeta = store.readMeta();
+  const seriesLastDate: Record<string, IsoDate> = { ...(previousMeta?.series_last_date ?? {}) };
 
   // Generic over `T` rather than typed directly to `Record<string, string |
   // number>` at the call boundary: `TrafficPoint`, `CountPoint`, `RepoPoint`
@@ -324,7 +369,10 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
     return rows[rows.length - 1]?.date;
   };
 
-  const seriesLastDate: Record<string, IsoDate> = {};
+  // Overwrites only the keys this run actually wrote, onto the map already
+  // seeded above from the previous meta.json. A file not in `written` this
+  // run (a skipped optional series) simply keeps whatever seeded value it
+  // already had — see the seeding comment above for why.
   for (const file of written) {
     if (!file.endsWith('.csv')) continue;
     const last = lastDate(file);

--- a/scripts/metrics/src/collect.ts
+++ b/scripts/metrics/src/collect.ts
@@ -1,0 +1,332 @@
+import { upsertByDate, upsertDimensional } from './series.ts';
+import type { GitHubClient } from './github.ts';
+import type { Meta, Store } from './store.ts';
+import type {
+  CountPoint,
+  DimensionRow,
+  IsoDate,
+  ReleaseRow,
+  RepoPoint,
+  TrafficPoint,
+} from './types.ts';
+
+interface TrafficBucket {
+  timestamp: string;
+  count: number;
+  uniques: number;
+}
+interface ViewsResponse {
+  views: TrafficBucket[];
+}
+interface ClonesResponse {
+  clones: TrafficBucket[];
+}
+interface ReferrerResponse {
+  referrer: string;
+  count: number;
+  uniques: number;
+}
+interface PathResponse {
+  path: string;
+  title: string;
+  count: number;
+  uniques: number;
+}
+interface RepoResponse {
+  stargazers_count: number;
+  forks_count: number;
+  subscribers_count: number;
+  open_issues_count: number;
+}
+interface ReleaseResponse {
+  tag_name: string;
+  name: string | null;
+  published_at: string | null;
+  assets: Array<{ download_count: number }>;
+}
+interface ContributorResponse {
+  weeks: Array<{ w: number; c: number }>;
+}
+
+export interface CollectResult {
+  written: string[];
+  skipped: string[];
+}
+
+export interface CollectOptions {
+  client: GitHubClient;
+  store: Store;
+  /** `owner/repo`, from `github.repository`. */
+  slug: string;
+  /** Today in UTC, `YYYY-MM-DD`. Injected for deterministic tests. */
+  today: IsoDate;
+  /** Run timestamp, ISO 8601. Injected for deterministic tests. */
+  now: string;
+}
+
+/** Converts an ISO timestamp to its UTC calendar date. */
+function toDate(timestamp: string): IsoDate {
+  const date = timestamp.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Unparseable timestamp from the API: ${timestamp}`);
+  }
+  return date;
+}
+
+function toTraffic(buckets: TrafficBucket[]): TrafficPoint[] {
+  return buckets.map((bucket) => ({
+    date: toDate(bucket.timestamp),
+    count: bucket.count,
+    uniques: bucket.uniques,
+  }));
+}
+
+/**
+ * Reads the most recently recorded `downloads_total` from `repo.csv`, or
+ * `undefined` when there is no usable prior value (no row yet, or the last
+ * row's value doesn't parse as a finite number).
+ *
+ * Backs the fallback path when the optional `releases` fetch fails: see the
+ * long comment on `collect` for why this exists at all rather than the
+ * simpler `releases === null ? 0 : sum(...)` this replaced.
+ */
+function lastKnownDownloadsTotal(store: Store): number | undefined {
+  const rows = store.readCsv('repo.csv');
+  const last = rows[rows.length - 1];
+  if (last === undefined) return undefined;
+  const value = Number(last['downloads_total']);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Runs the daily collection.
+ *
+ * Atomicity is the whole design of this function, constructed rather than
+ * inherited from `Store` — the store's write path is atomic per file (a
+ * temp-write-then-rename), not across the several files one run touches.
+ * Every required series is fetched into memory (via `Promise.all`, which
+ * rejects on the first failure) before a single `store.write*` call is
+ * made, and every value derived from an optional fetch is fully computed
+ * before that point too. The result is that once the write phase begins,
+ * every `store.write*` call in it is synchronous (the store's read/write
+ * path uses Node's `*Sync` fs functions throughout) with no `await` between
+ * them — so there is no `await` point, and therefore no place the event
+ * loop could interleave a second run or hand control anywhere else, between
+ * the first file this run writes and the last. `meta.json` is written last
+ * of all, once every data file has landed, so its presence (and its
+ * `last_success` timestamp) is a completion marker a reader can trust: if a
+ * run dies before reaching it, `readMeta()` still reflects the previous
+ * run.
+ *
+ * The remaining failure window is real, not theoretical, and worth stating
+ * plainly rather than claiming perfect atomicity: a synchronous run of
+ * `writeFileSync`/`renameSync` calls still touches the OS one syscall at a
+ * time, so a hard process kill (OOM, `SIGKILL`) or an OS-level write error
+ * (`ENOSPC`, a permissions change mid-run) occurring between two of those
+ * syscalls can still leave some files updated to today and others holding
+ * yesterday's content, with `meta.json` in that case simply never reaching
+ * its update and so still pointing at the last run that DID complete. That
+ * window cannot be closed at this layer — `store.ts`'s own per-file write
+ * admits the same limit for a single file — only made as narrow as
+ * synchronous, no-`await`, meta-json-last sequencing can make it.
+ *
+ * A required failure propagates before any of that begins, leaving the data
+ * directory and `meta.json` completely untouched, so a half-failed run can
+ * never produce a file the next run treats as authoritative. Optional
+ * series degrade to a skip instead, because releases and contributor stats
+ * are reconstructable at any later date while traffic is not.
+ */
+export async function collect(options: CollectOptions): Promise<CollectResult> {
+  const { client, store, slug, today, now } = options;
+  const repoPath = `/repos/${slug}`;
+  const skipped: string[] = [];
+
+  // --- Required. Any rejection here aborts before any write. ---
+  const [views, clones, referrers, paths, repo] = await Promise.all([
+    client.get<ViewsResponse>(`${repoPath}/traffic/views`),
+    client.get<ClonesResponse>(`${repoPath}/traffic/clones`),
+    client.get<ReferrerResponse[]>(`${repoPath}/traffic/popular/referrers`),
+    client.get<PathResponse[]>(`${repoPath}/traffic/popular/paths`),
+    client.get<RepoResponse>(repoPath),
+  ]);
+
+  // --- Optional. A failure skips the series, never zeroes it. ---
+  let releases: ReleaseResponse[] | null = null;
+  try {
+    releases = await client.get<ReleaseResponse[]>(`${repoPath}/releases`);
+  } catch {
+    skipped.push('releases.csv');
+  }
+
+  let contributors: ContributorResponse[] | null = null;
+  try {
+    contributors = await client.getStats<ContributorResponse[]>(`${repoPath}/stats/contributors`);
+  } catch {
+    contributors = null;
+  }
+  if (contributors === null) skipped.push('contributors.csv');
+
+  // `downloads_total` is folded into `repo.csv` alongside the required
+  // `subscribers`/`open_issues` counters, but it is itself sourced from the
+  // optional `releases` fetch. `releases === null ? 0 : sum(...)` — summing
+  // to zero when the fetch failed — would write a permanent lie: a zero
+  // recorded for a download count GitHub simply never returned this run,
+  // indistinguishable later from a genuine zero. When `releases` fetched
+  // cleanly the sum is authoritative and always wins. When it didn't, the
+  // last value this file actually recorded is carried forward instead of
+  // invented — mirroring the same "leave the previous value alone" contract
+  // `getStats`'s null already imposes on contributors — and if there is no
+  // prior value to carry (first run, or a fetch failure on day one), the
+  // whole `repo.csv` row is skipped rather than writing an undefined value
+  // as if it were measured.
+  let downloadsTotal: number | undefined;
+  if (releases !== null) {
+    downloadsTotal = releases.reduce(
+      (sum, release) =>
+        sum + release.assets.reduce((assetSum, asset) => assetSum + asset.download_count, 0),
+      0,
+    );
+  } else {
+    downloadsTotal = lastKnownDownloadsTotal(store);
+    if (downloadsTotal !== undefined) skipped.push('repo.csv:downloads_total');
+  }
+
+  const written: string[] = [];
+
+  // Generic over `T` rather than typed directly to `Record<string, string |
+  // number>` at the call boundary: `TrafficPoint`, `CountPoint`, `RepoPoint`
+  // and `ReleaseRow` are all `interface` declarations, none of which carry
+  // an index signature, and TypeScript does not treat "every property
+  // happens to be `string | number`" as satisfying `Record<string, string |
+  // number>` for a nominally-declared interface — only the internal cast to
+  // `Record` (a controlled, single-purpose assertion, not `any`) bridges
+  // that gap, once per call, at the one place it's actually needed: handing
+  // rows to `store.writeCsv`, whose signature is necessarily untyped
+  // `Record` because the store has no knowledge of any specific series'
+  // shape.
+  function writeCsvSeries<T extends { date: IsoDate }>(
+    file: string,
+    header: readonly string[],
+    incoming: readonly T[],
+  ): void {
+    const existing = store.readCsv(file) as unknown as T[];
+    const merged = upsertByDate(existing, incoming, 'overwrite');
+    store.writeCsv(file, header, merged as unknown as Array<Record<string, string | number>>);
+    written.push(file);
+  }
+
+  function writeDimensional(file: string, incoming: readonly DimensionRow[]): void {
+    const merged = upsertDimensional(store.readNdjson(file), incoming);
+    store.writeNdjson(file, merged);
+    written.push(file);
+  }
+
+  writeCsvSeries('traffic/views.csv', ['date', 'count', 'uniques'], toTraffic(views.views));
+  writeCsvSeries('traffic/clones.csv', ['date', 'count', 'uniques'], toTraffic(clones.clones));
+
+  writeDimensional(
+    'traffic/referrers.ndjson',
+    referrers.map((item) => ({
+      snapshot_date: today,
+      dimension: item.referrer,
+      title: '',
+      count: item.count,
+      uniques: item.uniques,
+    })),
+  );
+  writeDimensional(
+    'traffic/paths.ndjson',
+    paths.map((item) => ({
+      snapshot_date: today,
+      dimension: item.path,
+      title: item.title,
+      count: item.count,
+      uniques: item.uniques,
+    })),
+  );
+
+  // Stars and forks come from the repo object's counters rather than by listing
+  // stargazers. That is a point-in-time measurement, so it correctly reflects
+  // people who starred and later unstarred — which the backfill, working from
+  // `starred_at`, structurally cannot see.
+  const stars: CountPoint = { date: today, total: repo.stargazers_count };
+  const forks: CountPoint = { date: today, total: repo.forks_count };
+  writeCsvSeries('stars.csv', ['date', 'total'], [stars]);
+  writeCsvSeries('forks.csv', ['date', 'total'], [forks]);
+
+  if (downloadsTotal === undefined) {
+    // No fresh fetch and nothing on record to carry forward: writing a row
+    // here has no genuine value for `downloads_total` to put in it, so the
+    // whole row is skipped this run rather than inventing one.
+    skipped.push('repo.csv');
+  } else {
+    const repoPoint: RepoPoint = {
+      date: today,
+      subscribers: repo.subscribers_count,
+      open_issues: repo.open_issues_count,
+      downloads_total: downloadsTotal,
+    };
+    writeCsvSeries(
+      'repo.csv',
+      ['date', 'subscribers', 'open_issues', 'downloads_total'],
+      [repoPoint],
+    );
+  }
+
+  if (releases !== null) {
+    const releaseRows: ReleaseRow[] = releases
+      .filter((release) => release.published_at !== null)
+      .map((release) => ({
+        date: toDate(release.published_at as string),
+        tag: release.tag_name,
+        name: release.name ?? release.tag_name,
+      }));
+    writeCsvSeries('releases.csv', ['date', 'tag', 'name'], releaseRows);
+  }
+
+  if (contributors !== null) {
+    // A contributor counts from the week of their first commit onward, so the
+    // series is a cumulative distinct count rather than a weekly total.
+    const firstWeeks = contributors
+      .map((contributor) => contributor.weeks.find((week) => week.c > 0)?.w)
+      .filter((week): week is number => week !== undefined)
+      .sort((a, b) => a - b);
+    let running = 0;
+    const points: CountPoint[] = firstWeeks.map((week) => {
+      running += 1;
+      return { date: new Date(week * 1000).toISOString().slice(0, 10), total: running };
+    });
+    if (points.length > 0) {
+      writeCsvSeries('contributors.csv', ['date', 'total'], points);
+    } else {
+      // A genuine 200 with no contributor ever showing a positive-commit
+      // week is not distinguishable here from "nothing to report" — either
+      // way there is no fresh value to write, so this degrades to a skip
+      // exactly like a persistent 202 does, rather than silently leaving it
+      // out of `skipped` just because the failure mode differs.
+      skipped.push('contributors.csv');
+    }
+  }
+
+  const lastDate = (file: string): IsoDate | undefined => {
+    const rows = store.readCsv(file);
+    return rows[rows.length - 1]?.date;
+  };
+
+  const seriesLastDate: Record<string, IsoDate> = {};
+  for (const file of written) {
+    if (!file.endsWith('.csv')) continue;
+    const last = lastDate(file);
+    if (last !== undefined) seriesLastDate[file] = last;
+  }
+
+  const meta: Meta = {
+    last_run: now,
+    last_success: now,
+    error: null,
+    series_last_date: seriesLastDate,
+  };
+  store.writeMeta(meta);
+
+  return { written, skipped };
+}

--- a/scripts/metrics/src/collect.ts
+++ b/scripts/metrics/src/collect.ts
@@ -1,4 +1,4 @@
-import { upsertByDate, upsertDimensional } from './series.ts';
+import { upsertByDate, upsertByKey, upsertDimensional, compareReleaseRows } from './series.ts';
 import type { GitHubClient } from './github.ts';
 import type { Meta, Store } from './store.ts';
 import type {
@@ -134,9 +134,16 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   ]);
 
   // --- Optional. A failure skips the series, never zeroes it. ---
+  // Paginated, matching backfill.ts: GitHub's default page size is 30, so a
+  // plain `client.get` here would sum asset downloads from only the 30 most
+  // recent releases. Past the 31st release that produces a cumulative
+  // counter that DECREASES on the day a new release ships, and from then on
+  // every run records a plausible-looking total that was never the true
+  // sum — with no error, ever, because a short list is not distinguishable
+  // from a complete one without paginating to find out.
   let releases: ReleaseResponse[] | null = null;
   try {
-    releases = await client.get<ReleaseResponse[]>(`${repoPath}/releases`);
+    releases = await client.paginate<ReleaseResponse>(`${repoPath}/releases`);
   } catch {
     skipped.push('releases.csv');
   }
@@ -201,6 +208,24 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
     written.push(file);
   }
 
+  // `releases.csv` cannot use `writeCsvSeries`/`upsertByDate`: a release
+  // series is not a daily series, and keying its merge on `date` would
+  // collapse two releases published on the same UTC day into one row,
+  // silently dropping the other. A release's true row identity is its tag,
+  // so this merges with `upsertByKey` keyed on `tag` instead, and sorts with
+  // `compareReleaseRows` (date, then tag) so the output stays byte-stable
+  // regardless of which same-day release the API happened to list first.
+  function writeReleases(file: string, incoming: readonly ReleaseRow[]): void {
+    const existing = store.readCsv(file) as unknown as ReleaseRow[];
+    const merged = upsertByKey(existing, incoming, (row) => row.tag, 'overwrite', compareReleaseRows);
+    store.writeCsv(
+      file,
+      ['date', 'tag', 'name'],
+      merged as unknown as Array<Record<string, string | number>>,
+    );
+    written.push(file);
+  }
+
   function writeDimensional(file: string, incoming: readonly DimensionRow[]): void {
     const merged = upsertDimensional(store.readNdjson(file), incoming);
     store.writeNdjson(file, merged);
@@ -261,7 +286,7 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
         tag: release.tag_name,
         name: release.name ?? release.tag_name,
       }));
-    writeCsvSeries('releases.csv', ['date', 'tag', 'name'], releaseRows);
+    writeReleases('releases.csv', releaseRows);
   }
 
   if (contributors !== null) {

--- a/scripts/metrics/src/github.test.ts
+++ b/scripts/metrics/src/github.test.ts
@@ -203,6 +203,21 @@ describe('createClient.paginate', () => {
     // time — otherwise this test would hang instead of asserting anything.
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   }, 2000);
+
+  it('refuses to follow a rel="next" URL whose origin is not the GitHub API, rather than sending the bearer token there', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse([{ id: 1 }], {
+        headers: { link: '<https://evil.example.com/steal>; rel="next"' },
+      }),
+    );
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/x')).rejects.toThrow('https://evil.example.com/steal');
+    // Exactly one fetch: the malicious next-URL must never be requested.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('unparseable 2xx response bodies', () => {

--- a/scripts/metrics/src/github.test.ts
+++ b/scripts/metrics/src/github.test.ts
@@ -77,6 +77,22 @@ describe('createClient.getStats', () => {
     expect(result).not.toEqual({});
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
+
+  it('sleeps between retries but skips the sleep after the final attempt', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, { status: 202 }));
+    const sleep = vi.fn(async () => {});
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep,
+      statsAttempts: 4,
+    });
+    const result = await client.getStats('/stats/contributors');
+    expect(result).toBeNull();
+    // 4 attempts means 3 gaps between them; the 4th (final) attempt must not
+    // sleep afterward, since nothing will read the result of that sleep.
+    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[2000], [4000], [6000]]);
+  });
 });
 
 describe('createClient.paginate', () => {
@@ -106,5 +122,129 @@ describe('createClient.paginate', () => {
     await client.paginate('/x');
     const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     expect(call[0]).toContain('per_page=100');
+  });
+
+  it('throws and names the URL when a page body is an object instead of an array', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ not: 'an array' }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/x')).rejects.toThrow(
+      'https://api.github.com/x?per_page=100',
+    );
+  });
+
+  it('throws and names the URL when a page body is a string instead of an array', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse('not an array'));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/y')).rejects.toThrow(
+      'https://api.github.com/y?per_page=100',
+    );
+  });
+
+  it('aborts and does not return partial results when a later page is non-2xx', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 1 }], {
+          headers: { link: '<https://api.github.com/x?page=2>; rel="next"' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('server error', { status: 500 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    let result: unknown;
+    let error: unknown;
+    try {
+      result = await client.paginate('/x');
+    } catch (caught) {
+      error = caught;
+    }
+    expect(result).toBeUndefined();
+    expect(error).toBeInstanceOf(GitHubError);
+    expect(error).toMatchObject({ status: 500 });
+  });
+
+  it('throws a descriptive error naming the URL when rel=next cycles back to an earlier page', async () => {
+    const page1 = (): Response =>
+      jsonResponse([{ id: 1 }], {
+        headers: { link: '<https://api.github.com/x?page=2>; rel="next"' },
+      });
+    const page2 = (): Response =>
+      jsonResponse([{ id: 2 }], {
+        // Points back at the very first URL this call fetched, forming a cycle.
+        headers: { link: '<https://api.github.com/x?per_page=100>; rel="next"' },
+      });
+    const fetchImpl = vi.fn(async (url: string) => (url.includes('page=2') ? page2() : page1()));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/x')).rejects.toThrow(
+      'https://api.github.com/x?per_page=100',
+    );
+    // The cycle must be caught before re-fetching the repeated URL a third
+    // time — otherwise this test would hang instead of asserting anything.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  }, 2000);
+});
+
+describe('unparseable 2xx response bodies', () => {
+  it('wraps a 204 empty body in a GitHubError carrying the status and the parse failure as cause', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    let error: unknown;
+    try {
+      await client.get('/x');
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(GitHubError);
+    expect(error).toMatchObject({ status: 204 });
+    expect((error as GitHubError).cause).toBeInstanceOf(Error);
+  });
+
+  it('wraps a 200 with a non-JSON body in a GitHubError carrying the status', async () => {
+    const fetchImpl = vi.fn(async () => new Response('not json', { status: 200 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    let error: unknown;
+    try {
+      await client.get('/x');
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(GitHubError);
+    expect(error).toMatchObject({ status: 200 });
+    expect((error as GitHubError).cause).toBeInstanceOf(Error);
+  });
+
+  it('wraps an unparseable getStats success body in a GitHubError', async () => {
+    const fetchImpl = vi.fn(async () => new Response('not json', { status: 200 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.getStats('/stats/contributors')).rejects.toBeInstanceOf(GitHubError);
+  });
+
+  it('wraps an unparseable paginate page body in a GitHubError', async () => {
+    const fetchImpl = vi.fn(async () => new Response('not json', { status: 200 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/x')).rejects.toBeInstanceOf(GitHubError);
   });
 });

--- a/scripts/metrics/src/github.test.ts
+++ b/scripts/metrics/src/github.test.ts
@@ -181,7 +181,17 @@ describe('createClient.paginate', () => {
         // Points back at the very first URL this call fetched, forming a cycle.
         headers: { link: '<https://api.github.com/x?per_page=100>; rel="next"' },
       });
-    const fetchImpl = vi.fn(async (url: string) => (url.includes('page=2') ? page2() : page1()));
+    // Hard ceiling inside the mock itself. Without the cycle guard this loop
+    // is a tight microtask cycle that never yields to a macrotask, so it
+    // exhausts memory and crashes the worker BEFORE vitest's timeout can fire
+    // — an opaque CI crash instead of a red test. Throwing here makes a future
+    // regression fail fast and legibly.
+    let calls = 0;
+    const fetchImpl = vi.fn(async (url: string) => {
+      calls += 1;
+      if (calls > 4) throw new Error('cycle guard regressed: paginate kept fetching');
+      return url.includes('page=2') ? page2() : page1();
+    });
     const client = createClient('t', {
       fetchImpl: fetchImpl as unknown as typeof fetch,
       sleep: noSleep,

--- a/scripts/metrics/src/github.test.ts
+++ b/scripts/metrics/src/github.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createClient, GitHubError } from './github.ts';
+
+const noSleep = async (): Promise<void> => {};
+
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+  });
+}
+
+describe('createClient.get', () => {
+  it('sends the token and the API version header', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ ok: true }));
+    const client = createClient('tok_123', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await client.get('/repos/o/r');
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toBe('https://api.github.com/repos/o/r');
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer tok_123');
+    expect(headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+  });
+
+  it('honours a custom Accept header for the star media type', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse([]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await client.get('/stargazers', 'application/vnd.github.star+json');
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    const headers = call[1].headers as Record<string, string>;
+    expect(headers.Accept).toBe('application/vnd.github.star+json');
+  });
+
+  it('throws GitHubError carrying the status on a non-2xx response', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ message: 'Not Found' }, { status: 404 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.get('/nope')).rejects.toBeInstanceOf(GitHubError);
+    await expect(client.get('/nope')).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe('createClient.getStats', () => {
+  it('retries a 202 and returns the body once it becomes 200', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, { status: 202 }))
+      .mockResolvedValueOnce(jsonResponse([{ total: 5 }]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.getStats('/stats/contributors')).resolves.toEqual([{ total: 5 }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null after a persistent 202 rather than an empty body', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, { status: 202 }));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+      statsAttempts: 3,
+    });
+    const result = await client.getStats('/stats/contributors');
+    expect(result).toBeNull();
+    expect(result).not.toEqual({});
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('createClient.paginate', () => {
+  it('follows rel=next until it is absent and concatenates pages', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 1 }], {
+          headers: { link: '<https://api.github.com/x?page=2>; rel="next"' },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse([{ id: 2 }]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/x')).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('requests 100 items per page', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse([]));
+    const client = createClient('t', {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await client.paginate('/x');
+    const call = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(call[0]).toContain('per_page=100');
+  });
+});

--- a/scripts/metrics/src/github.ts
+++ b/scripts/metrics/src/github.ts
@@ -1,0 +1,155 @@
+const API_ROOT = 'https://api.github.com';
+
+/**
+ * Any non-2xx GitHub API response, carrying the HTTP status so callers can
+ * distinguish e.g. a 404 (resource genuinely absent) from a 403 (rate
+ * limited or unauthorized) without re-parsing the message string. Thrown by
+ * every method on `GitHubClient` except the deliberate 202-swallowing in
+ * `getStats` — see there for why that status alone is not an error.
+ */
+export class GitHubError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(`GitHub API ${status}: ${message}`);
+    this.name = 'GitHubError';
+    this.status = status;
+  }
+}
+
+export interface GitHubClient {
+  /** Fetches one resource. Throws GitHubError on any non-2xx response. */
+  get<T>(path: string, accept?: string): Promise<T>;
+  /**
+   * Fetches a `/stats/*` resource. GitHub computes these asynchronously and
+   * answers with 202 and an empty body while the computation is in flight;
+   * the cache is invalidated by every push to the default branch, so on an
+   * active repo a 202 is routine rather than exceptional and can persist
+   * across every retry in a run.
+   *
+   * Returns `null` when the resource is still computing after every retry.
+   * `null` is the ONLY way this method can report "not available" — the `T`
+   * branch is only ever produced by parsing a genuine 200 response body, so
+   * there is no code path that turns an in-progress computation into a
+   * zero-shaped value of `T`. Callers MUST treat `null` as "skip this metric
+   * today, leave the previously recorded value alone" and must never
+   * substitute a zero for it: a zero written for a metric GitHub never
+   * finished computing is a permanent, silent lie in an archive that is the
+   * only surviving copy of data GitHub deletes after 14 days.
+   */
+  getStats<T>(path: string): Promise<T | null>;
+  /**
+   * Fetches every page of a list endpoint by following the `Link` header's
+   * `rel="next"` until it is absent, concatenating pages in order. Any
+   * non-2xx response or unparseable page aborts the whole call by throwing
+   * — there is no partial-result fallback, so a caller can never mistake a
+   * pagination failure partway through for a complete list.
+   */
+  paginate<T>(path: string, accept?: string): Promise<T[]>;
+}
+
+export interface ClientOptions {
+  /** Injectable in place of global `fetch`, so tests never touch the network. */
+  fetchImpl?: typeof fetch;
+  /** Injectable in place of a real timer, so tests never actually wait. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Number of times `getStats` polls a 202 before giving up and returning `null`. */
+  statsAttempts?: number;
+}
+
+/**
+ * Extracts the `rel="next"` URL from a `Link` header, or `null` when there
+ * is no next page. GitHub's `Link` header packs multiple relations
+ * (`next`, `last`, `prev`, `first`) into one comma-separated value, so this
+ * splits on `,` first and matches each `<url>; rel="..."` segment
+ * individually rather than searching the raw header text, which could
+ * false-match a `rel="next"` substring belonging to a different URL.
+ */
+function nextLink(header: string | null): string | null {
+  if (header === null) return null;
+  for (const part of header.split(',')) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (match?.[1] !== undefined) return match[1];
+  }
+  return null;
+}
+
+export function createClient(token: string, options: ClientOptions = {}): GitHubClient {
+  const doFetch = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const statsAttempts = options.statsAttempts ?? 5;
+
+  const baseHeaders: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'backspace-metrics',
+  };
+
+  function absolute(path: string): string {
+    return path.startsWith('http') ? path : `${API_ROOT}${path}`;
+  }
+
+  async function request(url: string, accept?: string): Promise<Response> {
+    const headers = accept === undefined ? baseHeaders : { ...baseHeaders, Accept: accept };
+    return doFetch(url, { headers });
+  }
+
+  /**
+   * Reads a non-2xx response body as text for the error message and throws.
+   * Shared by every method so a failure looks the same regardless of which
+   * one produced it. Deliberately does not attempt to parse the body as
+   * JSON: GitHub's own error bodies are JSON, but a proxy or outage page in
+   * front of the API need not be, and failing to parse THAT would mask the
+   * original non-2xx status behind a confusing secondary SyntaxError.
+   */
+  async function throwForStatus(response: Response): Promise<never> {
+    throw new GitHubError(response.status, await response.text());
+  }
+
+  async function get<T>(path: string, accept?: string): Promise<T> {
+    const response = await request(absolute(path), accept);
+    if (!response.ok) return throwForStatus(response);
+    return (await response.json()) as T;
+  }
+
+  async function getStats<T>(path: string): Promise<T | null> {
+    const url = absolute(path);
+    for (let attempt = 0; attempt < statsAttempts; attempt++) {
+      const response = await request(url);
+      // 202 means GitHub is still computing the statistic; the body is a
+      // placeholder and reading it as data would write a zero over a real
+      // value. Never parse the body on this branch — the only way this
+      // function can produce a `T` is from a genuine 200 below.
+      if (response.status === 202) {
+        const isLastAttempt = attempt === statsAttempts - 1;
+        if (!isLastAttempt) await sleep(2000 * (attempt + 1));
+        continue;
+      }
+      if (!response.ok) return throwForStatus(response);
+      return (await response.json()) as T;
+    }
+    return null;
+  }
+
+  async function paginate<T>(path: string, accept?: string): Promise<T[]> {
+    const separator = path.includes('?') ? '&' : '?';
+    let url: string | null = absolute(`${path}${separator}per_page=100`);
+    const items: T[] = [];
+    while (url !== null) {
+      const response: Response = await request(url, accept);
+      if (!response.ok) return throwForStatus(response);
+      const page = (await response.json()) as unknown;
+      if (!Array.isArray(page)) {
+        throw new Error(
+          `paginate: expected an array from ${url} but got ${typeof page} — the pagination sequence is truncated or the endpoint does not return a list`,
+        );
+      }
+      items.push(...(page as T[]));
+      url = nextLink(response.headers.get('link'));
+    }
+    return items;
+  }
+
+  return { get, getStats, paginate };
+}

--- a/scripts/metrics/src/github.ts
+++ b/scripts/metrics/src/github.ts
@@ -86,6 +86,34 @@ function nextLink(header: string | null): string | null {
   return null;
 }
 
+/**
+ * Rejects a `rel="next"` URL whose origin is not the GitHub API.
+ *
+ * `paginate` attaches the bearer token to every request it makes,
+ * unconditionally — `request()` has no notion of "this URL doesn't get the
+ * token." `rel="next"` is server-supplied input: nothing on this side
+ * controls what a compromised, misconfigured, or malicious proxy in front
+ * of `api.github.com` puts in that header. Without this check, a `Link`
+ * header pointing anywhere else would have this client dutifully carry the
+ * token there on the very next loop iteration. Checked against a parsed
+ * `origin`, not a string prefix — `https://api.github.com.evil.example.com`
+ * or `https://evil.example.com/https://api.github.com` both start with (or
+ * contain) the right substring while being a different host entirely.
+ */
+function assertGitHubOrigin(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch (cause) {
+    throw new Error(`paginate: rel="next" URL ${url} could not be parsed as a URL`, { cause });
+  }
+  if (parsed.origin !== API_ROOT) {
+    throw new Error(
+      `paginate: rel="next" URL ${url} has origin ${parsed.origin}, not ${API_ROOT} — refusing to send the bearer token to an untrusted host`,
+    );
+  }
+}
+
 export function createClient(token: string, options: ClientOptions = {}): GitHubClient {
   const doFetch = options.fetchImpl ?? fetch;
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
@@ -194,7 +222,9 @@ export function createClient(token: string, options: ClientOptions = {}): GitHub
         );
       }
       items.push(...(page as T[]));
-      url = nextLink(response.headers.get('link'));
+      const next = nextLink(response.headers.get('link'));
+      if (next !== null) assertGitHubOrigin(next);
+      url = next;
     }
     return items;
   }

--- a/scripts/metrics/src/github.ts
+++ b/scripts/metrics/src/github.ts
@@ -10,15 +10,19 @@ const API_ROOT = 'https://api.github.com';
 export class GitHubError extends Error {
   readonly status: number;
 
-  constructor(status: number, message: string) {
-    super(`GitHub API ${status}: ${message}`);
+  constructor(status: number, message: string, options?: { cause?: unknown }) {
+    super(`GitHub API ${status}: ${message}`, options);
     this.name = 'GitHubError';
     this.status = status;
   }
 }
 
 export interface GitHubClient {
-  /** Fetches one resource. Throws GitHubError on any non-2xx response. */
+  /**
+   * Fetches one resource. Throws GitHubError on any non-2xx response, and
+   * also on a 2xx response whose body cannot be parsed as JSON (e.g. a 204),
+   * so every failure this method can produce carries a status uniformly.
+   */
   get<T>(path: string, accept?: string): Promise<T>;
   /**
    * Fetches a `/stats/*` resource. GitHub computes these asynchronously and
@@ -36,6 +40,12 @@ export interface GitHubClient {
    * substitute a zero for it: a zero written for a metric GitHub never
    * finished computing is a permanent, silent lie in an archive that is the
    * only surviving copy of data GitHub deletes after 14 days.
+   *
+   * A 200 whose body is literally `null` also produces a `null` return here,
+   * indistinguishable to the caller from a persistent 202. That is safe, not
+   * an oversight: the contract above already requires every caller to treat
+   * `null` as "skip this metric today" regardless of why it came back, so no
+   * caller needs to tell the two cases apart to behave correctly.
    */
   getStats<T>(path: string): Promise<T | null>;
   /**
@@ -43,7 +53,9 @@ export interface GitHubClient {
    * `rel="next"` until it is absent, concatenating pages in order. Any
    * non-2xx response or unparseable page aborts the whole call by throwing
    * — there is no partial-result fallback, so a caller can never mistake a
-   * pagination failure partway through for a complete list.
+   * pagination failure partway through for a complete list. Also throws if a
+   * `rel="next"` URL repeats a URL already fetched in this call, rather than
+   * following a cycle forever.
    */
   paginate<T>(path: string, accept?: string): Promise<T[]>;
 }
@@ -107,10 +119,30 @@ export function createClient(token: string, options: ClientOptions = {}): GitHub
     throw new GitHubError(response.status, await response.text());
   }
 
+  /**
+   * Parses a 2xx response body as JSON, so every method that reaches this
+   * point returns either a real parsed value or a `GitHubError`. Without
+   * this wrapper, an empty body (a 204) or a body that isn't valid JSON
+   * would reach `response.json()` directly and throw a raw `SyntaxError` —
+   * the one failure path in this client that wouldn't carry a status and
+   * wouldn't be a `GitHubError`, forcing callers to handle it specially. The
+   * original `SyntaxError` is preserved as `cause` rather than discarded, so
+   * a maintainer diagnosing a parse failure still sees exactly what broke.
+   */
+  async function parseBody<T>(response: Response): Promise<T> {
+    try {
+      return (await response.json()) as T;
+    } catch (cause) {
+      throw new GitHubError(response.status, 'response body could not be parsed as JSON', {
+        cause,
+      });
+    }
+  }
+
   async function get<T>(path: string, accept?: string): Promise<T> {
     const response = await request(absolute(path), accept);
     if (!response.ok) return throwForStatus(response);
-    return (await response.json()) as T;
+    return parseBody<T>(response);
   }
 
   async function getStats<T>(path: string): Promise<T | null> {
@@ -127,7 +159,7 @@ export function createClient(token: string, options: ClientOptions = {}): GitHub
         continue;
       }
       if (!response.ok) return throwForStatus(response);
-      return (await response.json()) as T;
+      return parseBody<T>(response);
     }
     return null;
   }
@@ -136,10 +168,26 @@ export function createClient(token: string, options: ClientOptions = {}): GitHub
     const separator = path.includes('?') ? '&' : '?';
     let url: string | null = absolute(`${path}${separator}per_page=100`);
     const items: T[] = [];
+    // Tracks every URL already fetched in this call so a self-referential or
+    // looping `rel="next"` chain is caught and thrown on instead of followed
+    // forever. A scheduled workflow has no human watching it: an infinite
+    // loop here means a runner burning CPU until it's killed, and collection
+    // silently never finishing rather than failing loud. A fixed page cap
+    // was considered and rejected in favor of this: a cap invents an
+    // arbitrary ceiling that a legitimately long result set (e.g. paginated
+    // stargazers during backfill) could one day cross, while tracking actual
+    // repeats catches the real failure mode with no ceiling at all.
+    const seen = new Set<string>();
     while (url !== null) {
+      if (seen.has(url)) {
+        throw new Error(
+          `paginate: rel="next" returned ${url} a second time in the same call — the pagination sequence is cyclic and would loop forever`,
+        );
+      }
+      seen.add(url);
       const response: Response = await request(url, accept);
       if (!response.ok) return throwForStatus(response);
-      const page = (await response.json()) as unknown;
+      const page = await parseBody<unknown>(response);
       if (!Array.isArray(page)) {
         throw new Error(
           `paginate: expected an array from ${url} but got ${typeof page} — the pagination sequence is truncated or the endpoint does not return a list`,

--- a/scripts/metrics/src/no-runtime-deps.test.ts
+++ b/scripts/metrics/src/no-runtime-deps.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const srcDir = path.dirname(fileURLToPath(import.meta.url));
+
+function sourceFiles(): string[] {
+  return readdirSync(srcDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+}
+
+/** Matches the module specifier of any static import or re-export. */
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s+['"]([^'"]+)['"]/g;
+
+/** Matches a bare side-effect import: `import 'x'` with no `from` clause. */
+const SIDE_EFFECT_RE = /(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g;
+
+/**
+ * Extract all import specifiers from a file, from both `from` imports and
+ * side-effect imports. Used by both constraint tests.
+ */
+function allSpecifiersInFile(text: string): Array<{ spec: string; statement: string }> {
+  const specifiers: Array<{ spec: string; statement: string }> = [];
+
+  for (const match of text.matchAll(IMPORT_RE)) {
+    const spec = match[1];
+    if (spec !== undefined) {
+      specifiers.push({ spec, statement: match[0] });
+    }
+  }
+
+  for (const match of text.matchAll(SIDE_EFFECT_RE)) {
+    const spec = match[1];
+    if (spec !== undefined) {
+      specifiers.push({ spec, statement: match[0] });
+    }
+  }
+
+  return specifiers;
+}
+
+describe('collector source constraints', () => {
+  it('has source files to check', () => {
+    expect(sourceFiles().length).toBeGreaterThan(0);
+  });
+
+  it('imports nothing outside node: builtins and relative paths', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(path.join(srcDir, file), 'utf8');
+      for (const { spec } of allSpecifiersInFile(text)) {
+        const ok = spec.startsWith('node:') || spec.startsWith('./') || spec.startsWith('../');
+        if (!ok) offenders.push(`${file} -> ${spec}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('uses the .ts extension on every relative import', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(path.join(srcDir, file), 'utf8');
+      for (const { spec } of allSpecifiersInFile(text)) {
+        if ((spec.startsWith('./') || spec.startsWith('../')) && !spec.endsWith('.ts')) {
+          offenders.push(`${file} -> ${spec}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // Known limitation: the `import type` check below matches only the
+  // statement-level form. `import { type Foo } from './types.ts'` — the inline
+  // modifier, which Node erases correctly and is therefore safe — would be
+  // flagged. Use the statement-level form in this package and the guard stays
+  // quiet. A precise check needs an AST parser, which is not worth a dependency
+  // in a package whose whole point is having none.
+  it('imports types with the type keyword so Node can erase them', () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      const text = readFileSync(path.join(srcDir, file), 'utf8');
+      for (const { spec, statement } of allSpecifiersInFile(text)) {
+        if (!spec.endsWith('types.ts')) continue;
+        if (!/import\s+type\b/.test(statement)) {
+          offenders.push(`${file} -> ${spec} (missing import type)`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/metrics/src/no-runtime-deps.test.ts
+++ b/scripts/metrics/src/no-runtime-deps.test.ts
@@ -9,6 +9,27 @@ function sourceFiles(): string[] {
   return readdirSync(srcDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
 }
 
+/**
+ * Strips block comments and whole-line `//` comments before scanning.
+ *
+ * The scanners below are regexes, not a parser, so without this they read
+ * JSDoc prose as if it were code: a doc comment that happens to contain a
+ * quoted phrase near the word `from` matches IMPORT_RE and fails the build
+ * for a dependency that does not exist. That cost a real implementer real
+ * time on this package, and every module here is heavily documented.
+ *
+ * Only two forms are stripped, both deliberately conservative. A real
+ * `import` statement can never begin with `//`, and the imports in these
+ * files all precede any code that could contain a stray `/*` inside a string
+ * literal — so stripping cannot hide an import from the scanners, which is
+ * the only direction that would turn a spurious failure into a missed
+ * defect. `stripComments keeps a real import that follows a comment` below
+ * pins that.
+ */
+export function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
 /** Matches the module specifier of any static import or re-export. */
 const IMPORT_RE = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s+['"]([^'"]+)['"]/g;
 
@@ -19,7 +40,8 @@ const SIDE_EFFECT_RE = /(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g;
  * Extract all import specifiers from a file, from both `from` imports and
  * side-effect imports. Used by both constraint tests.
  */
-function allSpecifiersInFile(text: string): Array<{ spec: string; statement: string }> {
+function allSpecifiersInFile(source: string): Array<{ spec: string; statement: string }> {
+  const text = stripComments(source);
   const specifiers: Array<{ spec: string; statement: string }> = [];
 
   for (const match of text.matchAll(IMPORT_RE)) {
@@ -87,5 +109,21 @@ describe('collector source constraints', () => {
       }
     }
     expect(offenders).toEqual([]);
+  });
+
+  it('ignores import-like prose inside comments', () => {
+    const source = [
+      '/**',
+      ' * Reads a value from \'somewhere\' and returns it.',
+      ' */',
+      "// import lodash from 'lodash';",
+      "import { parseCsv } from './series.ts';",
+    ].join('\n');
+    expect(allSpecifiersInFile(source).map((s) => s.spec)).toEqual(['./series.ts']);
+  });
+
+  it('stripComments keeps a real import that follows a comment', () => {
+    const source = ["/* a block comment */", "import { x } from 'node:fs';"].join('\n');
+    expect(stripComments(source)).toContain("import { x } from 'node:fs';");
   });
 });

--- a/scripts/metrics/src/no-runtime-deps.test.ts
+++ b/scripts/metrics/src/no-runtime-deps.test.ts
@@ -37,8 +37,23 @@ const IMPORT_RE = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s+['"]([^'"]+)['"]/g
 const SIDE_EFFECT_RE = /(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g;
 
 /**
- * Extract all import specifiers from a file, from both `from` imports and
- * side-effect imports. Used by both constraint tests.
+ * Matches a CommonJS `require('x')` call or a dynamic `import('x')`
+ * expression. Both are runtime escape hatches from the static forms above:
+ * `IMPORT_RE`/`SIDE_EFFECT_RE` only recognise `import`/`export ... from`
+ * statement syntax, so a `require('left-pad')` or `await import('left-pad')`
+ * sails straight through them and would silently reintroduce a runtime
+ * dependency in a package whose whole point is having none. This is
+ * deliberately still a regex, not an AST parse — a real parser is not worth
+ * a dependency in this package — so it only recognises the direct call form
+ * with a string literal argument, which is what every real instance of this
+ * escape hatch looks like.
+ */
+const REQUIRE_OR_DYNAMIC_IMPORT_RE = /\b(?:require|import)\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+/**
+ * Extract all import specifiers from a file, from `from` imports,
+ * side-effect imports, and `require()`/dynamic `import()` calls. Used by
+ * both constraint tests.
  */
 function allSpecifiersInFile(source: string): Array<{ spec: string; statement: string }> {
   const text = stripComments(source);
@@ -52,6 +67,13 @@ function allSpecifiersInFile(source: string): Array<{ spec: string; statement: s
   }
 
   for (const match of text.matchAll(SIDE_EFFECT_RE)) {
+    const spec = match[1];
+    if (spec !== undefined) {
+      specifiers.push({ spec, statement: match[0] });
+    }
+  }
+
+  for (const match of text.matchAll(REQUIRE_OR_DYNAMIC_IMPORT_RE)) {
     const spec = match[1];
     if (spec !== undefined) {
       specifiers.push({ spec, statement: match[0] });
@@ -125,5 +147,25 @@ describe('collector source constraints', () => {
   it('stripComments keeps a real import that follows a comment', () => {
     const source = ["/* a block comment */", "import { x } from 'node:fs';"].join('\n');
     expect(stripComments(source)).toContain("import { x } from 'node:fs';");
+  });
+
+  it('catches a require() call the same as a static import', () => {
+    const source = "const lodash = require('lodash');\n";
+    expect(allSpecifiersInFile(source).map((s) => s.spec)).toEqual(['lodash']);
+  });
+
+  it('catches a dynamic import() expression the same as a static import', () => {
+    const source = "async function f() {\n  const mod = await import('left-pad');\n  return mod;\n}\n";
+    expect(allSpecifiersInFile(source).map((s) => s.spec)).toEqual(['left-pad']);
+  });
+
+  it('flags a require()/dynamic import() of a disallowed specifier via the existing dependency check', () => {
+    const offenders: string[] = [];
+    const source = "const lodash = require('lodash');\nconst x = await import('left-pad');\n";
+    for (const { spec } of allSpecifiersInFile(source)) {
+      const ok = spec.startsWith('node:') || spec.startsWith('./') || spec.startsWith('../');
+      if (!ok) offenders.push(spec);
+    }
+    expect(offenders).toEqual(['lodash', 'left-pad']);
   });
 });

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -285,6 +285,20 @@ describe('upsertDimensional', () => {
     expect(formatNdjson(twice)).toBe(formatNdjson(once));
   });
 
+  it('throws on a corrupt existing row even when incoming would overwrite that key', () => {
+    // Deliberately stricter than the format->parse round trip this replaced:
+    // that only saw post-dedup survivors, so a corrupt existing row an
+    // incoming row happened to overwrite slipped through silently. Failing
+    // the merge is the safe direction for the only surviving copy of data
+    // GitHub has already deleted.
+    const existing: DimensionRow[] = [
+      { snapshot_date: '2026-08-01', dimension: 'a.com', title: '', count: NaN, uniques: 1 },
+    ];
+    const incoming = [row('2026-08-01', 'a.com', 5)];
+    expect(() => upsertDimensional(existing, incoming)).toThrow(/non-finite/);
+    expect(() => upsertDimensional(existing, incoming)).toThrow(/a\.com/);
+  });
+
   it('throws on a non-finite count, naming the dimension and not a line number', () => {
     const existing = [row('2026-08-01', 'a.com', 1)];
     const incoming: DimensionRow[] = [

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -83,6 +83,17 @@ describe('parseCsv', () => {
     const text = 'date,count\n2026-08-01,10\n2026-08-02,20,99\n';
     expect(() => parseCsv(text)).toThrow(/row 2/i);
   });
+
+  it('throws on an unterminated quote rather than swallowing the rest of the file', () => {
+    // Without this guard the open quote absorbs every following row into one
+    // field: two well-formed rows would vanish with no error raised.
+    const text = 'date,note\n2026-08-01,"oops\n2026-08-02,10\n2026-08-03,20\n';
+    expect(() => parseCsv(text)).toThrow(/unterminated/i);
+  });
+
+  it('still parses a file whose final row has no trailing newline', () => {
+    expect(parseCsv('date,count\n2026-08-01,10')).toEqual([{ date: '2026-08-01', count: '10' }]);
+  });
 });
 
 describe('formatCsv', () => {

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { parseCsv, formatCsv, upsertByDate, parseNdjson, formatNdjson, upsertDimensional } from './series.ts';
-import type { DimensionRow } from './types.ts';
+import {
+  parseCsv,
+  formatCsv,
+  upsertByDate,
+  upsertByKey,
+  compareReleaseRows,
+  parseNdjson,
+  formatNdjson,
+  upsertDimensional,
+} from './series.ts';
+import type { DimensionRow, ReleaseRow } from './types.ts';
 
 describe('parseCsv', () => {
   it('parses a header and rows into keyed records', () => {
@@ -70,9 +79,27 @@ describe('parseCsv', () => {
     expect(parseCsv(text)).toEqual([{ date: '2026-08-01', count: '10' }]);
   });
 
-  it('pads a short row (fewer fields than the header) with empty strings', () => {
+  it('throws on a short row (fewer fields than the header), naming the row number', () => {
+    // A short row relative to its own header can only mean truncation:
+    // parseCsv derives the header from the same file it is parsing, so
+    // there is no legitimate reason a data row would have fewer fields than
+    // that header. Silently padding it converts a measured value into
+    // "not measured" with nothing in the log — see formatCsv's blank-field
+    // round trip below for the case that must NOT throw.
     const text = 'date,count,uniques\n2026-08-01,10\n';
-    expect(parseCsv(text)).toEqual([{ date: '2026-08-01', count: '10', uniques: '' }]);
+    expect(() => parseCsv(text)).toThrow(/row 1/i);
+  });
+
+  it('round-trips a row with the correct field count but a blank value, without throwing', () => {
+    // A blank field is NOT a short row: the comma count still matches the
+    // header, so the field is present with an empty value. This is the
+    // shape `formatCsv` produces for `downloads_total` when the optional
+    // releases fetch failed (see collect.ts), and it must keep parsing
+    // cleanly even after the short-row check above starts throwing.
+    const text = 'date,subscribers,downloads_total\n2026-08-01,1,\n';
+    expect(parseCsv(text)).toEqual([
+      { date: '2026-08-01', subscribers: '1', downloads_total: '' },
+    ]);
   });
 
   it('throws on a long row (more fields than the header), naming the row number', () => {
@@ -167,6 +194,65 @@ describe('upsertByDate', () => {
       { date: '2026-08-01', total: 1 },
     ], 'overwrite');
     expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-09']);
+  });
+});
+
+function release(date: string, tag: string, name = tag): ReleaseRow {
+  return { date, tag, name };
+}
+
+describe('upsertByKey', () => {
+  it('overwrite mode: the incoming row wins on a key collision', () => {
+    const existing = [release('2026-08-01', 'v1.0.0', 'old name')];
+    const result = upsertByKey(
+      existing,
+      [release('2026-08-01', 'v1.0.0', 'new name')],
+      (row) => row.tag,
+      'overwrite',
+      compareReleaseRows,
+    );
+    expect(result).toEqual([release('2026-08-01', 'v1.0.0', 'new name')]);
+  });
+
+  it('if-absent mode: never replaces a key that already has a row', () => {
+    const existing = [release('2026-08-01', 'v1.0.0', 'old name')];
+    const result = upsertByKey(
+      existing,
+      [release('2026-08-01', 'v1.0.0', 'new name')],
+      (row) => row.tag,
+      'if-absent',
+      compareReleaseRows,
+    );
+    expect(result).toEqual([release('2026-08-01', 'v1.0.0', 'old name')]);
+  });
+
+  it('keys on the selector, not on date: two releases on the same UTC day both survive', () => {
+    const result = upsertByKey(
+      [],
+      [release('2026-08-01', 'v1.0.0'), release('2026-08-01', 'v1.0.1')],
+      (row) => row.tag,
+      'overwrite',
+      compareReleaseRows,
+    );
+    expect(result.map((r) => r.tag)).toEqual(['v1.0.0', 'v1.0.1']);
+  });
+
+  it('is idempotent: re-running with identical input changes nothing', () => {
+    const rows = [release('2026-08-01', 'v1.0.0'), release('2026-08-01', 'v1.0.1')];
+    const once = upsertByKey([], rows, (row) => row.tag, 'overwrite', compareReleaseRows);
+    const twice = upsertByKey(once, rows, (row) => row.tag, 'overwrite', compareReleaseRows);
+    expect(twice).toEqual(once);
+  });
+
+  it('sorts by date then tag regardless of insertion order, for byte-stable output', () => {
+    const result = upsertByKey(
+      [release('2026-08-02', 'v2.0.0'), release('2026-08-01', 'v1.0.1')],
+      [release('2026-08-01', 'v1.0.0')],
+      (row) => row.tag,
+      'overwrite',
+      compareReleaseRows,
+    );
+    expect(result.map((r) => r.tag)).toEqual(['v1.0.0', 'v1.0.1', 'v2.0.0']);
   });
 });
 

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { parseCsv, formatCsv, upsertByDate } from './series.ts';
+
+describe('parseCsv', () => {
+  it('parses a header and rows into keyed records', () => {
+    const text = 'date,count,uniques\n2026-08-01,10,4\n2026-08-02,12,5\n';
+    expect(parseCsv(text)).toEqual([
+      { date: '2026-08-01', count: '10', uniques: '4' },
+      { date: '2026-08-02', count: '12', uniques: '5' },
+    ]);
+  });
+
+  it('returns an empty array for empty or header-only input', () => {
+    expect(parseCsv('')).toEqual([]);
+    expect(parseCsv('date,count\n')).toEqual([]);
+  });
+
+  it('round-trips quoted fields containing commas and quotes', () => {
+    const rows = [{ snapshot_date: '2026-08-01', title: 'Backspace: chat, voice and "video"' }];
+    const text = formatCsv(['snapshot_date', 'title'], rows);
+    expect(parseCsv(text)).toEqual([
+      { snapshot_date: '2026-08-01', title: 'Backspace: chat, voice and "video"' },
+    ]);
+  });
+});
+
+describe('formatCsv', () => {
+  it('emits a header, sorts by the first column, and ends with a newline', () => {
+    const text = formatCsv(['date', 'total'], [
+      { date: '2026-08-02', total: 2 },
+      { date: '2026-08-01', total: 1 },
+    ]);
+    expect(text).toBe('date,total\n2026-08-01,1\n2026-08-02,2\n');
+  });
+});
+
+describe('upsertByDate', () => {
+  const existing = [
+    { date: '2026-08-01', total: 1 },
+    { date: '2026-08-02', total: 2 },
+  ];
+
+  it('overwrite mode: fetched values win on collision', () => {
+    const result = upsertByDate(existing, [{ date: '2026-08-02', total: 99 }], 'overwrite');
+    expect(result).toEqual([
+      { date: '2026-08-01', total: 1 },
+      { date: '2026-08-02', total: 99 },
+    ]);
+  });
+
+  it('overwrite mode: overlapping windows produce no duplicates', () => {
+    const incoming = [
+      { date: '2026-08-02', total: 2 },
+      { date: '2026-08-03', total: 3 },
+    ];
+    const result = upsertByDate(existing, incoming, 'overwrite');
+    expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-02', '2026-08-03']);
+  });
+
+  it('overwrite mode: re-running with identical input is byte-identical', () => {
+    const once = upsertByDate(existing, existing, 'overwrite');
+    const twice = upsertByDate(once, existing, 'overwrite');
+    expect(formatCsv(['date', 'total'], twice)).toBe(formatCsv(['date', 'total'], once));
+  });
+
+  it('if-absent mode: never overwrites a date that already has a row', () => {
+    const result = upsertByDate(existing, [{ date: '2026-08-02', total: 99 }], 'if-absent');
+    expect(result).toEqual(existing);
+  });
+
+  it('if-absent mode: fills only genuinely missing dates', () => {
+    const result = upsertByDate(existing, [
+      { date: '2026-08-02', total: 99 },
+      { date: '2026-08-03', total: 3 },
+    ], 'if-absent');
+    expect(result).toEqual([
+      { date: '2026-08-01', total: 1 },
+      { date: '2026-08-02', total: 2 },
+      { date: '2026-08-03', total: 3 },
+    ]);
+  });
+
+  it('leaves gaps absent rather than zero-filling them', () => {
+    const result = upsertByDate([], [
+      { date: '2026-08-01', total: 1 },
+      { date: '2026-08-05', total: 5 },
+    ], 'overwrite');
+    expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-05']);
+  });
+
+  it('sorts output ascending regardless of input order', () => {
+    const result = upsertByDate([], [
+      { date: '2026-08-09', total: 9 },
+      { date: '2026-08-01', total: 1 },
+    ], 'overwrite');
+    expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-09']);
+  });
+});

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -261,6 +261,14 @@ describe('upsertDimensional', () => {
     const existing = [row('2026-08-01', 'a.com', 1)];
     const result = upsertDimensional(existing, [row('2026-08-02', 'a.com', 2)]);
     expect(result).toHaveLength(2);
+    const untouched = result.find((r) => r.snapshot_date === '2026-08-01');
+    expect(untouched).toEqual({
+      snapshot_date: '2026-08-01',
+      dimension: 'a.com',
+      title: '',
+      count: 1,
+      uniques: 1,
+    });
   });
 
   it('does not resurrect a dimension that dropped out of the new snapshot', () => {
@@ -275,5 +283,64 @@ describe('upsertDimensional', () => {
     const once = upsertDimensional([], rows);
     const twice = upsertDimensional(once, rows);
     expect(formatNdjson(twice)).toBe(formatNdjson(once));
+  });
+
+  it('throws on a non-finite count, naming the dimension and not a line number', () => {
+    const existing = [row('2026-08-01', 'a.com', 1)];
+    const incoming: DimensionRow[] = [
+      { snapshot_date: '2026-08-01', dimension: 'a.com', title: '', count: Infinity, uniques: 1 },
+    ];
+    expect(() => upsertDimensional(existing, incoming)).toThrow(/2026-08-01.*a\.com/);
+    expect(() => upsertDimensional(existing, incoming)).toThrow(/count/);
+    try {
+      upsertDimensional(existing, incoming);
+      throw new Error('expected upsertDimensional to throw');
+    } catch (error) {
+      expect(String(error)).not.toMatch(/line/i);
+    }
+  });
+
+  it('does not round-trip through JSON: a title with an escapable character survives byte-exact', () => {
+    const existing: DimensionRow[] = [];
+    const withEscapableTitle: DimensionRow = {
+      ...row('2026-08-01', 'a.com', 1),
+      title: 'quote " and back\\slash',
+    };
+    const result = upsertDimensional(existing, [withEscapableTitle]);
+    expect(result[0]?.title).toBe('quote " and back\\slash');
+  });
+});
+
+describe('formatNdjson key order', () => {
+  it('produces byte-identical output for rows with identical values but different property insertion order', () => {
+    const canonical: DimensionRow = {
+      snapshot_date: '2026-08-01',
+      dimension: 'a.com',
+      title: 'Home',
+      count: 5,
+      uniques: 2,
+    };
+    const shuffled: DimensionRow = {
+      count: 5,
+      title: 'Home',
+      uniques: 2,
+      snapshot_date: '2026-08-01',
+      dimension: 'a.com',
+    };
+    expect(formatNdjson([shuffled])).toBe(formatNdjson([canonical]));
+  });
+
+  it('emits canonical snapshot_date,dimension,title,count,uniques key order in the JSON text', () => {
+    const shuffled: DimensionRow = {
+      uniques: 2,
+      count: 5,
+      dimension: 'a.com',
+      title: 'Home',
+      snapshot_date: '2026-08-01',
+    };
+    const text = formatNdjson([shuffled]);
+    expect(text).toBe(
+      '{"snapshot_date":"2026-08-01","dimension":"a.com","title":"Home","count":5,"uniques":2}\n',
+    );
   });
 });

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { parseCsv, formatCsv, upsertByDate } from './series.ts';
+import { parseCsv, formatCsv, upsertByDate, parseNdjson, formatNdjson, upsertDimensional } from './series.ts';
+import type { DimensionRow } from './types.ts';
 
 describe('parseCsv', () => {
   it('parses a header and rows into keyed records', () => {
@@ -166,5 +167,113 @@ describe('upsertByDate', () => {
       { date: '2026-08-01', total: 1 },
     ], 'overwrite');
     expect(result.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-09']);
+  });
+});
+
+function row(snapshot_date: string, dimension: string, count: number): DimensionRow {
+  return { snapshot_date, dimension, title: '', count, uniques: 1 };
+}
+
+describe('formatNdjson', () => {
+  it('sorts by snapshot_date asc, then count desc, then dimension asc', () => {
+    const text = formatNdjson([
+      row('2026-08-02', 'b.com', 5),
+      row('2026-08-01', 'z.com', 1),
+      row('2026-08-01', 'a.com', 9),
+      row('2026-08-01', 'm.com', 9),
+    ]);
+    const order = text
+      .trim()
+      .split('\n')
+      .map((line) => {
+        const parsed = JSON.parse(line) as DimensionRow;
+        return `${parsed.snapshot_date}/${parsed.dimension}`;
+      });
+    expect(order).toEqual([
+      '2026-08-01/a.com',
+      '2026-08-01/m.com',
+      '2026-08-01/z.com',
+      '2026-08-02/b.com',
+    ]);
+  });
+
+  it('round-trips through parseNdjson', () => {
+    const rows = [row('2026-08-01', 'news.ycombinator.com', 118)];
+    expect(parseNdjson(formatNdjson(rows))).toEqual(rows);
+  });
+
+  it('ignores blank lines when parsing', () => {
+    expect(parseNdjson('\n\n')).toEqual([]);
+  });
+});
+
+describe('parseNdjson malformed input', () => {
+  it('throws naming the line number for invalid JSON syntax', () => {
+    const text = '{"snapshot_date":"2026-08-01","dimension":"a.com","title":"","count":1,"uniques":1}\n{not json}\n';
+    expect(() => parseNdjson(text)).toThrow(/line 2/i);
+  });
+
+  it('throws when a line is valid JSON but not an object', () => {
+    expect(() => parseNdjson('[1,2,3]\n')).toThrow(/line 1/i);
+    expect(() => parseNdjson('"just a string"\n')).toThrow(/line 1/i);
+    expect(() => parseNdjson('42\n')).toThrow(/line 1/i);
+    expect(() => parseNdjson('null\n')).toThrow(/line 1/i);
+  });
+
+  it('throws naming the missing field when a required string field is absent', () => {
+    const text = '{"dimension":"a.com","title":"","count":1,"uniques":1}\n';
+    expect(() => parseNdjson(text)).toThrow(/snapshot_date/);
+  });
+
+  it('throws when a numeric field is the wrong type', () => {
+    const text = '{"snapshot_date":"2026-08-01","dimension":"a.com","title":"","count":"1","uniques":1}\n';
+    expect(() => parseNdjson(text)).toThrow(/count/);
+  });
+
+  it('throws when a numeric field is not finite', () => {
+    // JSON has no NaN/Infinity literal, but a magnitude like 1e999 overflows
+    // to Infinity during JSON.parse itself; the parser must not wave a
+    // non-finite count through as if it were a real measured value.
+    const text = '{"snapshot_date":"2026-08-01","dimension":"a.com","title":"","count":1e999,"uniques":1}\n';
+    expect(() => parseNdjson(text)).toThrow(/count/);
+  });
+
+  it('throws naming the line number for the second offending row, not the first', () => {
+    const text = '{"snapshot_date":"2026-08-01","dimension":"a.com","title":"","count":1,"uniques":1}\n{"snapshot_date":"2026-08-02","dimension":"b.com","title":"","count":1}\n';
+    expect(() => parseNdjson(text)).toThrow(/line 2/i);
+  });
+
+  it('does not reject an object carrying an unrecognised extra key', () => {
+    const text = '{"snapshot_date":"2026-08-01","dimension":"a.com","title":"","count":1,"uniques":1,"extra":"future field"}\n';
+    expect(parseNdjson(text)).toEqual([row('2026-08-01', 'a.com', 1)]);
+  });
+});
+
+describe('upsertDimensional', () => {
+  it('replaces a row with the same (snapshot_date, dimension)', () => {
+    const existing = [row('2026-08-01', 'a.com', 1)];
+    const result = upsertDimensional(existing, [row('2026-08-01', 'a.com', 42)]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.count).toBe(42);
+  });
+
+  it('keeps rows from other snapshots untouched', () => {
+    const existing = [row('2026-08-01', 'a.com', 1)];
+    const result = upsertDimensional(existing, [row('2026-08-02', 'a.com', 2)]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not resurrect a dimension that dropped out of the new snapshot', () => {
+    const existing = [row('2026-08-01', 'a.com', 1)];
+    const result = upsertDimensional(existing, [row('2026-08-02', 'b.com', 2)]);
+    const day2 = result.filter((r) => r.snapshot_date === '2026-08-02');
+    expect(day2.map((r) => r.dimension)).toEqual(['b.com']);
+  });
+
+  it('re-running with identical input is byte-identical', () => {
+    const rows = [row('2026-08-01', 'a.com', 1), row('2026-08-01', 'b.com', 2)];
+    const once = upsertDimensional([], rows);
+    const twice = upsertDimensional(once, rows);
+    expect(formatNdjson(twice)).toBe(formatNdjson(once));
   });
 });

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -22,6 +22,67 @@ describe('parseCsv', () => {
       { snapshot_date: '2026-08-01', title: 'Backspace: chat, voice and "video"' },
     ]);
   });
+
+  it('parses CRLF input to clean keys and clean values', () => {
+    const text = 'date,count,uniques\r\n2026-08-01,10,4\r\n';
+    const rows = parseCsv(text);
+    expect(rows).toEqual([{ date: '2026-08-01', count: '10', uniques: '4' }]);
+    expect(rows[0]?.uniques).toBe('4');
+  });
+
+  it('parses a file with a mix of LF and CRLF line endings', () => {
+    const text = 'date,count\n2026-08-01,10\r\n2026-08-02,20\n';
+    expect(parseCsv(text)).toEqual([
+      { date: '2026-08-01', count: '10' },
+      { date: '2026-08-02', count: '20' },
+    ]);
+  });
+
+  it('round-trips a value containing an embedded newline as a single row', () => {
+    const rows = [{ date: '2026-08-01', note: 'line one\nline two' }];
+    const text = formatCsv(['date', 'note'], rows);
+    const parsed = parseCsv(text);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.note).toBe('line one\nline two');
+  });
+
+  it('round-trips a value containing an embedded CRLF', () => {
+    const rows = [{ date: '2026-08-01', note: 'line one\r\nline two' }];
+    const text = formatCsv(['date', 'note'], rows);
+    const parsed = parseCsv(text);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.note).toBe('line one\r\nline two');
+  });
+
+  it('round-trips a value containing a quote, a comma, and a newline together', () => {
+    const rows = [{ date: '2026-08-01', note: 'has "quote", a comma\nand a newline' }];
+    const text = formatCsv(['date', 'note'], rows);
+    const parsed = parseCsv(text);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.note).toBe('has "quote", a comma\nand a newline');
+  });
+
+  it('returns [] for header-only input, empty string, and input with a trailing blank line', () => {
+    expect(parseCsv('date,count\n')).toEqual([]);
+    expect(parseCsv('')).toEqual([]);
+    const text = 'date,count\n2026-08-01,10\n\n';
+    expect(parseCsv(text)).toEqual([{ date: '2026-08-01', count: '10' }]);
+  });
+
+  it('pads a short row (fewer fields than the header) with empty strings', () => {
+    const text = 'date,count,uniques\n2026-08-01,10\n';
+    expect(parseCsv(text)).toEqual([{ date: '2026-08-01', count: '10', uniques: '' }]);
+  });
+
+  it('throws on a long row (more fields than the header), naming the row number', () => {
+    const text = 'date,count\n2026-08-01,10,4\n';
+    expect(() => parseCsv(text)).toThrow(/row 1/i);
+  });
+
+  it('throws naming the correct 1-based row number for a later offending row', () => {
+    const text = 'date,count\n2026-08-01,10\n2026-08-02,20,99\n';
+    expect(() => parseCsv(text)).toThrow(/row 2/i);
+  });
 });
 
 describe('formatCsv', () => {

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -12,7 +12,7 @@ import type { DimensionRow, IsoDate, ReleaseRow } from './types.ts';
  * identifier, so byte ordering and locale ordering coincide today — the
  * point of this function is that byte ordering also stays put tomorrow.
  */
-function compareStrings(a: string, b: string): number {
+export function compareStrings(a: string, b: string): number {
   if (a < b) return -1;
   if (a > b) return 1;
   return 0;

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -1,4 +1,4 @@
-import type { IsoDate } from './types.ts';
+import type { DimensionRow, IsoDate } from './types.ts';
 
 /** Quotes a CSV field only when it contains a comma, quote, or newline. */
 function quote(value: string): string {
@@ -129,4 +129,115 @@ export function upsertByDate<T extends { date: IsoDate }>(
     byDate.set(row.date, row);
   }
   return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Validates that a decoded JSON value is a well-formed `DimensionRow` and
+ * narrows it to that type.
+ *
+ * Unlike a CSV row, a JSON object's fields are named rather than positional,
+ * so an unrecognised extra key cannot desynchronise the fields that follow
+ * it the way an extra CSV column can — there is nothing for it to corrupt.
+ * An extra key is therefore let through untouched (dropped by the return
+ * shape, not rejected), which also gives a future field a forward-compatible
+ * landing spot. A *missing* or *wrong-typed* known field is a different
+ * story: this snapshot is the only surviving copy of data GitHub deletes
+ * after 14 days, so a row that doesn't match the schema is corruption, not
+ * schema evolution, and must fail loudly rather than be coerced (e.g. a
+ * stringified count silently `Number()`-ed) into something plausible.
+ */
+function parseDimensionRow(value: unknown, lineNumber: number): DimensionRow {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`parseNdjson: line ${lineNumber} is not a JSON object`);
+  }
+  const { snapshot_date, dimension, title, count, uniques } = value as Record<string, unknown>;
+  if (typeof snapshot_date !== 'string') {
+    throw new Error(`parseNdjson: line ${lineNumber} has a missing or non-string "snapshot_date"`);
+  }
+  if (typeof dimension !== 'string') {
+    throw new Error(`parseNdjson: line ${lineNumber} has a missing or non-string "dimension"`);
+  }
+  if (typeof title !== 'string') {
+    throw new Error(`parseNdjson: line ${lineNumber} has a missing or non-string "title"`);
+  }
+  if (typeof count !== 'number' || !Number.isFinite(count)) {
+    throw new Error(`parseNdjson: line ${lineNumber} has a missing or non-finite "count"`);
+  }
+  if (typeof uniques !== 'number' || !Number.isFinite(uniques)) {
+    throw new Error(`parseNdjson: line ${lineNumber} has a missing or non-finite "uniques"`);
+  }
+  return { snapshot_date, dimension, title, count, uniques };
+}
+
+/**
+ * Parses newline-delimited JSON dimensional rows, one `DimensionRow` per
+ * line. Blank lines (including a trailing newline at end of input) are
+ * skipped rather than treated as malformed.
+ *
+ * Fails loudly rather than coercing bad data: a line that isn't valid JSON,
+ * or that decodes to something other than a well-formed `DimensionRow`
+ * (missing field, wrong type, non-finite number), throws with the 1-based
+ * line number so a corrupt snapshot is caught at read time instead of
+ * silently propagating into the dashboard. See `parseDimensionRow` for the
+ * exact shape contract and why an unrecognised extra key is *not* treated as
+ * corruption.
+ */
+export function parseNdjson(text: string): DimensionRow[] {
+  return text
+    .split('\n')
+    .map((line, index): [string, number] => [line, index + 1])
+    .filter(([line]) => line.trim().length > 0)
+    .map(([line, lineNumber]) => {
+      let value: unknown;
+      try {
+        value = JSON.parse(line);
+      } catch (cause) {
+        throw new Error(`parseNdjson: line ${lineNumber} is not valid JSON`, { cause });
+      }
+      return parseDimensionRow(value, lineNumber);
+    });
+}
+
+/**
+ * Serialises dimensional rows with a fixed total order: `snapshot_date`
+ * ascending, then `count` descending, then `dimension` ascending as the
+ * tie-break.
+ *
+ * The order is part of the storage contract, not a preference. Any unstable
+ * ordering rewrites the whole file on every daily commit, which would defeat
+ * the one-line-per-day diff that justified plain text over SQLite.
+ */
+export function formatNdjson(rows: readonly DimensionRow[]): string {
+  const sorted = [...rows].sort((a, b) => {
+    if (a.snapshot_date !== b.snapshot_date) {
+      return a.snapshot_date.localeCompare(b.snapshot_date);
+    }
+    if (a.count !== b.count) return b.count - a.count;
+    return a.dimension.localeCompare(b.dimension);
+  });
+  return sorted.map((row) => JSON.stringify(row)).join('\n') + '\n';
+}
+
+/**
+ * Merges dimensional rows keyed by `(snapshot_date, dimension)`, with the
+ * incoming row unconditionally winning on collision.
+ *
+ * Unlike `upsertByDate`, there is no `if-absent` backfill mode: dimensional
+ * rows come from GitHub's trailing-14-day top-10 referrer/path snapshot,
+ * fetched fresh once a day, and there is no `starred_at`-style historical
+ * signal to reconstruct them from after the fact. The daily fetch is the
+ * only source of truth for this data, so overwrite is the only correct mode
+ * — there is nothing else it could mean to merge two dimensional snapshots.
+ *
+ * Deliberately reuses `formatNdjson`'s comparator (via a format/parse round
+ * trip) rather than duplicating the sort, so the two can never drift apart.
+ */
+export function upsertDimensional(
+  existing: readonly DimensionRow[],
+  incoming: readonly DimensionRow[],
+): DimensionRow[] {
+  const byKey = new Map<string, DimensionRow>();
+  for (const row of existing) byKey.set(`${row.snapshot_date} ${row.dimension}`, row);
+  for (const row of incoming) byKey.set(`${row.snapshot_date} ${row.dimension}`, row);
+  return parseNdjson(formatNdjson([...byKey.values()]));
 }

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -61,6 +61,12 @@ function splitRows(text: string): string[][] {
       i++;
     }
   }
+  if (inQuotes) {
+    throw new Error(
+      'parseCsv: unterminated quoted field — the input ends while a quote is still open, ' +
+        'so the file is truncated or corrupt',
+    );
+  }
   if (rowHasContent) {
     fields.push(current);
     rows.push(fields);

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -6,47 +6,81 @@ function quote(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
-/** Splits one CSV line, honouring quoted fields and doubled escape quotes. */
-function splitLine(line: string): string[] {
-  const fields: string[] = [];
+/**
+ * Splits CSV text into rows of fields in a single pass, tracking quote state
+ * across newlines so that a row boundary (`\n` or `\r\n`) is only recognised
+ * when no quote is open. A `\n`, `\r\n`, or `,` inside quotes is literal field
+ * data. A doubled `""` inside quotes is one literal `"`. A trailing newline at
+ * end of input produces no phantom empty row, and a blank line outside quotes
+ * is skipped rather than parsed as an all-empty row.
+ */
+function splitRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let fields: string[] = [];
   let current = '';
   let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
+  let rowHasContent = false;
+  let i = 0;
+  while (i < text.length) {
+    const char = text[i];
     if (inQuotes) {
       if (char === '"') {
-        if (line[i + 1] === '"') {
+        if (text[i + 1] === '"') {
           current += '"';
-          i++;
+          i += 2;
         } else {
           inQuotes = false;
+          i++;
         }
       } else {
         current += char ?? '';
+        i++;
       }
     } else if (char === '"') {
       inQuotes = true;
+      rowHasContent = true;
+      i++;
     } else if (char === ',') {
       fields.push(current);
       current = '';
+      rowHasContent = true;
+      i++;
+    } else if (char === '\n' || char === '\r') {
+      if (char === '\r' && text[i + 1] === '\n') i++;
+      i++;
+      if (rowHasContent) {
+        fields.push(current);
+        rows.push(fields);
+      }
+      fields = [];
+      current = '';
+      rowHasContent = false;
     } else {
       current += char ?? '';
+      rowHasContent = true;
+      i++;
     }
   }
-  fields.push(current);
-  return fields;
+  if (rowHasContent) {
+    fields.push(current);
+    rows.push(fields);
+  }
+  return rows;
 }
 
 export function parseCsv(text: string): Record<string, string>[] {
-  const lines = text.split('\n').filter((line) => line.length > 0);
-  const headerLine = lines.shift();
-  if (headerLine === undefined) return [];
-  const header = splitLine(headerLine);
-  return lines.map((line) => {
-    const fields = splitLine(line);
+  const rows = splitRows(text);
+  const header = rows.shift();
+  if (header === undefined) return [];
+  return rows.map((fields, index) => {
+    if (fields.length > header.length) {
+      throw new Error(
+        `parseCsv: row ${index + 1} has ${fields.length} fields but the header has ${header.length}`,
+      );
+    }
     const row: Record<string, string> = {};
-    header.forEach((key, index) => {
-      row[key] = fields[index] ?? '';
+    header.forEach((key, fieldIndex) => {
+      row[key] = fields[fieldIndex] ?? '';
     });
     return row;
   });

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -304,10 +304,14 @@ export function parseNdjson(text: string): DimensionRow[] {
  */
 function compareDimensionRows(a: DimensionRow, b: DimensionRow): number {
   if (a.snapshot_date !== b.snapshot_date) {
-    return a.snapshot_date.localeCompare(b.snapshot_date);
+    return compareStrings(a.snapshot_date, b.snapshot_date);
   }
   if (a.count !== b.count) return b.count - a.count;
-  return a.dimension.localeCompare(b.dimension);
+  // `dimension` holds a referrer host or a repo path, so unlike every other
+  // value sorted here it can legitimately be non-ASCII. That makes byte
+  // ordering matter more, not less: an ICU update could reorder this file
+  // even though nothing about the data changed.
+  return compareStrings(a.dimension, b.dimension);
 }
 
 /**

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -138,10 +138,13 @@ export function upsertByDate<T extends { date: IsoDate }>(
  * Unlike a CSV row, a JSON object's fields are named rather than positional,
  * so an unrecognised extra key cannot desynchronise the fields that follow
  * it the way an extra CSV column can — there is nothing for it to corrupt.
- * An extra key is therefore let through untouched (dropped by the return
- * shape, not rejected), which also gives a future field a forward-compatible
- * landing spot. A *missing* or *wrong-typed* known field is a different
- * story: this snapshot is the only surviving copy of data GitHub deletes
+ * An extra key is therefore accepted rather than rejected, but it is not
+ * preserved: this function returns a fixed 5-field object literal, so any
+ * unrecognised key is unconditionally dropped from the result. It is not a
+ * landing spot for a future field — adding a field means updating this
+ * validator, not relying on a key silently passing through. A *missing* or
+ * *wrong-typed* known field is a different story: this snapshot is the only
+ * surviving copy of data GitHub deletes
  * after 14 days, so a row that doesn't match the schema is corruption, not
  * schema evolution, and must fail loudly rather than be coerced (e.g. a
  * stringified count silently `Number()`-ed) into something plausible.
@@ -199,23 +202,79 @@ export function parseNdjson(text: string): DimensionRow[] {
 }
 
 /**
- * Serialises dimensional rows with a fixed total order: `snapshot_date`
- * ascending, then `count` descending, then `dimension` ascending as the
- * tie-break.
+ * Total order for dimensional rows: `snapshot_date` ascending, then `count`
+ * descending, then `dimension` ascending as the tie-break.
  *
  * The order is part of the storage contract, not a preference. Any unstable
  * ordering rewrites the whole file on every daily commit, which would defeat
- * the one-line-per-day diff that justified plain text over SQLite.
+ * the one-line-per-day diff that justified plain text over SQLite. Shared by
+ * `formatNdjson` and `upsertDimensional` so the two orderings can never drift
+ * apart.
+ *
+ * Rows tying on all three keys retain their relative input order, per
+ * `Array.prototype.sort`'s ES2019 stability guarantee. In practice this case
+ * cannot arise from `upsertDimensional`'s own output: its
+ * `(snapshot_date, dimension)` dedup means no two rows it produces ever share
+ * both keys, so a true three-key tie is unreachable there.
+ */
+function compareDimensionRows(a: DimensionRow, b: DimensionRow): number {
+  if (a.snapshot_date !== b.snapshot_date) {
+    return a.snapshot_date.localeCompare(b.snapshot_date);
+  }
+  if (a.count !== b.count) return b.count - a.count;
+  return a.dimension.localeCompare(b.dimension);
+}
+
+/**
+ * Serialises dimensional rows with the fixed total order defined by
+ * `compareDimensionRows`.
+ *
+ * Builds the stringify target explicitly in canonical field order rather
+ * than passing each row's own object through: `JSON.stringify` emits keys in
+ * an object's insertion order, so without this the byte output would depend
+ * on how the caller happened to construct the row. That guarantee belongs to
+ * this function, not to callers' construction habits — the file is committed
+ * to git daily, and a varying key order would rewrite every line on every
+ * commit, defeating the plain-text-over-database rationale this format
+ * exists for.
  */
 export function formatNdjson(rows: readonly DimensionRow[]): string {
-  const sorted = [...rows].sort((a, b) => {
-    if (a.snapshot_date !== b.snapshot_date) {
-      return a.snapshot_date.localeCompare(b.snapshot_date);
-    }
-    if (a.count !== b.count) return b.count - a.count;
-    return a.dimension.localeCompare(b.dimension);
-  });
-  return sorted.map((row) => JSON.stringify(row)).join('\n') + '\n';
+  const sorted = [...rows].sort(compareDimensionRows);
+  return (
+    sorted
+      .map((row) =>
+        JSON.stringify({
+          snapshot_date: row.snapshot_date,
+          dimension: row.dimension,
+          title: row.title,
+          count: row.count,
+          uniques: row.uniques,
+        }),
+      )
+      .join('\n') + '\n'
+  );
+}
+
+/**
+ * Rejects a `DimensionRow` whose `count` or `uniques` is non-finite
+ * (`NaN`/`Infinity`), which the plain `number` type on `DimensionRow`
+ * otherwise admits without complaint. Named for the merge that calls it —
+ * an in-memory operation, not a file parse — so the message identifies the
+ * offending `(snapshot_date, dimension)` pair and field directly, rather
+ * than borrowing `parseNdjson`'s "line N" phrasing, which would misdirect a
+ * corruption investigation toward a file read that never happened.
+ */
+function assertFiniteDimensionRow(row: DimensionRow): void {
+  if (!Number.isFinite(row.count)) {
+    throw new Error(
+      `upsertDimensional: row (${row.snapshot_date}, ${row.dimension}) has a non-finite "count"`,
+    );
+  }
+  if (!Number.isFinite(row.uniques)) {
+    throw new Error(
+      `upsertDimensional: row (${row.snapshot_date}, ${row.dimension}) has a non-finite "uniques"`,
+    );
+  }
 }
 
 /**
@@ -229,15 +288,34 @@ export function formatNdjson(rows: readonly DimensionRow[]): string {
  * only source of truth for this data, so overwrite is the only correct mode
  * — there is nothing else it could mean to merge two dimensional snapshots.
  *
- * Deliberately reuses `formatNdjson`'s comparator (via a format/parse round
- * trip) rather than duplicating the sort, so the two can never drift apart.
+ * Every row that enters the merge, existing or incoming, is validated with
+ * `assertFiniteDimensionRow` first — see there for why the message shape
+ * differs from `parseNdjson`'s.
+ *
+ * Sorts the merged rows directly with `compareDimensionRows` — the same
+ * comparator `formatNdjson` uses — rather than round-tripping through
+ * `formatNdjson`/`parseNdjson`. The round trip bought nothing but the cost
+ * of re-serialising and re-parsing the whole dataset on every merge, and it
+ * was also, incidentally, the only thing rejecting a non-finite count before
+ * `assertFiniteDimensionRow` took over that job explicitly.
+ *
+ * Keys on `` `${snapshot_date}\0${dimension}` `` rather than a
+ * space-joined string: a NUL byte cannot occur in either field, so the key
+ * cannot collide the way a space-joined key could if `snapshot_date` ever
+ * contained one.
  */
 export function upsertDimensional(
   existing: readonly DimensionRow[],
   incoming: readonly DimensionRow[],
 ): DimensionRow[] {
   const byKey = new Map<string, DimensionRow>();
-  for (const row of existing) byKey.set(`${row.snapshot_date} ${row.dimension}`, row);
-  for (const row of incoming) byKey.set(`${row.snapshot_date} ${row.dimension}`, row);
-  return parseNdjson(formatNdjson([...byKey.values()]));
+  for (const row of existing) {
+    assertFiniteDimensionRow(row);
+    byKey.set(`${row.snapshot_date}\0${row.dimension}`, row);
+  }
+  for (const row of incoming) {
+    assertFiniteDimensionRow(row);
+    byKey.set(`${row.snapshot_date}\0${row.dimension}`, row);
+  }
+  return [...byKey.values()].sort(compareDimensionRows);
 }

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -1,0 +1,92 @@
+import type { IsoDate } from './types.ts';
+
+/** Quotes a CSV field only when it contains a comma, quote, or newline. */
+function quote(value: string): string {
+  if (!/[",\n\r]/.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/** Splits one CSV line, honouring quoted fields and doubled escape quotes. */
+function splitLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char ?? '';
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === ',') {
+      fields.push(current);
+      current = '';
+    } else {
+      current += char ?? '';
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+export function parseCsv(text: string): Record<string, string>[] {
+  const lines = text.split('\n').filter((line) => line.length > 0);
+  const headerLine = lines.shift();
+  if (headerLine === undefined) return [];
+  const header = splitLine(headerLine);
+  return lines.map((line) => {
+    const fields = splitLine(line);
+    const row: Record<string, string> = {};
+    header.forEach((key, index) => {
+      row[key] = fields[index] ?? '';
+    });
+    return row;
+  });
+}
+
+export function formatCsv(
+  header: readonly string[],
+  rows: ReadonlyArray<Record<string, string | number>>,
+): string {
+  const sortKey = header[0];
+  if (sortKey === undefined) throw new Error('formatCsv requires at least one header column');
+  const sorted = [...rows].sort((a, b) =>
+    String(a[sortKey] ?? '').localeCompare(String(b[sortKey] ?? '')),
+  );
+  const body = sorted.map((row) => header.map((key) => quote(String(row[key] ?? ''))).join(','));
+  return [header.join(','), ...body].join('\n') + '\n';
+}
+
+/**
+ * Merges `incoming` into `existing`, keyed by `date`, returning a
+ * date-ascending array.
+ *
+ * `overwrite` — the fetched value wins. Used by the daily collector, where the
+ * API is authoritative and re-fetching a 14-day window must be idempotent.
+ *
+ * `if-absent` — an existing row is never replaced. Used by backfill, which
+ * reconstructs history from `starred_at` and therefore cannot see stars that
+ * were later removed. Overwriting a measured value with a reconstructed one
+ * would silently corrupt the series.
+ */
+export function upsertByDate<T extends { date: IsoDate }>(
+  existing: readonly T[],
+  incoming: readonly T[],
+  mode: 'overwrite' | 'if-absent',
+): T[] {
+  const byDate = new Map<IsoDate, T>();
+  for (const row of existing) byDate.set(row.date, row);
+  for (const row of incoming) {
+    if (mode === 'if-absent' && byDate.has(row.date)) continue;
+    byDate.set(row.date, row);
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -290,7 +290,17 @@ function assertFiniteDimensionRow(row: DimensionRow): void {
  *
  * Every row that enters the merge, existing or incoming, is validated with
  * `assertFiniteDimensionRow` first — see there for why the message shape
- * differs from `parseNdjson`'s.
+ * differs from `parseNdjson`'s. Validating `existing` is deliberately
+ * STRICTER than the round trip this replaced, not equivalent to it: the
+ * round trip only ever saw post-dedup survivors, so a corrupt existing row
+ * that incoming happened to overwrite slipped through silently. It is safe
+ * to tighten because `existing` is loaded from disk through `parseNdjson`,
+ * which already rejects a non-finite count at parse time — so for the real
+ * pipeline the check can only fire on rows a caller built in memory. When
+ * it does fire, the whole merge fails rather than self-healing, matching
+ * `parseNdjson`, which aborts a whole file rather than skipping one bad
+ * line. For the only surviving copy of deleted data, refusing to proceed
+ * beats quietly papering over a value that should have been impossible.
  *
  * Sorts the merged rows directly with `compareDimensionRows` — the same
  * comparator `formatNdjson` uses — rather than round-tripping through

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -1,4 +1,22 @@
-import type { DimensionRow, IsoDate } from './types.ts';
+import type { DimensionRow, IsoDate, ReleaseRow } from './types.ts';
+
+/**
+ * Plain UTF-16 code-unit comparison, deliberately NOT `String.prototype
+ * .localeCompare`. `localeCompare`'s collation is ICU-version dependent —
+ * the exact ordering it produces for a given pair of strings can change
+ * across Node versions with no code change on this side at all, which would
+ * silently reorder an entire committed file on the next run after a Node
+ * upgrade. That would destroy the one-line-per-day diff property the plain
+ * text format was chosen for in the first place. Every value ordered by
+ * this comparator in the codebase is an ISO date or similarly plain ASCII
+ * identifier, so byte ordering and locale ordering coincide today — the
+ * point of this function is that byte ordering also stays put tomorrow.
+ */
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
 
 /** Quotes a CSV field only when it contains a comma, quote, or newline. */
 function quote(value: string): string {
@@ -79,7 +97,18 @@ export function parseCsv(text: string): Record<string, string>[] {
   const header = rows.shift();
   if (header === undefined) return [];
   return rows.map((fields, index) => {
-    if (fields.length > header.length) {
+    // A row with a DIFFERENT field count than the header — too many OR too
+    // few — can only mean truncation or corruption: the header was derived
+    // from this same file, so a short row relative to its own header is not
+    // "a column was added later" (that case is handled entirely by
+    // `formatCsv`'s `row[key] ?? ''` and never reaches this parser at all).
+    // Padding a short row with `''` would silently convert a measured value
+    // into "not measured," permanently, with nothing in the log — the exact
+    // failure this archive exists to avoid. A row with the CORRECT field
+    // count and an empty value (e.g. a blank `downloads_total`) is a
+    // different shape entirely and is unaffected by this check: it has one
+    // fewer comma than a short row, not one fewer field.
+    if (fields.length !== header.length) {
       throw new Error(
         `parseCsv: row ${index + 1} has ${fields.length} fields but the header has ${header.length}`,
       );
@@ -99,7 +128,7 @@ export function formatCsv(
   const sortKey = header[0];
   if (sortKey === undefined) throw new Error('formatCsv requires at least one header column');
   const sorted = [...rows].sort((a, b) =>
-    String(a[sortKey] ?? '').localeCompare(String(b[sortKey] ?? '')),
+    compareStrings(String(a[sortKey] ?? ''), String(b[sortKey] ?? '')),
   );
   const body = sorted.map((row) => header.map((key) => quote(String(row[key] ?? ''))).join(','));
   return [header.join(','), ...body].join('\n') + '\n';
@@ -128,7 +157,63 @@ export function upsertByDate<T extends { date: IsoDate }>(
     if (mode === 'if-absent' && byDate.has(row.date)) continue;
     byDate.set(row.date, row);
   }
-  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+  return [...byDate.values()].sort((a, b) => compareStrings(a.date, b.date));
+}
+
+/**
+ * Merges `incoming` into `existing` keyed by an explicit `key` selector
+ * rather than `date`, with the same `'overwrite' | 'if-absent'` modes as
+ * `upsertByDate` and the same meaning for each.
+ *
+ * Exists because not every series is a daily series: `releases.csv` can
+ * legitimately hold more than one row for the same UTC date (two releases
+ * published the same day), so keying its merge on `date` — as
+ * `upsertByDate` does — silently collapses them into one row and drops the
+ * other. A release's true row identity is its tag, which `upsertByDate` has
+ * no way to express. `upsertByDate` itself is left untouched for the
+ * genuinely daily series (`stars.csv`, `forks.csv`, `repo.csv`, traffic):
+ * this is a new function, not a generalisation that reshapes the old one's
+ * behaviour underneath its existing callers.
+ *
+ * `compare` orders the merged result explicitly, rather than deriving an
+ * order from `key` (which would sort releases by tag, not by date) or from
+ * Map iteration order (which is insertion order, and therefore differs
+ * between `collect.ts` and `backfill.ts` depending on which one merged the
+ * row first) — either alternative would make the final row order,
+ * regardless of source, an implementation detail rather than a fixed
+ * contract, and an unstable order rewrites the whole file on every commit.
+ */
+export function upsertByKey<T>(
+  existing: readonly T[],
+  incoming: readonly T[],
+  key: (row: T) => string,
+  mode: 'overwrite' | 'if-absent',
+  compare: (a: T, b: T) => number,
+): T[] {
+  const byKey = new Map<string, T>();
+  for (const row of existing) byKey.set(key(row), row);
+  for (const row of incoming) {
+    const rowKey = key(row);
+    if (mode === 'if-absent' && byKey.has(rowKey)) continue;
+    byKey.set(rowKey, row);
+  }
+  return [...byKey.values()].sort(compare);
+}
+
+/**
+ * Total order for release rows: `date` ascending, then `tag` ascending as
+ * the tie-break. `releases.csv` is keyed on `tag` (see `upsertByKey` above),
+ * not `date`, specifically so two releases published on the same UTC day
+ * both survive as distinct rows — which means their relative order can no
+ * longer fall out of a date-keyed `Map`'s iteration order the way every
+ * other series' does. Both `collect.ts` and `backfill.ts` pass this exact
+ * comparator to `upsertByKey` rather than each deriving their own, so the
+ * two writers of `releases.csv` can never disagree on ordering the way they
+ * previously disagreed on which same-day release survived at all.
+ */
+export function compareReleaseRows(a: ReleaseRow, b: ReleaseRow): number {
+  if (a.date !== b.date) return compareStrings(a.date, b.date);
+  return compareStrings(a.tag, b.tag);
 }
 
 /**

--- a/scripts/metrics/src/store.test.ts
+++ b/scripts/metrics/src/store.test.ts
@@ -229,6 +229,19 @@ describe('createStore', () => {
       expect(existsSync(outside)).toBe(false);
     });
 
+    it('throws on a sibling directory whose name merely starts with the data directory name', () => {
+      // The classic prefix bug: a naive `full.startsWith(root)` check accepts
+      // /x/data-evil/y for root /x/data, because the string does start with it.
+      // The guard must compare against root + separator, not root alone.
+      const store = createStore(dir);
+      const sibling = path.join('..', `${path.basename(dir)}-evil`, 'stolen.csv');
+      expect(() => store.readCsv(sibling)).toThrow();
+      expect(() =>
+        store.writeCsv(sibling, ['date', 'total'], [{ date: '2026-08-01', total: 1 }]),
+      ).toThrow();
+      expect(existsSync(path.resolve(dir, sibling))).toBe(false);
+    });
+
     it('allows a file argument that resolves exactly to a subpath of the data directory', () => {
       const store = createStore(dir);
       store.writeCsv('a/b/c.csv', ['date', 'total'], [{ date: '2026-08-01', total: 1 }]);

--- a/scripts/metrics/src/store.test.ts
+++ b/scripts/metrics/src/store.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+  chmodSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createStore } from './store.ts';
+
+let dir = '';
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'metrics-store-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('createStore', () => {
+  it('returns an empty array for a file that does not exist', () => {
+    const store = createStore(dir);
+    expect(store.readCsv('stars.csv')).toEqual([]);
+    expect(store.readNdjson('traffic/referrers.ndjson')).toEqual([]);
+  });
+
+  it('creates nested directories on write', () => {
+    const store = createStore(dir);
+    store.writeCsv('traffic/views.csv', ['date', 'count'], [{ date: '2026-08-01', count: 3 }]);
+    expect(existsSync(path.join(dir, 'traffic/views.csv'))).toBe(true);
+  });
+
+  it('round-trips CSV through the filesystem', () => {
+    const store = createStore(dir);
+    store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-08-01', total: 56 }]);
+    expect(store.readCsv('stars.csv')).toEqual([{ date: '2026-08-01', total: '56' }]);
+  });
+
+  it('round-trips NDJSON through the filesystem', () => {
+    const store = createStore(dir);
+    const rows = [
+      { snapshot_date: '2026-08-01', dimension: 'a.com', title: '', count: 5, uniques: 2 },
+    ];
+    store.writeNdjson('traffic/referrers.ndjson', rows);
+    expect(store.readNdjson('traffic/referrers.ndjson')).toEqual(rows);
+  });
+
+  it('returns null when meta.json is absent', () => {
+    expect(createStore(dir).readMeta()).toBeNull();
+  });
+
+  it('writes meta.json as pretty-printed JSON with a trailing newline', () => {
+    const store = createStore(dir);
+    store.writeMeta({
+      last_run: '2026-08-25T03:00:41Z',
+      last_success: '2026-08-25T03:00:41Z',
+      error: null,
+      series_last_date: { 'stars.csv': '2026-08-25' },
+    });
+    const text = readFileSync(path.join(dir, 'meta.json'), 'utf8');
+    expect(text.endsWith('\n')).toBe(true);
+    expect(text).toContain('\n  "last_run"');
+    expect(store.readMeta()?.series_last_date['stars.csv']).toBe('2026-08-25');
+  });
+
+  it('does not double the trailing newline that formatCsv/formatNdjson already append', () => {
+    const store = createStore(dir);
+    store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-08-01', total: 1 }]);
+    const csvText = readFileSync(path.join(dir, 'stars.csv'), 'utf8');
+    expect(csvText.endsWith('\n\n')).toBe(false);
+
+    store.writeNdjson('traffic/referrers.ndjson', [
+      { snapshot_date: '2026-08-01', dimension: 'a.com', title: '', count: 1, uniques: 1 },
+    ]);
+    const ndjsonText = readFileSync(path.join(dir, 'traffic/referrers.ndjson'), 'utf8');
+    expect(ndjsonText.endsWith('\n\n')).toBe(false);
+  });
+
+  describe('absent vs. corrupt', () => {
+    it('throws (does not return []) when a CSV file exists but has a malformed row', () => {
+      const store = createStore(dir);
+      // header has 2 columns; data row has 3 — parseCsv must throw, not be
+      // swallowed into an empty read.
+      writeFileSync(path.join(dir, 'stars.csv'), 'date,total\n2026-08-01,1,extra\n', 'utf8');
+      expect(() => store.readCsv('stars.csv')).toThrow();
+    });
+
+    it('throws (does not return []) when an NDJSON file exists but has an invalid line', () => {
+      const store = createStore(dir);
+      writeFileSync(path.join(dir, 'referrers.ndjson'), 'not json\n', 'utf8');
+      expect(() => store.readNdjson('referrers.ndjson')).toThrow();
+    });
+
+    it('throws when a file path is actually a directory rather than treating it as absent', () => {
+      const store = createStore(dir);
+      mkdirSync(path.join(dir, 'stars.csv'));
+      expect(() => store.readCsv('stars.csv')).toThrow();
+    });
+
+    it('throws when meta.json exists but is not valid JSON', () => {
+      const store = createStore(dir);
+      writeFileSync(path.join(dir, 'meta.json'), '{ not valid json', 'utf8');
+      expect(() => store.readMeta()).toThrow();
+    });
+
+    it('throws when meta.json is valid JSON but missing a required field', () => {
+      const store = createStore(dir);
+      writeFileSync(
+        path.join(dir, 'meta.json'),
+        JSON.stringify({ last_run: '2026-08-25T03:00:41Z', error: null, series_last_date: {} }),
+        'utf8',
+      );
+      expect(() => store.readMeta()).toThrow(/last_success/);
+    });
+
+    it('throws when meta.json has a wrong-typed field', () => {
+      const store = createStore(dir);
+      writeFileSync(
+        path.join(dir, 'meta.json'),
+        JSON.stringify({
+          last_run: '2026-08-25T03:00:41Z',
+          last_success: null,
+          error: null,
+          series_last_date: 'not-an-object',
+        }),
+        'utf8',
+      );
+      expect(() => store.readMeta()).toThrow(/series_last_date/);
+    });
+
+    it('throws when meta.json series_last_date has a non-string value', () => {
+      const store = createStore(dir);
+      writeFileSync(
+        path.join(dir, 'meta.json'),
+        JSON.stringify({
+          last_run: '2026-08-25T03:00:41Z',
+          last_success: null,
+          error: null,
+          series_last_date: { 'stars.csv': 20260825 },
+        }),
+        'utf8',
+      );
+      expect(() => store.readMeta()).toThrow(/series_last_date/);
+    });
+
+    it('propagates a permission error rather than treating it as absent', () => {
+      // Root can read past permission bits, so this case is only meaningful
+      // for a non-root test runner; skip rather than false-fail under root.
+      if (process.getuid?.() === 0) return;
+      const store = createStore(dir);
+      const file = path.join(dir, 'stars.csv');
+      writeFileSync(file, 'date,total\n2026-08-01,1\n', 'utf8');
+      chmodSync(file, 0o000);
+      try {
+        expect(() => store.readCsv('stars.csv')).toThrow();
+      } finally {
+        chmodSync(file, 0o644);
+      }
+    });
+  });
+
+  describe('atomic writes', () => {
+    it('leaves no temp file behind after a successful write', () => {
+      const store = createStore(dir);
+      store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-08-01', total: 1 }]);
+      const entries = readdirSync(dir);
+      expect(entries).toEqual(['stars.csv']);
+    });
+
+    it('replaces an existing file wholesale rather than truncating it in place', () => {
+      const store = createStore(dir);
+      store.writeCsv('stars.csv', ['date', 'total'], [{ date: '2026-08-01', total: 1 }]);
+      store.writeCsv(
+        'stars.csv',
+        ['date', 'total'],
+        [
+          { date: '2026-08-01', total: 1 },
+          { date: '2026-08-02', total: 2 },
+        ],
+      );
+      const entries = readdirSync(dir);
+      expect(entries).toEqual(['stars.csv']);
+      expect(store.readCsv('stars.csv')).toEqual([
+        { date: '2026-08-01', total: '1' },
+        { date: '2026-08-02', total: '2' },
+      ]);
+    });
+
+    it('leaves no temp file behind after writing meta.json', () => {
+      const store = createStore(dir);
+      store.writeMeta({
+        last_run: '2026-08-25T03:00:41Z',
+        last_success: null,
+        error: null,
+        series_last_date: {},
+      });
+      expect(readdirSync(dir)).toEqual(['meta.json']);
+    });
+  });
+
+  describe('path containment', () => {
+    it('throws rather than reading outside the data directory via ../ traversal', () => {
+      const store = createStore(dir);
+      expect(() => store.readCsv('../outside.csv')).toThrow();
+      expect(() => store.readNdjson('../../etc/outside.ndjson')).toThrow();
+    });
+
+    it('throws rather than writing outside the data directory via ../ traversal', () => {
+      const store = createStore(dir);
+      expect(() =>
+        store.writeCsv('../outside.csv', ['date', 'total'], [{ date: '2026-08-01', total: 1 }]),
+      ).toThrow();
+      expect(existsSync(path.join(dir, '..', 'outside.csv'))).toBe(false);
+    });
+
+    it('throws rather than reading/writing an absolute path outside the data directory', () => {
+      const store = createStore(dir);
+      const outside = path.join(tmpdir(), 'metrics-store-outside.csv');
+      expect(() => store.readCsv(outside)).toThrow();
+      expect(() =>
+        store.writeCsv(outside, ['date', 'total'], [{ date: '2026-08-01', total: 1 }]),
+      ).toThrow();
+      expect(existsSync(outside)).toBe(false);
+    });
+
+    it('allows a file argument that resolves exactly to a subpath of the data directory', () => {
+      const store = createStore(dir);
+      store.writeCsv('a/b/c.csv', ['date', 'total'], [{ date: '2026-08-01', total: 1 }]);
+      expect(store.readCsv('a/b/c.csv')).toEqual([{ date: '2026-08-01', total: '1' }]);
+    });
+  });
+});

--- a/scripts/metrics/src/store.ts
+++ b/scripts/metrics/src/store.ts
@@ -1,0 +1,209 @@
+import { readFileSync, writeFileSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
+import path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { parseCsv, formatCsv, parseNdjson, formatNdjson } from './series.ts';
+import type { DimensionRow, IsoDate } from './types.ts';
+
+/** Collector health, written to `meta.json` at the root of the data branch. */
+export interface Meta {
+  last_run: string;
+  last_success: string | null;
+  error: string | null;
+  /** Keys are exact file paths, e.g. `traffic/views.csv`. */
+  series_last_date: Record<string, IsoDate>;
+}
+
+export interface Store {
+  readCsv(file: string): Record<string, string>[];
+  writeCsv(
+    file: string,
+    header: readonly string[],
+    rows: ReadonlyArray<Record<string, string | number>>,
+  ): void;
+  readNdjson(file: string): DimensionRow[];
+  writeNdjson(file: string, rows: readonly DimensionRow[]): void;
+  readMeta(): Meta | null;
+  writeMeta(meta: Meta): void;
+}
+
+/**
+ * Node's fs error objects carry `code` but TypeScript only knows `Error`.
+ * Narrows to the shape this module actually inspects, without resorting to
+ * `any`.
+ */
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const code = (error as Record<string, unknown>)['code'];
+  return typeof code === 'string' ? code : undefined;
+}
+
+/**
+ * Validates that a decoded JSON value is a well-formed `Meta` and narrows it
+ * to that type.
+ *
+ * `readMeta` is the only read path in this module whose payload isn't
+ * already validated by a `series.ts` parser, so without this check a
+ * truncated or hand-edited `meta.json` — missing `last_success`, or a
+ * `series_last_date` that decoded to a string instead of an object — would
+ * be blindly cast and start handing `undefined` or the wrong shape to every
+ * caller that trusts `Meta`. `series_last_date`'s values are checked for
+ * `string`, not further validated as `IsoDate` (a `YYYY-MM-DD` shape check
+ * duplicated from nowhere else in this package): a malformed date here would
+ * poison a single series' resume point, not falsify data already written to
+ * a CSV/NDJSON file, so it fails on the next inconsistency rather than
+ * requiring an extra check with no shared home.
+ */
+function parseMeta(value: unknown): Meta {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('readMeta: meta.json does not decode to a JSON object');
+  }
+  const { last_run, last_success, error, series_last_date } = value as Record<string, unknown>;
+  if (typeof last_run !== 'string') {
+    throw new Error('readMeta: meta.json has a missing or non-string "last_run"');
+  }
+  if (last_success !== null && typeof last_success !== 'string') {
+    throw new Error('readMeta: meta.json has a "last_success" that is neither null nor a string');
+  }
+  if (error !== null && typeof error !== 'string') {
+    throw new Error('readMeta: meta.json has an "error" that is neither null nor a string');
+  }
+  if (
+    typeof series_last_date !== 'object' ||
+    series_last_date === null ||
+    Array.isArray(series_last_date)
+  ) {
+    throw new Error('readMeta: meta.json has a "series_last_date" that is not a JSON object');
+  }
+  for (const [key, entry] of Object.entries(series_last_date)) {
+    if (typeof entry !== 'string') {
+      throw new Error(`readMeta: meta.json "series_last_date.${key}" is not a string`);
+    }
+  }
+  return {
+    last_run,
+    last_success,
+    error,
+    series_last_date: series_last_date as Record<string, IsoDate>,
+  };
+}
+
+/**
+ * Resolves a `file` argument against `dataDir` and rejects any result that
+ * would land outside it.
+ *
+ * `file` values reach this module from the orchestrator (Task 7), driven by
+ * series names like `traffic/views.csv`. A value containing `../` segments —
+ * or a value that is itself an absolute path, which `path.resolve` treats as
+ * overriding `dataDir` entirely — would otherwise let a caller read or write
+ * anywhere on disk that this process has permission to touch. Since this
+ * store is the only module that touches the filesystem, this is the one
+ * place that boundary can be enforced; every read and write funnels through
+ * it rather than trusting `path.join` to keep the result contained, which it
+ * does not.
+ */
+function resolve(dataDir: string, file: string): string {
+  const root = path.resolve(dataDir);
+  const full = path.resolve(root, file);
+  if (full !== root && !full.startsWith(root + path.sep)) {
+    throw new Error(`Store: "${file}" resolves outside the data directory`);
+  }
+  return full;
+}
+
+export function createStore(dataDir: string): Store {
+  /**
+   * Reads a file's full text, or `null` if it does not exist yet — the only
+   * two outcomes a caller may treat as "no data" vs. "data present".
+   *
+   * Tells absence apart from an unreadable file using the error's `code`
+   * rather than by checking existence first: an
+   * `existsSync`-then-`readFileSync` pair has a race (the file can be
+   * deleted between the two calls) and, more importantly, would make an
+   * `EISDIR` or `EACCES` failure indistinguishable from absence if the catch
+   * swallowed every error alike. Only `ENOENT` — the file genuinely is not
+   * there — collapses to `null`, which callers read as first run,
+   * legitimately empty. Every other failure (wrong permissions, the path is
+   * a directory, a symlink loop) propagates as a thrown error, because this
+   * archive is the only surviving copy of data GitHub deletes after 14 days
+   * and a swallowed read error would silently persist an empty series over
+   * real history on the very next write.
+   */
+  function read(file: string): string | null {
+    const full = resolve(dataDir, file);
+    try {
+      return readFileSync(full, 'utf8');
+    } catch (cause) {
+      if (errorCode(cause) === 'ENOENT') return null;
+      throw new Error(`Store: failed to read "${file}"`, { cause });
+    }
+  }
+
+  /**
+   * Writes `text` to `file`, creating parent directories as needed.
+   *
+   * Writes to a sibling temp file in the same directory and `renameSync`s it
+   * over the target rather than calling `writeFileSync` on the target
+   * directly. A direct write is not atomic: if the process is killed (OOM,
+   * `SIGKILL`, power loss) partway through, the target is left holding a
+   * truncated prefix of the new content, indistinguishable on the next run
+   * from a genuine (if malformed) file — `readCsv`/`readNdjson` would throw
+   * on it as corruption, but the ORIGINAL, previously-good content is gone
+   * either way, and for data GitHub has already deleted upstream that loss
+   * is permanent. A `rename` within the same directory (same filesystem) is
+   * atomic on POSIX and on NTFS: the target either still holds the old
+   * complete content or holds the new complete content, never a mix, no
+   * matter when the process dies. The temp name includes random bytes so
+   * concurrent writes to different files (or a crash-and-rerun before
+   * cleanup) never collide on one temp path. On failure, the temp file is
+   * best-effort unlinked so a partial temp artifact doesn't accumulate next
+   * to the target — the target itself is untouched since the rename never
+   * happened.
+   */
+  function write(file: string, text: string): void {
+    const full = resolve(dataDir, file);
+    mkdirSync(path.dirname(full), { recursive: true });
+    const tmp = `${full}.tmp-${randomBytes(8).toString('hex')}`;
+    try {
+      writeFileSync(tmp, text, 'utf8');
+      renameSync(tmp, full);
+    } catch (cause) {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        // Best-effort cleanup only; the original error below is the one that matters.
+      }
+      throw cause;
+    }
+  }
+
+  return {
+    readCsv(file) {
+      const text = read(file);
+      return text === null ? [] : parseCsv(text);
+    },
+    writeCsv(file, header, rows) {
+      write(file, formatCsv(header, rows));
+    },
+    readNdjson(file) {
+      const text = read(file);
+      return text === null ? [] : parseNdjson(text);
+    },
+    writeNdjson(file, rows) {
+      write(file, formatNdjson(rows));
+    },
+    readMeta() {
+      const text = read('meta.json');
+      if (text === null) return null;
+      let value: unknown;
+      try {
+        value = JSON.parse(text);
+      } catch (cause) {
+        throw new Error('readMeta: meta.json is not valid JSON', { cause });
+      }
+      return parseMeta(value);
+    },
+    writeMeta(meta) {
+      write('meta.json', JSON.stringify(meta, null, 2) + '\n');
+    },
+  };
+}

--- a/scripts/metrics/src/store.ts
+++ b/scripts/metrics/src/store.ts
@@ -144,15 +144,23 @@ export function createStore(dataDir: string): Store {
    * Writes to a sibling temp file in the same directory and `renameSync`s it
    * over the target rather than calling `writeFileSync` on the target
    * directly. A direct write is not atomic: if the process is killed (OOM,
-   * `SIGKILL`, power loss) partway through, the target is left holding a
-   * truncated prefix of the new content, indistinguishable on the next run
-   * from a genuine (if malformed) file — `readCsv`/`readNdjson` would throw
-   * on it as corruption, but the ORIGINAL, previously-good content is gone
-   * either way, and for data GitHub has already deleted upstream that loss
-   * is permanent. A `rename` within the same directory (same filesystem) is
+   * `SIGKILL`) partway through, the target is left holding a truncated
+   * prefix of the new content, indistinguishable on the next run from a
+   * genuine (if malformed) file — `readCsv`/`readNdjson` would throw on it
+   * as corruption, but the ORIGINAL, previously-good content is gone either
+   * way, and for data GitHub has already deleted upstream that loss is
+   * permanent. A `rename` within the same directory (same filesystem) is
    * atomic on POSIX and on NTFS: the target either still holds the old
-   * complete content or holds the new complete content, never a mix, no
-   * matter when the process dies. The temp name includes random bytes so
+   * complete content or holds the new complete content, never a mix.
+   *
+   * The guarantee is against a TORN FILE, not against loss of the write.
+   * Without an `fsync` on the temp file and its directory, an unclean host
+   * power loss can still discard the rename itself on some filesystems. That
+   * is deliberately not defended against: a run that dies mid-write never
+   * reaches the step that commits its output, so the archive simply keeps
+   * yesterday's complete files and the next run refetches — GitHub's traffic
+   * window is 14 days wide, so a lost run is recoverable in a way a torn file
+   * is not. The temp name includes random bytes so
    * concurrent writes to different files (or a crash-and-rerun before
    * cleanup) never collide on one temp path. On failure, the temp file is
    * best-effort unlinked so a partial temp artifact doesn't accumulate next
@@ -172,7 +180,9 @@ export function createStore(dataDir: string): Store {
       } catch {
         // Best-effort cleanup only; the original error below is the one that matters.
       }
-      throw cause;
+      // Wrapped for the same reason the read path wraps: a bare ENOSPC or
+      // EACCES from deep in node:fs does not say which series failed to write.
+      throw new Error(`Store: failed to write "${file}"`, { cause });
     }
   }
 

--- a/scripts/metrics/src/types.ts
+++ b/scripts/metrics/src/types.ts
@@ -1,0 +1,42 @@
+/** A UTC calendar date, `YYYY-MM-DD`. */
+export type IsoDate = string;
+
+/** One day of views or clones. */
+export interface TrafficPoint {
+  date: IsoDate;
+  count: number;
+  uniques: number;
+}
+
+/** One day of a cumulative counter (stars, forks, contributors). */
+export interface CountPoint {
+  date: IsoDate;
+  total: number;
+}
+
+/** A published release. `date` is the UTC day of `published_at`. */
+export interface ReleaseRow {
+  date: IsoDate;
+  tag: string;
+  name: string;
+}
+
+/** One day of repo-object counters. */
+export interface RepoPoint {
+  date: IsoDate;
+  subscribers: number;
+  open_issues: number;
+  downloads_total: number;
+}
+
+/**
+ * One row of a trailing-14-day aggregate, tagged with the day it was fetched.
+ * `dimension` is the referrer host or the content path.
+ */
+export interface DimensionRow {
+  snapshot_date: IsoDate;
+  dimension: string;
+  title: string;
+  count: number;
+  uniques: number;
+}

--- a/scripts/metrics/src/types.ts
+++ b/scripts/metrics/src/types.ts
@@ -21,12 +21,19 @@ export interface ReleaseRow {
   name: string;
 }
 
-/** One day of repo-object counters. */
+/**
+ * One day of repo-object counters. `downloads_total` is sourced from the
+ * optional `releases` fetch, unlike `subscribers`/`open_issues`, which are
+ * required; it is `null` when that fetch failed this run and no fresh sum
+ * could be measured. `null` renders as a blank CSV field (see `formatCsv`),
+ * distinguishing "not measured this run" from a genuine `0` — never collapse
+ * the two.
+ */
 export interface RepoPoint {
   date: IsoDate;
   subscribers: number;
   open_issues: number;
-  downloads_total: number;
+  downloads_total: number | null;
 }
 
 /**

--- a/scripts/metrics/tsconfig.json
+++ b/scripts/metrics/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## What this changes

GitHub deletes repo traffic data (views, clones, referrers, popular paths) after 14 days, and once it's gone it cannot be reconstructed from anything. This adds a daily GitHub Action that snapshots it into an orphan `metrics-data` branch as CSV/NDJSON, retained indefinitely, plus a manually-dispatched backfill that reconstructs the history that permanent timestamps *do* make recoverable (`starred_at`, fork `created_at`, release `published_at`).

No dashboard in this PR — that was deliberately split into a second workstream and does not exist yet.

`scripts/metrics/` is a new zero-runtime-dependency workspace package run directly by Node's native TypeScript type stripping, so there is no build step in the run path.

## Type of change

- [x] New feature

## Design notes

The archive is the only surviving copy of what it records, so the whole package is built around one rule: **a value that was never measured must never look measured.**

- Absent means "not measured"; zero means "measured as zero". Gaps are never zero-filled, and `repo.csv`'s `downloads_total` is written blank rather than zero when the optional releases fetch fails.
- A persistent HTTP 202 from `/stats/*` returns `null` ("GitHub is still computing"), never zero.
- Any *required* fetch failing writes nothing at all; every fetch resolves before any write, and the write phase is synchronous.
- Backfill is write-if-absent and never overwrites a measured value. It reconstructs stars from `starred_at`, which cannot see unstars, so it disagrees with the live counter by design — the measured value wins.
- Both workflows share the `metrics-data` concurrency group, which is what keeps them from racing on the branch.

## Setup this needs

- `METRICS_TOKEN` secret: a fine-grained PAT for this repo only, `Administration: read` + `Contents: read`. `GITHUB_TOKEN` cannot substitute — there is no `administration` key in the Actions `permissions:` vocabulary, so the traffic endpoints are unreachable with it.
- A ruleset on `metrics-data` blocking deletion and force-push (already created, mirroring `cla-signatures`). It deliberately does not require PRs or status checks, because the collector commits directly.

The `metrics-data` branch does not need creating — the workflow bootstraps it on first run.

## Checklist

- [x] `pnpm build` succeeds (shared types, server, and web all build)
- [x] Tests pass where applicable (`pnpm test`) — 168 tests in `@backspace/metrics`, `tsc --noEmit` clean, `actionlint` clean on both workflows
- [x] I updated the relevant `docs/systems/` spec — new `docs/systems/metrics.md`, plus the `CLAUDE.md` subsystem table and the `security-scanning.md` maintainer checklist
- [x] No federated-identity surface: this package talks only to the GitHub API and the local filesystem, and touches no user records

## Notes for reviewers

Worth knowing where the sharp edges were found, since several only appeared at the boundary between the two writers of the same file:

- `/releases` was fetched unpaginated in the collector while backfill paginated it, so `downloads_total` would have silently become a permanent undercount the day a 31st release shipped — a *cumulative* counter that decreases, with no error.
- `releases.csv` was date-keyed, so two releases on the same UTC day collapsed into one row, and the two writers kept different ones. It is now keyed on tag.
- `parseCsv` silently padded a truncated row, converting a measured value into "not measured" and persisting it. It now throws on any field-count mismatch.
- A malformed `METRICS_TOKEN` reaching Node's `Headers.append` throws a `TypeError` that echoes the secret verbatim into a public log. The token is validated for control characters before any request is constructed, so that path is unreachable rather than merely handled.
