### PR TITLE
feat(insights): publish the archive in a form crawlers can read

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -152,6 +152,11 @@ jobs:
         env:
           METRICS_DATA_DIR: ${{ github.workspace }}/.metrics-data
           METRICS_OUTPUT_PATH: ${{ github.workspace }}/site/insights/data.json
+          # Lets the static data page emit absolute links and schema.org
+          # Dataset metadata. Optional by design: a fork that has not set it
+          # still gets a correct page with relative links, rather than one
+          # advertising this deployment's domain as the home of its data.
+          METRICS_SITE_URL: https://thezwiss.github.io/backspace
         run: node scripts/metrics/src/cli-bundle.ts
 
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ tests/reports/*
 # A build artifact, never committed: the metrics-data branch is the single source
 # of truth, and a committed derived copy invites the two to disagree.
 site/insights/data.json
+# Generated beside it at deploy time by cli-bundle.ts: the same archive as
+# static, no-JavaScript tables. Listed explicitly rather than left to the
+# generic `data/` rule above, which exists for packages/server/data/.
+site/insights/data/

--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -121,6 +121,20 @@ All files live at the root of the `metrics-data` branch. CSVs are sorted ascendi
 | `contributors.csv` | `date,total` | Cumulative distinct-contributor count, where a contributor counts from the UTC date of the start of their first commit week onward. Capped: see the note below the table |
 | `repo.csv` | `date,subscribers,open_issues,downloads_total,downloads_app,downloads_updates` | The repo object's counters as read on that date, plus release asset `download_count` sums: every asset, then that total split into app installs and update-check traffic |
 
+### The static data page
+
+`cli-bundle.ts` writes a second artifact beside `data.json`: `<bundle dir>/data/index.html`, served at `…/insights/data/`. It is rendered by `renderDataPage` in `datapage.ts`, a pure function over the same `DashboardData` the charts are built from, so the two encodings cannot disagree about a figure.
+
+It exists because the dashboard draws every value client-side. A text-only crawler, an LLM fetching the URL, or a reader with JavaScript disabled otherwise sees the headings and the methodology and not one measured number. The static page carries the values as real `<table>` rows, plus a schema.org `Dataset` block naming `data.json` as a machine-readable `distribution` — without which nothing on the site tells a crawler that `data.json` exists at all.
+
+Three properties worth keeping:
+
+- **Escaping is load-bearing, not cosmetic.** Referrer hostnames and popular paths are strings GitHub reports from real traffic, so they originate outside this repo and reach the page verbatim. `escapeHtml` covers `& < > " '`, ampersand first so replacements are not re-escaped, and `jsonLd` additionally escapes `<` so a `</script>` sequence in the data cannot terminate the structured-data block early. Both are pinned by tests in `datapage.test.ts`.
+- **The page inherits the absent-versus-zero rule.** A `null` renders as the words `not measured`, never as `0`; a measured zero renders as `0`. It also reports the resolution it was handed, so a downsampled bundle is labelled as weekly buckets rather than silently presented as daily.
+- **The output path is derived, not configured.** It is `data/index.html` inside `METRICS_OUTPUT_PATH`'s directory. A second path variable would be a second thing that can point elsewhere, at which point the page and the JSON it mirrors can disagree about where each lives. `METRICS_SITE_URL` is separate and genuinely optional: set, the page emits absolute links and `Dataset` URLs; unset, it links relatively, so a fork gets a correct page rather than one advertising this deployment's domain as the home of its data.
+
+Both `site/insights/data.json` and `site/insights/data/` are gitignored: they exist only inside a deploy run.
+
 **The download split.** `downloads_total` sums every release asset. That number is dominated by update machinery rather than by installs: electron-updater fetches `latest.yml` / `latest-mac.yml` / `latest-linux.yml` on every update check from every installed client, and `.blockmap` files during a differential update, and GitHub counts all of them in `download_count` exactly like an installer. When the split was added on 2026-09-02 the feed files had 1,519 downloads against 323 for every real installer and archive combined, so the single figure overstated installs by roughly 5.7x.
 
 `downloads_app` counts installers and archives; `downloads_updates` counts anything matching `*.yml`, `*.yaml` or `*.blockmap` (`isUpdateArtifact` in `collect.ts`). For any row carrying all three, `downloads_app + downloads_updates === downloads_total`.

--- a/scripts/metrics/src/cli-bundle.ts
+++ b/scripts/metrics/src/cli-bundle.ts
@@ -8,6 +8,7 @@ import {
   BUNDLE_BUDGET_BYTES,
 } from './bundle.ts';
 import { requiredEnv, deriveRunTimestamps, describeFailure } from './cli-support.ts';
+import { renderDataPage } from './datapage.ts';
 
 /**
  * Entrypoint invoked by `.github/workflows/deploy-pages.yml` as
@@ -20,6 +21,10 @@ import { requiredEnv, deriveRunTimestamps, describeFailure } from './cli-support
  *   and `cli-backfill.ts` read, so all three entrypoints name the checkout
  *   once and identically.
  * - `METRICS_OUTPUT_PATH` — where to write the bundle, `site/insights/data.json`
+ * - `METRICS_SITE_URL` — optional. The deployed site's base URL, used to emit
+ *   absolute links and `Dataset` metadata on the static data page. Omitted, the
+ *   page still renders and links relatively; a fork that has not set it gets a
+ *   correct page rather than one pointing at somebody else's domain.
  *   in the deploy workflow. Parameterised rather than hardcoded so a
  *   maintainer can generate a bundle anywhere for inspection without
  *   dirtying the site tree, and so this file has no opinion about the site's
@@ -83,6 +88,30 @@ async function main(): Promise<void> {
     `wrote ${full}: ${result.bytes} bytes of the ${BUNDLE_BUDGET_BYTES}-byte budget ` +
       `(downsampled: ${result.downsampled ? 'yes, weekly buckets' : 'no, daily'})`,
   );
+
+  // The static, no-JavaScript rendering of the same bundle, written beside it
+  // as `<bundle dir>/data/index.html` so it serves at `…/insights/data/`.
+  //
+  // Derived from the bundle's own path rather than configured separately, on
+  // purpose: the two files are one artifact in two encodings, and a second
+  // path variable is a second thing that can be pointed somewhere else, at
+  // which point the page and the JSON it claims to mirror can disagree about
+  // where each of them lives.
+  //
+  // It exists because the dashboard draws every value client-side: a text-only
+  // crawler, or a reader with JavaScript off, otherwise sees the methodology
+  // and not one measured number. `serialiseWithinBudget` may have downsampled
+  // `data` to weekly buckets, and this renders whatever it was handed, so the
+  // page always states the resolution it is actually showing.
+  const pagePath = path.join(path.dirname(full), 'data', 'index.html');
+  const html = renderDataPage(data, { siteUrl: process.env['METRICS_SITE_URL'] });
+  try {
+    mkdirSync(path.dirname(pagePath), { recursive: true });
+    writeFileSync(pagePath, html, 'utf8');
+  } catch (cause) {
+    throw new Error(`cli-bundle: failed to write "${pagePath}"`, { cause });
+  }
+  console.log(`wrote ${pagePath}: ${Buffer.byteLength(html, 'utf8')} bytes of static tables`);
 
   // Last line of the run, on stderr, so it is the thing a maintainer sees at
   // the bottom of a green deploy log rather than something buried above the

--- a/scripts/metrics/src/datapage.test.ts
+++ b/scripts/metrics/src/datapage.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { renderDataPage, escapeHtml, jsonLd } from './datapage.ts';
+import type { DashboardData } from './bundle.ts';
+
+function data(overrides: Partial<DashboardData> = {}): DashboardData {
+  return {
+    generated_at: '2026-09-02T10:00:00.000Z',
+    collection_started: '2026-08-18',
+    meta: { last_run: null, last_success: null, error: null },
+    empty: false,
+    downsampled: false,
+    series: {
+      views: { dates: ['2026-08-18'], count: [75], uniques: [23] },
+      clones: { dates: ['2026-08-18'], count: [10], uniques: [8] },
+      stars: { dates: ['2026-08-18'], total: [52] },
+      forks: { dates: [], total: [] },
+      contributors: { dates: [], total: [] },
+      repo: {
+        dates: ['2026-08-18'],
+        subscribers: [1],
+        open_issues: [18],
+        downloads_total: [1802],
+        downloads_app: [null],
+        downloads_updates: [0],
+      },
+    },
+    releases: [],
+    dimensions: {
+      referrers: { snapshots: [], latest: [], trajectories: [] },
+      paths: { snapshots: [], latest: [], trajectories: [] },
+    },
+    ...overrides,
+  } as DashboardData;
+}
+
+describe('escapeHtml', () => {
+  it('escapes every character that can break out of markup', () => {
+    expect(escapeHtml(`<>&"'`)).toBe('&lt;&gt;&amp;&quot;&#39;');
+  });
+
+  it('escapes the ampersand first so escapes are not double-escaped', () => {
+    // Naive ordering turns `<` into `&lt;` and then the `&` of that into
+    // `&amp;lt;`, rendering the literal text "&lt;" on the page.
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('&lt;')).toBe('&amp;lt;');
+  });
+});
+
+describe('jsonLd', () => {
+  it('neutralises a closing script tag hidden in the data', () => {
+    const out = jsonLd({ name: '</script><img src=x onerror=alert(1)>' });
+    expect(out).not.toContain('</script>');
+    expect(JSON.parse(out.replace(/\\u003c/g, '<')).name).toBe(
+      '</script><img src=x onerror=alert(1)>',
+    );
+  });
+});
+
+describe('renderDataPage', () => {
+  it('puts the measured values in the HTML itself, not behind a fetch', () => {
+    const html = renderDataPage(data());
+    expect(html).toContain('75');
+    expect(html).toContain('>23<');
+    expect(html).not.toContain('<script src');
+  });
+
+  it('renders an unmeasured value as words, never as a zero', () => {
+    const html = renderDataPage(data());
+    expect(html).toContain('not measured');
+    // downloads_app is null here; a "0" cell for it would be a fabricated
+    // measurement, which is the one thing this whole archive exists to avoid.
+    expect(html).not.toMatch(/<td class="n">0<\/td>\s*<td class="n">0<\/td>/);
+  });
+
+  it('renders a measured zero at zero rather than as unmeasured', () => {
+    // downloads_updates is 0, a real reading, and must survive as one.
+    expect(renderDataPage(data())).toContain('<td class="n">0</td>');
+  });
+
+  it('escapes a referrer that tries to inject markup', () => {
+    const html = renderDataPage(
+      data({
+        dimensions: {
+          referrers: {
+            snapshots: ['2026-09-01'],
+            latest: [
+              {
+                dimension: '<script>alert(1)</script>',
+                title: '"><img src=x onerror=alert(2)>',
+                count: 1,
+                uniques: 1,
+              },
+            ],
+            trajectories: [],
+          },
+          paths: { snapshots: [], latest: [], trajectories: [] },
+        },
+      } as Partial<DashboardData>),
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('links relatively when no site URL is configured', () => {
+    const html = renderDataPage(data());
+    expect(html).toContain('href="../data.json"');
+    expect(html).not.toContain('https://thezwiss.github.io');
+  });
+
+  it('links absolutely when a site URL is configured, tolerating a trailing slash', () => {
+    const html = renderDataPage(data(), { siteUrl: 'https://example.com/repo/' });
+    expect(html).toContain('https://example.com/repo/insights/data.json');
+    expect(html).not.toContain('repo//insights');
+  });
+
+  it('emits a parseable schema.org Dataset naming the JSON distribution', () => {
+    const html = renderDataPage(data(), { siteUrl: 'https://example.com/repo' });
+    const block = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/.exec(html);
+    expect(block).not.toBeNull();
+    const parsed = JSON.parse((block?.[1] ?? '').replace(/\\u003c/g, '<')) as {
+      '@type': string;
+      distribution: Array<{ contentUrl: string; encodingFormat: string }>;
+    };
+    expect(parsed['@type']).toBe('Dataset');
+    expect(parsed.distribution[0]?.encodingFormat).toBe('application/json');
+    expect(parsed.distribution[0]?.contentUrl).toBe('https://example.com/repo/insights/data.json');
+  });
+
+  it('states the resolution it is actually showing when the bundle was downsampled', () => {
+    expect(renderDataPage(data({ downsampled: true }))).toContain('weekly buckets');
+    expect(renderDataPage(data())).toContain('daily');
+  });
+
+  it('says so plainly rather than printing an empty table for a series with no rows', () => {
+    expect(renderDataPage(data())).toContain('No rows recorded yet.');
+  });
+});

--- a/scripts/metrics/src/datapage.ts
+++ b/scripts/metrics/src/datapage.ts
@@ -1,0 +1,308 @@
+/**
+ * Renders the archive as a single static HTML page with no JavaScript.
+ *
+ * The dashboard draws its charts client-side from `data.json`, which means a
+ * text-only crawler — and any reader without JavaScript — sees headings and
+ * methodology but not one measured value. This page exists so the numbers
+ * themselves are in the HTML: real `<table>` rows, plus a schema.org
+ * `Dataset` block naming `data.json` as a machine-readable distribution.
+ *
+ * It is generated from the same `DashboardData` the charts are built from, so
+ * the two can never disagree about a figure. It states what it does not know:
+ * a `null` reads as "not measured", never as a zero, matching the rule the
+ * rest of this package is built on.
+ */
+import type { DashboardData, DimensionEntry, ReleaseEntry } from './bundle.ts';
+
+/**
+ * Escapes text for HTML element and attribute content.
+ *
+ * Load-bearing, not decorative: referrer hostnames and popular paths are
+ * strings GitHub reports from real traffic, so they are outside this repo's
+ * control and reach this page verbatim. Interpolating them raw would let a
+ * crafted path close a tag. Ampersand is replaced first so the replacement
+ * escapes of the later rules are not themselves re-escaped.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Serialises a value for a `<script type="application/ld+json">` block.
+ *
+ * `JSON.stringify` alone is not safe inside a script element: a `</script>`
+ * sequence anywhere in the data would terminate the block early and spill the
+ * rest of the JSON into the document as markup. Escaping the `<` of every
+ * tag-open prevents that while leaving the JSON semantically identical.
+ */
+export function jsonLd(value: unknown): string {
+  return JSON.stringify(value, null, 2).replace(/</g, '\\u003c');
+}
+
+/** A measured number, or an explicit statement that nothing was measured. */
+function cell(value: number | null): string {
+  return value === null
+    ? '<td class="na" title="No value was recorded for this date">not measured</td>'
+    : `<td class="n">${value.toLocaleString('en-US')}</td>`;
+}
+
+/**
+ * `numeric` right-aligns a column's header to sit over its right-aligned
+ * figures. Carried per column rather than inferred from position, because the
+ * dimension tables lead with two text columns and the series tables with one.
+ */
+interface Column {
+  label: string;
+  numeric: boolean;
+}
+
+function table(head: readonly Column[], body: readonly string[]): string {
+  if (body.length === 0) return '<p class="empty">No rows recorded yet.</p>';
+  return (
+    '<div class="scroll"><table>\n<thead><tr>' +
+    head
+      .map((h) => `<th${h.numeric ? ' class="n"' : ''}>${escapeHtml(h.label)}</th>`)
+      .join('') +
+    '</tr></thead>\n<tbody>\n' +
+    body.join('\n') +
+    '\n</tbody>\n</table></div>'
+  );
+}
+
+/** Rows of a dated series, newest first so the current figures are read first. */
+function seriesTable(
+  dates: readonly string[],
+  columns: ReadonlyArray<{ label: string; values: ReadonlyArray<number | null> }>,
+): string {
+  const rows: string[] = [];
+  for (let i = dates.length - 1; i >= 0; i--) {
+    rows.push(
+      `<tr><td class="d">${escapeHtml(dates[i] ?? '')}</td>` +
+        columns.map((c) => cell(c.values[i] ?? null)).join('') +
+        '</tr>',
+    );
+  }
+  return table(
+    [{ label: 'date', numeric: false }, ...columns.map((c) => ({ label: c.label, numeric: true }))],
+    rows,
+  );
+}
+
+function dimensionTable(rows: readonly DimensionEntry[], first: string): string {
+  return table(
+    [
+      { label: first, numeric: false },
+      { label: 'title', numeric: false },
+      { label: 'views', numeric: true },
+      { label: 'unique visitors', numeric: true },
+    ],
+    rows.map(
+      (r) =>
+        `<tr><td>${escapeHtml(r.dimension)}</td><td>${escapeHtml(r.title)}</td>` +
+        `<td class="n">${r.count.toLocaleString('en-US')}</td>` +
+        `<td class="n">${r.uniques.toLocaleString('en-US')}</td></tr>`,
+    ),
+  );
+}
+
+function releaseTable(rows: readonly ReleaseEntry[]): string {
+  return table(
+    [
+      { label: 'date', numeric: false },
+      { label: 'tag', numeric: false },
+      { label: 'name', numeric: false },
+    ],
+    rows.map(
+      (r) =>
+        `<tr><td class="d">${escapeHtml(r.date)}</td><td>${escapeHtml(r.tag)}</td>` +
+        `<td>${escapeHtml(r.name)}</td></tr>`,
+    ),
+  );
+}
+
+const STYLE = `
+:root { color-scheme: dark; --bg:#0b0b10; --panel:#13131a; --line:rgba(255,255,255,.09);
+        --txt:#efefef; --txt2:#a0a0aa; --txt3:#6d6d7c; --accent:#7c6cf6;
+        --mono: ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace; }
+* { box-sizing:border-box; }
+body { margin:0; padding:40px 24px 72px; background:var(--bg); color:var(--txt);
+       font:16px/1.6 system-ui,-apple-system,"Segoe UI",sans-serif; }
+main { max-width:1080px; margin:0 auto; }
+h1 { font-size:30px; letter-spacing:-.02em; margin:0 0 12px; }
+h2 { font-size:20px; letter-spacing:-.01em; margin:44px 0 6px; }
+p { color:var(--txt2); max-width:70ch; }
+a { color:var(--accent); }
+code, .d, .n, .na { font-family:var(--mono); font-size:13px; }
+.lede { font-size:17px; }
+.scroll { overflow-x:auto; border:1px solid var(--line); border-radius:12px; background:var(--panel); }
+table { border-collapse:collapse; width:100%; font-size:14px; }
+th, td { padding:8px 14px; text-align:left; border-bottom:1px solid var(--line); white-space:nowrap; }
+th { color:var(--txt3); font-weight:600; font-size:12px; text-transform:uppercase;
+     letter-spacing:.04em; position:sticky; top:0; background:var(--panel); }
+tr:last-child td { border-bottom:0; }
+.n { text-align:right; font-variant-numeric:tabular-nums; }
+.na { color:var(--txt3); font-style:italic; }
+.empty { color:var(--txt3); }
+.meta { font-family:var(--mono); font-size:12.5px; color:var(--txt3); }
+.note { border-left:2px solid var(--accent); padding:2px 0 2px 14px; margin:22px 0; }
+footer { margin-top:56px; padding-top:20px; border-top:1px solid var(--line); color:var(--txt3); font-size:13.5px; }
+`;
+
+export interface DataPageOptions {
+  /** Absolute site base with no trailing slash, e.g. `https://example.com/repo`. Omitted for relative links. */
+  siteUrl?: string | undefined;
+}
+
+export function renderDataPage(data: DashboardData, options: DataPageOptions = {}): string {
+  const base = options.siteUrl === undefined ? '' : options.siteUrl.replace(/\/+$/, '');
+  const insights = base === '' ? '../' : `${base}/insights/`;
+  const jsonUrl = base === '' ? '../data.json' : `${base}/insights/data.json`;
+
+  const s = data.series;
+  const covered =
+    data.collection_started === null
+      ? 'nothing recorded yet'
+      : `${data.collection_started} to ${data.generated_at.slice(0, 10)}`;
+
+  // schema.org Dataset. This is what makes the archive discoverable as data
+  // rather than as prose: it names the machine-readable distribution
+  // explicitly, so a crawler does not have to guess that data.json exists.
+  const dataset = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: 'Backspace repository traffic and growth archive',
+    description:
+      'Daily archive of the Backspace repository’s GitHub traffic, stars, forks, ' +
+      'contributors and releases. GitHub discards repository traffic data after 14 days; ' +
+      'this archive records it once per day and retains it indefinitely. Every figure is ' +
+      'measured, never estimated; a value that was not measured is recorded as absent ' +
+      'rather than as zero.',
+    url: `${insights}data/`,
+    license: 'https://www.gnu.org/licenses/agpl-3.0.html',
+    isAccessibleForFree: true,
+    creator: { '@type': 'Organization', name: 'Backspace' },
+    temporalCoverage: data.collection_started === null ? undefined : `${data.collection_started}/..`,
+    dateModified: data.generated_at,
+    measurementTechnique:
+      'GitHub REST API, collected once daily by a scheduled job and committed to a public git branch',
+    variableMeasured: [
+      'page views',
+      'unique visitors',
+      'repository clones',
+      'unique cloners',
+      'stars',
+      'forks',
+      'contributors',
+      'watchers',
+      'open issues',
+      'release asset downloads',
+      'referring sites',
+      'popular paths',
+    ],
+    distribution: [
+      {
+        '@type': 'DataDownload',
+        encodingFormat: 'application/json',
+        contentUrl: jsonUrl,
+        name: 'Complete archive bundle (JSON)',
+      },
+    ],
+  };
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Backspace repository data: every recorded figure</title>
+<meta name="description" content="The complete Backspace repository traffic and growth archive as plain tables: daily page views, clones, stars, forks, contributors, referrers and paths. Measured daily, never estimated, retained past GitHub's 14-day window." />
+<link rel="canonical" href="${escapeHtml(`${insights}data/`)}" />
+<style>${STYLE}</style>
+<script type="application/ld+json">
+${jsonLd(dataset)}
+</script>
+</head>
+<body>
+<main>
+<h1>Backspace repository data</h1>
+<p class="lede">Every figure the archive holds, as plain tables. This is the same data the
+<a href="${escapeHtml(insights)}">charted dashboard</a> is drawn from, rendered without JavaScript so it can be
+read, cited and crawled directly.</p>
+
+<p class="meta">coverage ${escapeHtml(covered)} &middot; generated ${escapeHtml(data.generated_at)} &middot;
+resolution ${escapeHtml(data.downsampled ? 'weekly buckets' : 'daily')}</p>
+
+<div class="note">
+<p><strong>How to read this.</strong> GitHub deletes repository traffic data after 14 days. A scheduled job
+records it once a day into a public git branch, and this page is built from that branch at deploy time.
+Nothing here is estimated or modelled. Where a value was never measured the cell reads
+<em>not measured</em> rather than <code>0</code>, because a zero would claim a measurement that was never taken.</p>
+<p>Machine-readable form: <a href="${escapeHtml(jsonUrl)}"><code>data.json</code></a>, the complete archive in one file.</p>
+</div>
+
+<h2>Page views</h2>
+<p>Daily views of the repository on GitHub, with the number of distinct visitors.</p>
+${seriesTable(s.views.dates, [
+  { label: 'views', values: s.views.count },
+  { label: 'unique visitors', values: s.views.uniques },
+])}
+
+<h2>Clones</h2>
+<p>Daily <code>git clone</code> operations, with the number of distinct cloners.</p>
+${seriesTable(s.clones.dates, [
+  { label: 'clones', values: s.clones.count },
+  { label: 'unique cloners', values: s.clones.uniques },
+])}
+
+<h2>Stars</h2>
+<p>Cumulative star count. Dates with no change carry no row.</p>
+${seriesTable(s.stars.dates, [{ label: 'stars', values: s.stars.total }])}
+
+<h2>Forks</h2>
+<p>Cumulative fork count. Dates with no change carry no row.</p>
+${seriesTable(s.forks.dates, [{ label: 'forks', values: s.forks.total }])}
+
+<h2>Contributors</h2>
+<p>Cumulative count of people with at least one commit, dated by each contributor's first commit week.</p>
+${seriesTable(s.contributors.dates, [{ label: 'contributors', values: s.contributors.total }])}
+
+<h2>Repository counters</h2>
+<p>Watchers, open issues, and release asset downloads. Downloads are split because GitHub counts an
+updater feed file the same as an installer: <em>app</em> is installers and archives, <em>update checks</em>
+is the metadata every installed client fetches when it checks for a new version.</p>
+${seriesTable(s.repo.dates, [
+  { label: 'watchers', values: s.repo.subscribers },
+  { label: 'open issues', values: s.repo.open_issues },
+  { label: 'downloads, all assets', values: s.repo.downloads_total },
+  { label: 'downloads, app', values: s.repo.downloads_app },
+  { label: 'downloads, update checks', values: s.repo.downloads_updates },
+])}
+
+<h2>Referring sites</h2>
+<p>Where visitors arrived from. GitHub reports this only as a trailing 14-day total per snapshot and
+lists at most 10 rows, so these are fortnight aggregates rather than daily figures.</p>
+${dimensionTable(data.dimensions.referrers.latest, 'referring site')}
+
+<h2>Popular paths</h2>
+<p>The most-visited paths in the repository, on the same trailing 14-day basis.</p>
+${dimensionTable(data.dimensions.paths.latest, 'path')}
+
+<h2>Releases</h2>
+${releaseTable(data.releases)}
+
+<footer>
+<p>Part of <a href="${escapeHtml(base === '' ? '../../' : `${base}/`)}">Backspace</a>, a self-hosted,
+open-source Discord alternative. Source and archive:
+<a href="https://github.com/TheZwiss/backspace">github.com/TheZwiss/backspace</a>.
+Data licensed under <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPL-3.0</a> with the project.</p>
+</footer>
+</main>
+</body>
+</html>
+`;
+}

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -6,6 +6,43 @@
 <title>Backspace insights: repository traffic and growth</title>
 <meta name="description" content="Traffic, growth and referral figures for the Backspace repository, collected daily into a public archive and rendered from a single static bundle." />
 <link rel="canonical" href="https://thezwiss.github.io/backspace/insights/" />
+<!-- Declares the archive as a dataset rather than as prose, and names its
+     machine-readable distribution explicitly. Without this a crawler reads the
+     methodology on this page but has no way to discover that data.json exists,
+     because every value here is fetched and drawn client-side. Kept in sync by
+     hand with the copy datapage.ts emits; both point at the same two URLs. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Backspace repository traffic and growth archive",
+  "description": "Daily archive of the Backspace repository's GitHub traffic, stars, forks, contributors and releases. GitHub discards repository traffic data after 14 days; this archive records it once per day and retains it indefinitely. Every figure is measured, never estimated; a value that was not measured is recorded as absent rather than as zero.",
+  "url": "https://thezwiss.github.io/backspace/insights/",
+  "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+  "isAccessibleForFree": true,
+  "creator": { "@type": "Organization", "name": "Backspace" },
+  "measurementTechnique": "GitHub REST API, collected once daily by a scheduled job and committed to a public git branch",
+  "variableMeasured": [
+    "page views", "unique visitors", "repository clones", "unique cloners",
+    "stars", "forks", "contributors", "watchers", "open issues",
+    "release asset downloads", "referring sites", "popular paths"
+  ],
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/json",
+      "contentUrl": "https://thezwiss.github.io/backspace/insights/data.json",
+      "name": "Complete archive bundle (JSON)"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "text/html",
+      "contentUrl": "https://thezwiss.github.io/backspace/insights/data/",
+      "name": "The same archive as static HTML tables"
+    }
+  ]
+}
+</script>
 <link rel="icon" type="image/png" href="../assets/logo.png" />
 <link rel="apple-touch-icon" href="../assets/logo.png" />
 <meta name="robots" content="index, follow" />
@@ -115,6 +152,9 @@ h1 {
   color: var(--txt2); font-size: clamp(1rem, 1.7vw, 1.1rem);
   max-width: 66ch; line-height: 1.65;
 }
+.raw-data { margin-top: 14px; }
+.raw-data code { font-size: 0.92em; }
+
 .provenance {
   font-family: var(--mono); font-size: 12.5px; color: var(--txt4);
   margin-top: 18px; line-height: 1.8;
@@ -442,6 +482,18 @@ footer a:hover { color: var(--txt); }
       data branch. The page reads a single bundle built from that archive at deploy time. Nothing
       is estimated, and nothing is fetched from anywhere but this site.
     </p>
+    <p class="sec-copy raw-data">
+      Prefer the numbers to the charts? The same archive is published as
+      <a href="data/">plain tables</a> and as one machine-readable file,
+      <a href="data.json"><code>data.json</code></a>. Both are built from this page's own bundle, so
+      they cannot disagree with what is drawn here.
+    </p>
+    <noscript>
+      <p class="sec-copy raw-data">
+        Every figure here is drawn in the browser from <code>data.json</code>, so without JavaScript
+        the charts cannot render. <a href="data/">The same archive as plain tables</a> needs none.
+      </p>
+    </noscript>
     <p class="provenance">
       <span><span class="k">archive history</span> <span class="v" id="pv-since">checking</span></span>
       <span><span class="k">bundle built</span> <span class="v" id="pv-generated">checking</span></span>
@@ -470,7 +522,7 @@ footer a:hover { color: var(--txt); }
         covers the window it describes; otherwise it reads as a dash, and a figure that could
         only be assembled from a different span is labelled with the span it actually covers.
       </p>
-      <div class="slot" id="header-stats"></div>
+  <div class="slot" id="header-stats"></div>
     </div>
   </section>
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -27,4 +27,15 @@
 - Source code and documentation: https://github.com/TheZwiss/backspace
 - Comparison with Discord, Revolt, Spacebar, Matrix, and Mumble: https://github.com/TheZwiss/backspace/blob/main/docs/comparison.md
 - License: https://github.com/TheZwiss/backspace/blob/main/LICENSE
-- Repository insights (traffic, growth, and referral figures, collected daily): https://thezwiss.github.io/backspace/insights/
+- Repository insights, charted (traffic, growth, and referral figures, collected daily): https://thezwiss.github.io/backspace/insights/
+- The same archive as plain HTML tables, no JavaScript required: https://thezwiss.github.io/backspace/insights/data/
+- The same archive as one machine-readable JSON file: https://thezwiss.github.io/backspace/insights/data.json
+
+## Repository metrics archive
+
+- What it is: a public, daily archive of this repository's GitHub traffic and growth. GitHub discards repository traffic data after 14 days; a scheduled job records it once a day into a public git branch, so the history is retained indefinitely.
+- Series recorded: daily page views and unique visitors, daily clones and unique cloners, cumulative stars, forks and contributors, watchers, open issues, release asset downloads, and trailing-14-day referring sites and popular paths.
+- Provenance: every figure is measured through the GitHub REST API. Nothing is estimated, modelled, or interpolated.
+- Absent versus zero: a value that was never measured is recorded as absent and rendered as a gap, never as a zero. A measured zero is recorded and rendered as zero. The two are never conflated, so a gap in a chart means "not measured" and not "fell to nothing".
+- Release downloads are reported split: installers and archives separately from update-check traffic, because GitHub counts an electron-updater feed file the same as an installer and every installed client fetches that feed on every update check.
+- Licence: the data is published under AGPL-3.0 along with the project, and is free to read, cite, and reuse with attribution.


### PR DESCRIPTION
## What this changes

The dashboard draws every value in the browser from `data.json`. A text-only crawler, an LLM fetching the URL, or anyone with JavaScript off therefore saw the headings and the methodology and **not one measured number** - confirmed by fetching the live page and stripping scripts: 2,760 characters of prose, zero series values. Worse, nothing on the site pointed at `data.json`, so there was no way to discover that a machine-readable form existed at all.

- **`/insights/data/`** - a new static page, no JavaScript, with every recorded figure as real `<table>` rows. Written by `cli-bundle.ts` beside `data.json` from the same `DashboardData` the charts use, so the two encodings cannot disagree about a figure.
- **schema.org `Dataset`** on both pages, naming `data.json` as a `distribution`. This is what makes the archive discoverable *as data* rather than as prose.
- **Dashboard** links to both forms, and falls back to the tables under `<noscript>`.
- **`llms.txt`** describes the archive, its series, its provenance, and its stable URLs.

## Type of change

- [x] New feature
- [x] Documentation

## Checklist

- [ ] ~`pnpm build` / `pnpm dev`~ - N/A, no app code touched
- [x] Tests pass - 274/274 (12 new in `datapage.test.ts`), `tsc --noEmit` clean, `actionlint` clean
- [x] Updated `docs/systems/metrics.md` - new build artifact and a new optional env var

## Notes for reviewers

**Escaping is load-bearing here, not cosmetic.** Referrer hostnames and popular paths are strings GitHub reports from real traffic, so they originate outside this repo and reach the page verbatim. `escapeHtml` covers `& < > " '` with ampersand first so replacements are not re-escaped, and `jsonLd` additionally escapes `<` so a `</script>` sequence in the data cannot terminate the structured-data block early and spill JSON into the document as markup. Both have tests that feed in `<script>alert(1)</script>` as a referrer name.

**The page inherits the absent-versus-zero rule.** A `null` renders as the words *not measured*, never `0`; a measured zero renders as `0`. It also reports the resolution it was handed, so a downsampled bundle is labelled weekly rather than silently presented as daily.

**The output path is derived, not configured** (`data/index.html` inside `METRICS_OUTPUT_PATH`'s directory). A second path variable would be a second thing that can point elsewhere, at which point the page and the JSON it mirrors disagree about where each lives. `METRICS_SITE_URL` is separate and genuinely optional: set, the page emits absolute links and Dataset URLs; unset, it links relatively, so a fork gets a correct page instead of one advertising this deployment's domain as the home of its data.

**Verified:** 12 browser assertions covering the dashboard after the edits, the noscript path with script execution disabled, and the static page rendering with no scripts at all.

**Not fixable from this repo:** `robots.txt` 404s because GitHub Pages serves it only from the *user* site root (`thezwiss.github.io/robots.txt`), not a project path. Its absence means crawling is allowed by default, so nothing is blocked.