### PR TITLE
fix(metrics): separate app downloads from update-check traffic

### DIFF
--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -119,7 +119,13 @@ All files live at the root of the `metrics-data` branch. CSVs are sorted ascendi
 | `forks.csv` | `date,total` | The repo's live `forks_count` as read on that date — see the caveat below the table |
 | `releases.csv` | `date,tag,name` | A release published on that UTC date (`date` = `published_at`'s UTC day) — see the caveat below the table |
 | `contributors.csv` | `date,total` | Cumulative distinct-contributor count, where a contributor counts from the UTC date of the start of their first commit week onward. Capped: see the note below the table |
-| `repo.csv` | `date,subscribers,open_issues,downloads_total` | The repo object's counters as read on that date, plus the sum of every release asset's `download_count` |
+| `repo.csv` | `date,subscribers,open_issues,downloads_total,downloads_app,downloads_updates` | The repo object's counters as read on that date, plus release asset `download_count` sums: every asset, then that total split into app installs and update-check traffic |
+
+**The download split.** `downloads_total` sums every release asset. That number is dominated by update machinery rather than by installs: electron-updater fetches `latest.yml` / `latest-mac.yml` / `latest-linux.yml` on every update check from every installed client, and `.blockmap` files during a differential update, and GitHub counts all of them in `download_count` exactly like an installer. When the split was added on 2026-09-02 the feed files had 1,519 downloads against 323 for every real installer and archive combined, so the single figure overstated installs by roughly 5.7x.
+
+`downloads_app` counts installers and archives; `downloads_updates` counts anything matching `*.yml`, `*.yaml` or `*.blockmap` (`isUpdateArtifact` in `collect.ts`). For any row carrying all three, `downloads_app + downloads_updates === downloads_total`.
+
+`downloads_total` keeps its original meaning and is still written, because redefining a column in place would silently change what its historical rows mean. Rows written before the split stay **blank** in the two new columns, never `0`: the archive never measured that split for those days, and `formatCsv` writes a missing field as an empty value, which the bundler maps to `null`. The dashboard shows `downloads_app` and `downloads_updates` as separate cards and no longer shows the combined total, which answered neither question.
 
 `repo.csv.downloads_total` is a `number | null` in memory (`RepoPoint` in `types.ts`) and is written as a **blank CSV field**, never `0`, whenever the optional `/releases` fetch fails that run (see §5). `subscribers` and `open_issues` are never blank — they come from the required `/repos/{slug}` fetch, which has already succeeded by the time `repo.csv` is written.
 
@@ -404,7 +410,8 @@ interface DashboardData {
 interface TrafficSeries { dates: string[]; count: Array<number | null>; uniques: Array<number | null>; }
 interface CountSeries   { dates: string[]; total: Array<number | null>; }
 interface RepoSeries    { dates: string[]; subscribers: Array<number | null>;
-                          open_issues: Array<number | null>; downloads_total: Array<number | null>; }
+                          open_issues: Array<number | null>; downloads_total: Array<number | null>;
+                          downloads_app: Array<number | null>; downloads_updates: Array<number | null>; }
 
 interface DimensionSeries {
   /** Snapshot dates, ascending. */

--- a/scripts/metrics/src/bundle.test.ts
+++ b/scripts/metrics/src/bundle.test.ts
@@ -130,6 +130,32 @@ describe('buildDashboardData — the not-measured distinction', () => {
     expect(build().series.repo.downloads_total[0]).toBe(0);
   });
 
+  it('maps a pre-split repo row to null for the download split, never to zero', () => {
+    // Exactly the shape on disk for every row written before the split
+    // columns existed: the field is ABSENT from the header, not merely blank.
+    writeRaw('repo.csv', 'date,subscribers,open_issues,downloads_total\n2026-09-01,1,18,1802\n');
+    const data = build();
+    expect(data.series.repo.downloads_total).toEqual([1802]);
+    expect(data.series.repo.downloads_app).toEqual([null]);
+    expect(data.series.repo.downloads_updates).toEqual([null]);
+    expect(data.series.repo.downloads_app[0]).not.toBe(0);
+    expect(data.series.repo.downloads_updates[0]).not.toBe(0);
+  });
+
+  it('parses a populated download split and keeps a measured zero at zero', () => {
+    writeRaw(
+      'repo.csv',
+      'date,subscribers,open_issues,downloads_total,downloads_app,downloads_updates\n' +
+        '2026-09-03,1,18,323,323,0\n',
+    );
+    const data = build();
+    expect(data.series.repo.downloads_app).toEqual([323]);
+    // A release with no update feed yet genuinely has zero update traffic.
+    // That is a measurement, and must not be flattened into a break.
+    expect(data.series.repo.downloads_updates).toEqual([0]);
+    expect(data.series.repo.downloads_updates[0]).not.toBeNull();
+  });
+
   it('parses a populated downloads_total as a number', () => {
     writeRaw('repo.csv', 'date,subscribers,open_issues,downloads_total\n2026-09-01,1,18,4210\n');
 
@@ -220,6 +246,8 @@ describe('buildDashboardData — absent vs. corrupt files', () => {
       subscribers: [],
       open_issues: [],
       downloads_total: [],
+      downloads_app: [],
+      downloads_updates: [],
     });
     expect(data.releases).toEqual([]);
     expect(data.dimensions.referrers).toEqual({ snapshots: [], latest: [], trajectories: [] });
@@ -741,7 +769,14 @@ function makeData(overrides: Partial<DashboardData> = {}): DashboardData {
       stars: { dates: [], total: [] },
       forks: { dates: [], total: [] },
       contributors: { dates: [], total: [] },
-      repo: { dates: [], subscribers: [], open_issues: [], downloads_total: [] },
+      repo: {
+        dates: [],
+        subscribers: [],
+        open_issues: [],
+        downloads_total: [],
+        downloads_app: [],
+        downloads_updates: [],
+      },
     },
     releases: [],
     dimensions: {
@@ -824,6 +859,10 @@ describe('downsampleWeekly — sum vs. last', () => {
       subscribers: [12],
       open_issues: [22],
       downloads_total: [320],
+      // Absent from this pre-split fixture, so the weekly bucket carries the
+      // same "not measured" it was given, never a zero.
+      downloads_app: [null],
+      downloads_updates: [null],
     });
   });
 
@@ -1124,6 +1163,8 @@ describe('downsampleWeekly — what it must not touch', () => {
       subscribers: [],
       open_issues: [],
       downloads_total: [],
+      downloads_app: [],
+      downloads_updates: [],
     });
     expect(weekly.empty).toBe(true);
   });

--- a/scripts/metrics/src/bundle.ts
+++ b/scripts/metrics/src/bundle.ts
@@ -42,6 +42,8 @@ export interface RepoSeries {
   subscribers: Array<number | null>;
   open_issues: Array<number | null>;
   downloads_total: Array<number | null>;
+  downloads_app: Array<number | null>;
+  downloads_updates: Array<number | null>;
 }
 
 /**
@@ -259,6 +261,15 @@ function readRepoSeries(store: Store): RepoSeries {
     ),
     downloads_total: rows.map((row) =>
       toNumberOrNull(row.fields['downloads_total'], `${REPO_FILE} downloads_total`, row.date),
+    ),
+    // Absent from every row written before the split existed. `toNumberOrNull`
+    // maps both an absent field and a blank one to null, so those rows read as
+    // "not measured" rather than as a zero download count.
+    downloads_app: rows.map((row) =>
+      toNumberOrNull(row.fields['downloads_app'], `${REPO_FILE} downloads_app`, row.date),
+    ),
+    downloads_updates: rows.map((row) =>
+      toNumberOrNull(row.fields['downloads_updates'], `${REPO_FILE} downloads_updates`, row.date),
     ),
   };
 }
@@ -698,6 +709,12 @@ function downsampleRepo(series: RepoSeries): RepoSeries {
     ),
     downloads_total: buckets.map((bucket) =>
       lastBucket(series.dates, series.downloads_total, bucket.indices),
+    ),
+    downloads_app: buckets.map((bucket) =>
+      lastBucket(series.dates, series.downloads_app, bucket.indices),
+    ),
+    downloads_updates: buckets.map((bucket) =>
+      lastBucket(series.dates, series.downloads_updates, bucket.indices),
     ),
   };
 }

--- a/scripts/metrics/src/collect.test.ts
+++ b/scripts/metrics/src/collect.test.ts
@@ -39,7 +39,10 @@ const RELEASES = [
     tag_name: 'v1.0.0',
     name: 'Backspace 1.0.0',
     published_at: '2026-08-01T10:00:00Z',
-    assets: [{ download_count: 20 }, { download_count: 17 }],
+    assets: [
+      { name: 'App-1.0.0-x64.exe', download_count: 20 },
+      { name: 'App-1.0.0.dmg', download_count: 17 },
+    ],
   },
 ];
 const CONTRIBUTORS = [{ weeks: [{ w: 1771200000, c: 3 }] }, { weeks: [{ w: 1771804800, c: 1 }] }];
@@ -136,8 +139,66 @@ describe('collect', () => {
         subscribers: '1',
         open_issues: '13',
         downloads_total: '37',
+        downloads_app: '37',
+        downloads_updates: '0',
       },
     ]);
+  });
+
+  it('splits release downloads into app installs and update-check traffic', async () => {
+    const store = createStore(dir);
+    const client = fakeClient({
+      '/repos/o/r/releases': [
+        {
+          tag_name: 'v1.0.0',
+          name: 'v1.0.0',
+          published_at: '2026-08-01T00:00:00Z',
+          assets: [
+            { name: 'Backspace-1.0.0-x64.exe', download_count: 139 },
+            { name: 'Backspace-1.0.0-arm64.dmg', download_count: 17 },
+            { name: 'latest.yml', download_count: 1203 },
+            { name: 'latest-mac.yml', download_count: 62 },
+            { name: 'Backspace-1.0.0-x64.exe.blockmap', download_count: 4 },
+          ],
+        },
+      ],
+    });
+    await collect({ client, store, ...base });
+    const row = store.readCsv('repo.csv')[0];
+    // The whole point: the headline figure is the 156 real installs, not the
+    // 1,425 that a plain sum over every asset would have reported.
+    expect(row?.downloads_app).toBe('156');
+    expect(row?.downloads_updates).toBe('1269');
+    expect(row?.downloads_total).toBe('1425');
+  });
+
+  it('keeps the split a decomposition of the total, never an overlap or a gap', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const row = store.readCsv('repo.csv')[0];
+    expect(Number(row?.downloads_app) + Number(row?.downloads_updates)).toBe(
+      Number(row?.downloads_total),
+    );
+  });
+
+  it('leaves the split blank on rows written before it existed, never zero', async () => {
+    const store = createStore(dir);
+    // A row as the collector wrote it before the split columns were added.
+    store.writeCsv(
+      'repo.csv',
+      ['date', 'subscribers', 'open_issues', 'downloads_total'],
+      [{ date: '2026-08-24', subscribers: 1, open_issues: 10, downloads_total: 1802 }],
+    );
+    await collect({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('repo.csv');
+    const old = rows.find((r) => r['date'] === '2026-08-24');
+    // A zero here would claim nobody had ever downloaded the app up to that
+    // day, which the archive never measured. Blank reads as "not measured".
+    expect(old?.downloads_app).toBe('');
+    expect(old?.downloads_updates).toBe('');
+    expect(old?.downloads_app).not.toBe('0');
+    // The pre-existing total is untouched: its definition did not change.
+    expect(old?.downloads_total).toBe('1802');
   });
 
   it('records release publish dates for the growth-chart annotations', async () => {
@@ -163,10 +224,10 @@ describe('collect', () => {
       'https://api.github.com/repos/o/r': REPO,
     };
     const page1 = [
-      { tag_name: 'v2.0.0', name: 'v2.0.0', published_at: '2026-08-10T00:00:00Z', assets: [{ download_count: 5 }] },
+      { tag_name: 'v2.0.0', name: 'v2.0.0', published_at: '2026-08-10T00:00:00Z', assets: [{ name: 'App-2.0.0.dmg', download_count: 5 }] },
     ];
     const page2 = [
-      { tag_name: 'v1.0.0', name: 'v1.0.0', published_at: '2026-08-01T00:00:00Z', assets: [{ download_count: 7 }] },
+      { tag_name: 'v1.0.0', name: 'v1.0.0', published_at: '2026-08-01T00:00:00Z', assets: [{ name: 'App-1.0.0.dmg', download_count: 7 }] },
     ];
     const fetchImpl = (async (url: string) => {
       if (url === 'https://api.github.com/repos/o/r/releases?per_page=100') {
@@ -334,8 +395,22 @@ describe('collect', () => {
     const result = await collect({ client, store, ...base });
     const rows = store.readCsv('repo.csv');
     expect(rows).toEqual([
-      { date: '2026-08-24', subscribers: '1', open_issues: '10', downloads_total: '25' },
-      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '' },
+      {
+        date: '2026-08-24',
+        subscribers: '1',
+        open_issues: '10',
+        downloads_total: '25',
+        downloads_app: '',
+        downloads_updates: '',
+      },
+      {
+        date: '2026-08-25',
+        subscribers: '1',
+        open_issues: '13',
+        downloads_total: '',
+        downloads_app: '',
+        downloads_updates: '',
+      },
     ]);
     expect(rows[1]?.downloads_total).toBe('');
     expect(rows[1]?.subscribers).toBe('1');
@@ -349,7 +424,14 @@ describe('collect', () => {
     const client = fakeClient({ '/repos/o/r/releases': new Error('502') });
     const result = await collect({ client, store, ...base });
     expect(store.readCsv('repo.csv')).toEqual([
-      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '' },
+      {
+        date: '2026-08-25',
+        subscribers: '1',
+        open_issues: '13',
+        downloads_total: '',
+        downloads_app: '',
+        downloads_updates: '',
+      },
     ]);
     expect(result.skipped).toContain('repo.csv:downloads_total');
     expect(result.skipped).not.toContain('repo.csv');
@@ -366,8 +448,22 @@ describe('collect', () => {
     );
     const result = await collect({ client: fakeClient(), store, ...base });
     expect(store.readCsv('repo.csv')).toEqual([
-      { date: '2026-08-24', subscribers: '1', open_issues: '10', downloads_total: '' },
-      { date: '2026-08-25', subscribers: '1', open_issues: '13', downloads_total: '37' },
+      {
+        date: '2026-08-24',
+        subscribers: '1',
+        open_issues: '10',
+        downloads_total: '',
+        downloads_app: '',
+        downloads_updates: '',
+      },
+      {
+        date: '2026-08-25',
+        subscribers: '1',
+        open_issues: '13',
+        downloads_total: '37',
+        downloads_app: '37',
+        downloads_updates: '0',
+      },
     ]);
     expect(result.skipped).not.toContain('repo.csv:downloads_total');
   });

--- a/scripts/metrics/src/collect.ts
+++ b/scripts/metrics/src/collect.ts
@@ -42,8 +42,28 @@ interface ReleaseResponse {
   tag_name: string;
   name: string | null;
   published_at: string | null;
-  assets: Array<{ download_count: number }>;
+  assets: Array<{ name: string; download_count: number }>;
 }
+/**
+ * Whether a release asset is update machinery rather than a user-initiated
+ * download.
+ *
+ * electron-updater fetches `latest.yml` / `latest-mac.yml` / `latest-linux.yml`
+ * on every update check from every installed client, and `.blockmap` files
+ * while performing a differential update. GitHub counts those in
+ * `download_count` exactly like an installer, so summing every asset reports
+ * mostly polling traffic: on this repo the feed files outnumbered real
+ * installer downloads by roughly five to one, which made a published
+ * "release downloads" figure overstate installs several-fold.
+ *
+ * "How many people installed this" and "how many clients are checking in" are
+ * two different questions, so they are recorded as two different columns
+ * rather than one number that answers neither.
+ */
+export function isUpdateArtifact(assetName: string): boolean {
+  return /\.(ya?ml|blockmap)$/i.test(assetName);
+}
+
 interface ContributorResponse {
   weeks: Array<{ w: number; c: number }>;
 }
@@ -189,15 +209,35 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   // the required repo-object fetch, which has already resolved successfully
   // by the time this runs, so a `releases` failure never costs the row those
   // two required fields.
+  //
+  // `downloads_total` keeps its original meaning — every asset, including
+  // update machinery — because it is an existing series and redefining a
+  // column in place would silently change what its historical rows mean.
+  // `downloads_app` and `downloads_updates` decompose it, and hold for every
+  // row written from here on; rows written before the split stay blank in
+  // both, which renders as a break rather than a fabricated zero. For any row
+  // carrying all three, `downloads_app + downloads_updates === downloads_total`.
   let downloadsTotal: number | null;
+  let downloadsApp: number | null;
+  let downloadsUpdates: number | null;
   if (releases !== null) {
-    downloadsTotal = releases.reduce(
-      (sum, release) =>
-        sum + release.assets.reduce((assetSum, asset) => assetSum + asset.download_count, 0),
-      0,
-    );
+    let total = 0;
+    let app = 0;
+    let updates = 0;
+    for (const release of releases) {
+      for (const asset of release.assets) {
+        total += asset.download_count;
+        if (isUpdateArtifact(asset.name)) updates += asset.download_count;
+        else app += asset.download_count;
+      }
+    }
+    downloadsTotal = total;
+    downloadsApp = app;
+    downloadsUpdates = updates;
   } else {
     downloadsTotal = null;
+    downloadsApp = null;
+    downloadsUpdates = null;
     skipped.push('repo.csv:downloads_total');
   }
 
@@ -326,8 +366,14 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
     subscribers: repo.subscribers_count,
     open_issues: repo.open_issues_count,
     downloads_total: downloadsTotal,
+    downloads_app: downloadsApp,
+    downloads_updates: downloadsUpdates,
   };
