### PR TITLE
fix(metrics): stop setup-node priming a pnpm cache that is never installed

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -105,6 +105,11 @@ jobs:
           # Pinned to 24: the CLI is TypeScript executed directly by Node's
           # native type stripping, with no build step and no dependencies.
           node-version: 24
+          # This job never installs anything, so there is no dependency cache to
+          # prime. Left at its default, setup-node detects the repo's pnpm from
+          # the root package.json and fails the step trying to invoke it, because
+          # nothing here installs pnpm the way ci.yml does.
+          package-manager-cache: false
 
       - name: Backfill
         env:

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -105,6 +105,11 @@ jobs:
           # Pinned to 24: the collector is TypeScript executed directly by Node's
           # native type stripping, with no build step and no dependencies.
           node-version: 24
+          # This job never installs anything, so there is no dependency cache to
+          # prime. Left at its default, setup-node detects the repo's pnpm from
+          # the root package.json and fails the step trying to invoke it, because
+          # nothing here installs pnpm the way ci.yml does.
+          package-manager-cache: false
 
       - name: Collect
         env:


### PR DESCRIPTION
The first live dispatch of `metrics.yml` failed at `Setup Node.js` with `Unable to locate executable file: pnpm`.

`actions/setup-node` defaults `package-manager-cache` to true, which detects the repo's pnpm from the root `package.json` and tries to invoke it to prime a cache. `ci.yml` gets away with this because it runs `pnpm/action-setup` first; the metrics workflows deliberately do not, because `@backspace/metrics` has zero runtime dependencies and installs nothing.

Turning the cache off is the correct fix rather than installing pnpm: there is genuinely nothing to cache.

Everything either side of this step already worked on that run — the orphan branch bootstrapped correctly on a repo where `metrics-data` did not exist, the data-branch checkout succeeded, and the failure path recorded and pushed `meta.json` as designed.