### PR TITLE
fix(metrics): run the backfill with GITHUB_TOKEN instead of the collector PAT

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -113,13 +113,22 @@ jobs:
 
       - name: Backfill
         env:
-          # Must be the PAT, not GITHUB_TOKEN: the latter carries a 1,000
-          # requests/hour per-repository limit rather than 5,000, and in any
-          # case cannot reach the traffic-scoped "Administration: read"
-          # permission the collector needs — see metrics.yml's header. This
-          # job does not read traffic, but it uses the same token as the
-          # daily collector for one PAT rather than provisioning a second.
-          METRICS_TOKEN: ${{ secrets.METRICS_TOKEN }}
+          # GITHUB_TOKEN, deliberately, NOT the collector's PAT. This job
+          # reads no traffic, so it never needs the "Administration: read"
+          # permission that forces metrics.yml onto a PAT; it reads only
+          # stargazers, forks and releases. Sharing the collector's
+          # fine-grained PAT here was the original choice and it does not
+          # work: that token is refused by the stargazers endpoint with
+          # "Resource not accessible by personal access token" (HTTP 403),
+          # which failed the job before it wrote anything.
+          #
+          # GITHUB_TOKEN's 1,000 requests/hour per-repository limit is not a
+          # constraint at this size: the three paginated calls cost a handful
+          # of requests, and this workflow is dispatched by hand, not on a
+          # schedule. The stargazers endpoint does require authentication --
+          # it answers 401 unauthenticated -- so this cannot simply drop the
+          # token instead.
+          METRICS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           METRICS_DATA_DIR: ${{ github.workspace }}/.metrics-data
         run: node scripts/metrics/src/cli-backfill.ts


### PR DESCRIPTION
## What this changes

`backfill.yml` had never been run. Dispatching it failed immediately:

```
GitHub API error (status 403): Resource not accessible by personal access token
  documentation_url: .../rest/activity/starring#list-stargazers
```

The job passed the collector's fine-grained `METRICS_TOKEN`, which the stargazers endpoint refuses. The workflow's own comment explains the PAT was chosen only to avoid provisioning a second token, and notes this job does not read traffic - so it never needed the `Administration: read` permission that forces `metrics.yml` onto a PAT in the first place.

Switching the backfill step to `GITHUB_TOKEN` fixes it. Verified by dispatching this branch: the run succeeded and reconstructed the history.

## Type of change

- [x] Bug fix

## Checklist

- [x] `actionlint` clean
- [ ] ~`pnpm build` / `pnpm dev` / tests~ - N/A, one workflow env value; no source change

## Notes for reviewers

**Why not just drop the token:** the stargazers endpoint answers **401 unauthenticated**, so it genuinely needs one. (`/forks` and `/releases` are both 200 unauthenticated; stargazers is the odd one out.)

**Rate limit:** `GITHUB_TOKEN` carries 1,000 requests/hour per repository rather than the PAT's 5,000. Not a constraint here - the three paginated calls cost a handful of requests, and this workflow is dispatched by hand, never scheduled.

**Result of the successful run:** `stars.csv` went from 2 rows to 31, reconstructed back to 2026-07-03; `forks.csv` from 2 rows to 6. All writes are `if-absent`, so the collector-measured rows for 2026-09-01 and 2026-09-02 were left untouched, exactly as `backfill.test.ts` pins down.

**Known limit, already documented in `backfill.ts`:** reconstruction reads `starred_at` for *current* stargazers only, so anyone who starred and later unstarred is invisible and historical values are a lower bound. The collector's live-counter rows remain authoritative for the dates it has covered.