-  writeCsvSeries('repo.csv', ['date', 'subscribers', 'open_issues', 'downloads_total'], [repoPoint]);
+  writeCsvSeries(
+    'repo.csv',
+    ['date', 'subscribers', 'open_issues', 'downloads_total', 'downloads_app', 'downloads_updates'],
+    [repoPoint],
+  );
 
   if (releases !== null) {
     const releaseRows: ReleaseRow[] = releases

--- a/scripts/metrics/src/types.ts
+++ b/scripts/metrics/src/types.ts
@@ -34,6 +34,14 @@ export interface RepoPoint {
   subscribers: number;
   open_issues: number;
   downloads_total: number | null;
+  /**
+   * `downloads_total` split by what the asset is for: `downloads_app` counts
+   * installers and archives, `downloads_updates` counts electron-updater feed
+   * files and blockmaps that every installed client fetches on an update
+   * check. Both are blank for rows written before the split existed.
+   */
+  downloads_app: number | null;
+  downloads_updates: number | null;
 }
 
 /**

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -858,7 +858,8 @@ footer a:hover { color: var(--txt); }
       checkSeries(d.series.stars, "series.stars", ["total"]) ||
       checkSeries(d.series.forks, "series.forks", ["total"]) ||
       checkSeries(d.series.contributors, "series.contributors", ["total"]) ||
-      checkSeries(d.series.repo, "series.repo", ["subscribers", "open_issues", "downloads_total"]) ||
+      checkSeries(d.series.repo, "series.repo",
+        ["subscribers", "open_issues", "downloads_total", "downloads_app", "downloads_updates"]) ||
       checkReleases(d.releases);
     if (problem !== null) return problem;
 
@@ -1623,7 +1624,17 @@ footer a:hover { color: var(--txt); }
     { label: "Views", kind: "flow", series: "views", field: "count" },
     { label: "Clones", kind: "flow", series: "clones", field: "count" },
     { label: "Contributors", kind: "step", series: "contributors", field: "total" },
-    { label: "Release downloads", kind: "point", series: "repo", field: "downloads_total" }
+    /* Deliberately NOT one "Release downloads" figure. GitHub counts an
+       electron-updater feed file (`latest.yml`) and a `.blockmap` in
+       `download_count` exactly like an installer, and every installed client
+       fetches the feed on every update check, so a combined total is
+       dominated by polling: when this split was introduced the feed files
+       outnumbered real installs about five to one. Two cards answer two
+       different questions instead of one number answering neither.
+       Both read null for rows the archive recorded before the split, which
+       renders as a dash rather than a zero. */
+    { label: "App downloads", kind: "point", series: "repo", field: "downloads_app" },
+    { label: "Update checks", kind: "point", series: "repo", field: "downloads_updates" }
   ];
 
   /* The series whose coverage inside the selected range is worth stating, and


### PR DESCRIPTION
## What this changes

The "Release downloads" figure was misleading. GitHub counts an electron-updater feed file (`latest.yml`) and a `.blockmap` in `download_count` exactly like an installer, and **every installed desktop client fetches the feed on every update check**. The published number was therefore mostly polling traffic:

| Category | Downloads |
|---|---|
| Update metadata (`latest*.yml`) | 1,519 |
| Delta-update helpers (`.blockmap`) | 3 |
| **Actual installers and archives** | **323** |
| Published as "Release downloads" | **1,841** |

About 83% of the headline figure was update polling, overstating real installs by roughly 5.7x.

`repo.csv` gains `downloads_app` and `downloads_updates`, and the dashboard replaces the one combined card with those two.

## Type of change

- [x] Bug fix
- [x] Documentation

## Checklist

- [ ] ~`pnpm build` / `pnpm dev`~ - N/A, no app code touched
- [x] Tests pass - 262/262 (5 new), `tsc --noEmit` clean, `actionlint` clean
- [x] Updated `docs/systems/metrics.md` - this is a schema change to `repo.csv` and to the bundle contract

## Notes for reviewers

**`downloads_total` is kept and still written.** Redefining a column in place would silently change what its historical rows mean: the two rows already in the archive would start reading as app-only figures they never were. The old column keeps its old meaning; the two new ones decompose it going forward, and `downloads_app + downloads_updates === downloads_total` for any row carrying all three (pinned by a test).

**Rows written before the split stay blank, not zero.** This is the case worth checking closely. `formatCsv` writes a missing field as an empty value and the bundler maps that to `null`, so the pre-split rows render as "No measurement recorded" rather than claiming nobody had ever downloaded the app. Verified in a browser against a real pre-split bundle: the cards show no number and no zero.

**Classification** is `*.yml`, `*.yaml`, `*.blockmap` (`isUpdateArtifact` in `collect.ts`), case-insensitive. Blockmaps are grouped with updates because they are fetched during differential updates, not by a person.

**After merge the two cards will read "No measurement recorded" until the collector next runs**, because the archive does not carry the new columns yet. That is correct rather than broken. I will trigger a collection right after the deploy so the real values land.

**Verified:** 10/10 browser assertions across both states (pre-split archive and post-split), plus the bundler invariant. `backfill.ts` is unaffected: it already excludes `repo.csv`.