### PR TITLE
feat(insights): state the headline figures in the served HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,8 @@ site/insights/data.json
 # static, no-JavaScript tables. Listed explicitly rather than left to the
 # generic `data/` rule above, which exists for packages/server/data/.
 site/insights/data/
+# Also written at deploy time by cli-bundle.ts, from the archive's coverage.
+# Not committed for the same reason as the two above, plus one of its own:
+# every `lastmod` in it would be wrong the moment the collector next runs, and
+# a lastmod that lies tells a crawler not to come back.
+site/sitemap.xml

--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -135,6 +135,26 @@ Three properties worth keeping:
 
 Both `site/insights/data.json` and `site/insights/data/` are gitignored: they exist only inside a deploy run.
 
+### Static content baked into the charted page
+
+The static data page solves the crawler problem for a reader that follows the link to it. `/insights/` is the URL that actually gets shared, and a fetcher that reads that URL and stops never does follow it — which is the common case for a search crawler or an assistant asked to look at the page. So `cli-bundle.ts` also writes two regions into `site/insights/index.html` itself, from the same `DashboardData`:
+
+- **`<!-- BUILD:SUMMARY -->`** — a paragraph of headline measurements: the latest measured value of each counter with the date it was measured, the peak day of views and clones, the leading referrer and path, and the archive's coverage and resolution. Rendered by `renderSummaryHtml` in `summary.ts`.
+- **`<!-- BUILD:JSONLD -->`** — the schema.org `Dataset` block, regenerated so `variableMeasured` carries `PropertyValue` entries with real values and `temporalCoverage` states the archive's actual span. Rendered by `renderDatasetJsonLd`. Skipped when `METRICS_SITE_URL` is unset, since every URL in it is absolute; the committed block stands in that case.
+
+Four properties this depends on:
+
+- **It is not a second implementation of the at-a-glance cards.** Those are range-dependent and carry 30-day deltas with their own reasons for declining to state one. Duplicating that logic in TypeScript would create two sets of rules that drift apart, and the drift would be invisible until they disagreed in public. `summary.ts` derives only figures whose rules are simple enough to be obviously correct.
+- **The absent-versus-zero rule applies to prose.** A figure with no measurement behind it loses its whole clause rather than printing `0` or a dash. This text is read by machines that will quote whatever number sits next to a label, so a dash next to "watchers" is a worse outcome here than on a chart.
+- **A missing marker throws.** `replaceRegion` refuses to return the page unchanged, because the committed fallback says "not built by the pipeline" and publishing it silently would look exactly like a successful deploy.
+- **`labelled()` mirrors the dashboard's `displayLabel` exactly** — trimmed `title` when non-empty, `dimension` otherwise. GitHub fills `title` for paths and leaves it **empty for every referrer**, where the host lives in `dimension`. Reading `title` alone renders "Leading referrer: , 193 views", which is how this was caught.
+
+### The sitemap
+
+`cli-bundle.ts` writes `site/sitemap.xml` (gitignored, `sitemap.ts`) listing the three published pages, with `lastmod` on the two generated ones taken from the archive's newest date rather than from the clock: they are rebuilt every deploy, but their *content* only changes when a collection adds a row, and `lastmod` describes content. The landing page carries no `lastmod` — nothing in this pipeline knows when it last changed.
+
+**`robots.txt` cannot be published from this repository.** It is only honoured at a domain root, and this site is a project page at `thezwiss.github.io/backspace/`; the root belongs to a separate `thezwiss.github.io` user-pages repository. A 404 there is permissive, so nothing is blocked, but the sitemap cannot be declared from it either — it has to be submitted to a search console directly, or referenced from a `robots.txt` in that other repository.
+
 **The download split.** `downloads_total` sums every release asset. That number is dominated by update machinery rather than by installs: electron-updater fetches `latest.yml` / `latest-mac.yml` / `latest-linux.yml` on every update check from every installed client, and `.blockmap` files during a differential update, and GitHub counts all of them in `download_count` exactly like an installer. When the split was added on 2026-09-02 the feed files had 1,519 downloads against 323 for every real installer and archive combined, so the single figure overstated installs by roughly 5.7x.
 
 `downloads_app` counts installers and archives; `downloads_updates` counts anything matching `*.yml`, `*.yaml` or `*.blockmap` (`isUpdateArtifact` in `collect.ts`). For any row carrying all three, `downloads_app + downloads_updates === downloads_total`.

--- a/scripts/metrics/src/cli-bundle.ts
+++ b/scripts/metrics/src/cli-bundle.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { createStore } from './store.ts';
 import {
@@ -9,6 +9,8 @@ import {
 } from './bundle.ts';
 import { requiredEnv, deriveRunTimestamps, describeFailure } from './cli-support.ts';
 import { renderDataPage } from './datapage.ts';
+import { buildSummary, renderSummaryHtml, renderDatasetJsonLd, replaceRegion } from './summary.ts';
+import { renderSitemap, siteEntries } from './sitemap.ts';
 
 /**
  * Entrypoint invoked by `.github/workflows/deploy-pages.yml` as
@@ -112,6 +114,61 @@ async function main(): Promise<void> {
     throw new Error(`cli-bundle: failed to write "${pagePath}"`, { cause });
   }
   console.log(`wrote ${pagePath}: ${Buffer.byteLength(html, 'utf8')} bytes of static tables`);
+
+  // The charted page's own static content: the headline measurements, and a
+  // `Dataset` block carrying real values and the archive's coverage.
+  //
+  // This exists because `/insights/` is the URL that gets shared, and every
+  // figure on it is drawn client-side — so its served HTML states the method
+  // and not one number. The static data page beside it solves that for a
+  // reader who follows the link; a fetcher that reads the shared URL and
+  // stops never does. Both regions are written from `data`, the same bundle
+  // the charts read, so the static text cannot disagree with the charts.
+  //
+  // `replaceRegion` throws when a marker is missing rather than leaving the
+  // page untouched: the committed fallback says "not built by the pipeline",
+  // and publishing that silently would look exactly like a successful deploy.
+  const indexPath = path.join(path.dirname(full), 'index.html');
+  const siteUrl = process.env['METRICS_SITE_URL'];
+  let page: string;
+  try {
+    page = readFileSync(indexPath, 'utf8');
+  } catch (cause) {
+    throw new Error(`cli-bundle: failed to read "${indexPath}"`, { cause });
+  }
+  const facts = buildSummary(data);
+  page = replaceRegion(page, 'SUMMARY', renderSummaryHtml(facts));
+  // The JSON-LD names absolute URLs, so it is regenerated only when this
+  // deployment knows its own address. Left alone, the committed block stands:
+  // correct for this site, and not something a fork republishes under its own
+  // domain while pointing at ours.
+  if (siteUrl !== undefined && siteUrl !== '') {
+    page = replaceRegion(page, 'JSONLD', renderDatasetJsonLd(facts, siteUrl));
+  }
+  try {
+    writeFileSync(indexPath, page, 'utf8');
+  } catch (cause) {
+    throw new Error(`cli-bundle: failed to write "${indexPath}"`, { cause });
+  }
+  console.log(
+    `wrote ${indexPath}: static figures` +
+      (siteUrl === undefined || siteUrl === '' ? ' (JSON-LD left as committed: no METRICS_SITE_URL)' : ' and Dataset metadata'),
+  );
+
+  // The sitemap, at the site root two levels up from the bundle. Skipped
+  // without a site URL for the same reason the JSON-LD is: every entry in it
+  // is an absolute URL, and a sitemap is a claim about which domain owns
+  // these pages.
+  if (siteUrl !== undefined && siteUrl !== '') {
+    const sitemapPath = path.join(path.dirname(path.dirname(full)), 'sitemap.xml');
+    const xml = renderSitemap(siteUrl, siteEntries(facts.to));
+    try {
+      writeFileSync(sitemapPath, xml, 'utf8');
+    } catch (cause) {
+      throw new Error(`cli-bundle: failed to write "${sitemapPath}"`, { cause });
+    }
+    console.log(`wrote ${sitemapPath}: ${siteEntries(facts.to).length} urls`);
+  }
 
   // Last line of the run, on stderr, so it is the thing a maintainer sees at
   // the bottom of a green deploy log rather than something buried above the

--- a/scripts/metrics/src/sitemap.test.ts
+++ b/scripts/metrics/src/sitemap.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { renderSitemap, siteEntries } from './sitemap.ts';
+
+describe('renderSitemap', () => {
+  it('emits a well-formed urlset with absolute locs', () => {
+    const xml = renderSitemap('https://example.com/backspace', siteEntries('2026-09-02'));
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"');
+    expect(xml).toContain('<loc>https://example.com/backspace/</loc>');
+    expect(xml).toContain('<loc>https://example.com/backspace/insights/</loc>');
+    expect(xml).toContain('<loc>https://example.com/backspace/insights/data/</loc>');
+    expect(xml.trim().endsWith('</urlset>')).toBe(true);
+  });
+
+  it('does not double the slash when the site URL already ends in one', () => {
+    const xml = renderSitemap('https://example.com/backspace/', siteEntries(null));
+    expect(xml).not.toContain('//insights');
+    expect(xml).toContain('<loc>https://example.com/backspace/insights/</loc>');
+  });
+
+  it('dates the two generated pages and leaves the landing page undated', () => {
+    const xml = renderSitemap('https://e.test', siteEntries('2026-09-02'));
+    expect(xml.match(/<lastmod>2026-09-02<\/lastmod>/g)).toHaveLength(2);
+  });
+
+  // An invented lastmod tells a crawler a page is unchanged when nothing here
+  // knows whether it is.
+  it('omits lastmod entirely when the archive has no date', () => {
+    expect(renderSitemap('https://e.test', siteEntries(null))).not.toContain('<lastmod>');
+  });
+
+  it('escapes XML metacharacters in a site URL', () => {
+    const xml = renderSitemap('https://e.test/a&b', siteEntries(null));
+    expect(xml).toContain('https://e.test/a&amp;b/');
+    expect(xml).not.toMatch(/<loc>[^<]*&(?!amp;|lt;|gt;|quot;|apos;)/);
+  });
+});

--- a/scripts/metrics/src/sitemap.ts
+++ b/scripts/metrics/src/sitemap.ts
@@ -1,0 +1,79 @@
+/**
+ * The sitemap for the published site.
+ *
+ * Written at deploy time rather than committed, because two of the three
+ * pages change whenever the collector runs and a `lastmod` that lies is worse
+ * than no `lastmod` at all: a crawler that has been told a page is unchanged
+ * has been given a reason not to come back.
+ *
+ * This exists because nothing else announces these pages. `robots.txt` has to
+ * live at the domain root — `thezwiss.github.io/robots.txt`, a different
+ * repository from this one — so a sitemap served from this project's own path
+ * is the only discovery signal this repository can publish for itself. It is
+ * still worth publishing without the robots.txt reference: a sitemap at a
+ * known URL can be submitted to a search console directly.
+ */
+
+export interface SitemapEntry {
+  /** Path relative to the site root, e.g. `insights/`. Empty string is the root. */
+  path: string;
+  /** `YYYY-MM-DD`, omitted when nothing dates the page. */
+  lastmod?: string;
+  changefreq: string;
+  priority: string;
+}
+
+/**
+ * Escapes the five characters XML reserves. The URLs here are built from a
+ * configured site URL and fixed paths rather than from archive data, so this
+ * is defence against a malformed configuration rather than against content —
+ * but an unescaped `&` in a site URL produces a sitemap no crawler will
+ * parse, and it would fail silently at the consumer rather than here.
+ */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function renderSitemap(siteUrl: string, entries: readonly SitemapEntry[]): string {
+  const base = siteUrl.replace(/\/+$/, '');
+  const urls = entries.map((entry) => {
+    const loc = escapeXml(entry.path === '' ? `${base}/` : `${base}/${entry.path}`);
+    const lastmod = entry.lastmod === undefined ? '' : `\n    <lastmod>${escapeXml(entry.lastmod)}</lastmod>`;
+    return (
+      '  <url>\n' +
+      `    <loc>${loc}</loc>${lastmod}\n` +
+      `    <changefreq>${escapeXml(entry.changefreq)}</changefreq>\n` +
+      `    <priority>${escapeXml(entry.priority)}</priority>\n` +
+      '  </url>'
+    );
+  });
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+    urls.join('\n') +
+    '\n</urlset>\n'
+  );
+}
+
+/**
+ * The three published pages.
+ *
+ * `lastmod` on the two data pages is the date the archive was last collected,
+ * not the date this ran: they are rebuilt on every deploy, but their CONTENT
+ * only changes when a collection adds a row, and `lastmod` describes content.
+ * The landing page carries none — nothing in this pipeline knows when it last
+ * changed, and inventing a date for it would be the same lie in miniature.
+ */
+export function siteEntries(archiveDate: string | null): SitemapEntry[] {
+  const dated = archiveDate === null ? {} : { lastmod: archiveDate };
+  return [
+    { path: '', changefreq: 'weekly', priority: '1.0' },
+    { path: 'insights/', ...dated, changefreq: 'daily', priority: '0.8' },
+    { path: 'insights/data/', ...dated, changefreq: 'daily', priority: '0.7' },
+  ];
+}

--- a/scripts/metrics/src/summary.test.ts
+++ b/scripts/metrics/src/summary.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSummary,
+  renderSummaryHtml,
+  renderDatasetJsonLd,
+  replaceRegion,
+} from './summary.ts';
+import type { DashboardData } from './bundle.ts';
+
+function data(overrides: Partial<DashboardData> = {}): DashboardData {
+  return {
+    generated_at: '2026-09-02T10:00:00.000Z',
+    collection_started: '2026-08-18',
+    meta: { last_run: null, last_success: null, error: null },
+    empty: false,
+    downsampled: false,
+    series: {
+      views: { dates: ['2026-08-18', '2026-08-19'], count: [75, 174], uniques: [23, 51] },
+      clones: { dates: ['2026-08-18', '2026-08-19'], count: [10, 8], uniques: [8, 6] },
+      stars: { dates: ['2026-08-18', '2026-08-19'], total: [52, 64] },
+      forks: { dates: ['2026-08-19'], total: [5] },
+      contributors: { dates: ['2026-08-18'], total: [3] },
+      repo: {
+        dates: ['2026-08-19'],
+        subscribers: [7],
+        open_issues: [18],
+        downloads_total: [1802],
+        downloads_app: [null],
+        downloads_updates: [0],
+      },
+    },
+    releases: [{ date: '2026-07-03', tag: 'v1.0.0', name: 'Backspace 1.0.0' }],
+    dimensions: {
+      referrers: {
+        snapshots: ['2026-08-19'],
+        latest: [{ dimension: 'Google', title: 'Google', count: 193, uniques: 53 }],
+        trajectories: [],
+      },
+      paths: {
+        snapshots: ['2026-08-19'],
+        latest: [{ dimension: '/x', title: 'Overview', count: 646, uniques: 263 }],
+        trajectories: [],
+      },
+    },
+    ...overrides,
+  } as DashboardData;
+}
+
+const empty = (): DashboardData =>
+  data({
+    collection_started: null,
+    empty: true,
+    series: {
+      views: { dates: [], count: [], uniques: [] },
+      clones: { dates: [], count: [], uniques: [] },
+      stars: { dates: [], total: [] },
+      forks: { dates: [], total: [] },
+      contributors: { dates: [], total: [] },
+      repo: {
+        dates: [],
+        subscribers: [],
+        open_issues: [],
+        downloads_total: [],
+        downloads_app: [],
+        downloads_updates: [],
+      },
+    },
+    releases: [],
+    dimensions: {
+      referrers: { snapshots: [], latest: [], trajectories: [] },
+      paths: { snapshots: [], latest: [], trajectories: [] },
+    },
+  });
+
+describe('buildSummary', () => {
+  it('takes each counter from its own newest measured row', () => {
+    const f = buildSummary(data());
+    expect(f.stars).toEqual({ value: 64, date: '2026-08-19' });
+    expect(f.forks).toEqual({ value: 5, date: '2026-08-19' });
+    expect(f.watchers).toEqual({ value: 7, date: '2026-08-19' });
+    // Series legitimately end on different dates; the older one is not padded.
+    expect(f.contributors).toEqual({ value: 3, date: '2026-08-18' });
+  });
+
+  // The defect this guards: a trailing null is "not measured", and reading the
+  // last ELEMENT rather than the last MEASURED element would report it as the
+  // current value or crash on it.
+  it('skips trailing unmeasured rows rather than reporting them', () => {
+    const d = data();
+    d.series.stars = { dates: ['2026-08-18', '2026-08-19'], total: [52, null] };
+    expect(buildSummary(d).stars).toEqual({ value: 52, date: '2026-08-18' });
+  });
+
+  it('reports the peak traffic day, not the latest', () => {
+    const f = buildSummary(data());
+    expect(f.viewsPeak).toEqual({ value: 174, uniques: 51, date: '2026-08-19' });
+    expect(f.clonesPeak).toEqual({ value: 10, uniques: 8, date: '2026-08-18' });
+  });
+
+  it('counts only measured days', () => {
+    const d = data();
+    d.series.views = { dates: ['a', 'b', 'c'], count: [1, null, 3], uniques: [1, null, 3] };
+    expect(buildSummary(d).viewsDays).toBe(2);
+  });
+
+  it('takes the coverage end from the latest date across every series', () => {
+    expect(buildSummary(data()).to).toBe('2026-08-19');
+    expect(buildSummary(data()).from).toBe('2026-08-18');
+  });
+
+  it('reports nulls throughout for an empty archive rather than zeroes', () => {
+    const f = buildSummary(empty());
+    expect(f.stars).toBeNull();
+    expect(f.viewsPeak).toBeNull();
+    expect(f.topReferrer).toBeNull();
+    expect(f.topPath).toBeNull();
+    expect(f.to).toBeNull();
+    expect(f.viewsDays).toBe(0);
+  });
+});
+
+describe('renderSummaryHtml', () => {
+  it('states every measured figure with the date it was measured on', () => {
+    const html = renderSummaryHtml(buildSummary(data()));
+    expect(html).toContain('64 stars');
+    expect(html).toContain('5 forks');
+    expect(html).toContain('7 watchers');
+    expect(html).toContain('measured 2026-08-19');
+    expect(html).toContain('174 views');
+    expect(html).toContain('Google');
+    expect(html).toContain('v1.0.0');
+    expect(html).toContain('2026-08-18 to 2026-08-19');
+    // The links live in the paragraph above this one; repeating them here
+    // duplicated them four lines apart on the rendered page.
+    expect(html).not.toContain('href="data/"');
+  });
+
+  // The rule the whole project turns on: never print a number for something
+  // that was not measured. A missing figure loses its clause entirely.
+  it('omits an unmeasured figure instead of printing zero or a dash', () => {
+    const d = data();
+    d.series.repo.subscribers = [null];
+    const html = renderSummaryHtml(buildSummary(d));
+    expect(html).not.toContain('watchers');
+    expect(html).not.toContain('0 watchers');
+    expect(html).toContain('64 stars');
+  });
+
+  it('says plainly that nothing is recorded rather than rendering a figure-less sentence', () => {
+    const html = renderSummaryHtml(buildSummary(empty()));
+    expect(html).toContain('no measurements yet');
+    expect(html).not.toContain('Latest measurements');
+  });
+
+  it('escapes a hostile dimension name, in the title and in the raw dimension', () => {
+    const d = data();
+    d.dimensions.referrers.latest = [
+      { dimension: '<img src=x onerror=alert(1)>', title: '', count: 1, uniques: 1 },
+    ];
+    d.dimensions.paths.latest = [
+      { dimension: '/<svg onload=alert(1)>', title: '<b>t</b>', count: 1, uniques: 1 },
+    ];
+    const html = renderSummaryHtml(buildSummary(d));
+    expect(html).not.toContain('<img');
+    expect(html).not.toContain('<svg');
+    expect(html).not.toContain('<b>t</b>');
+    expect(html).toContain('&lt;img');
+    expect(html).toContain('&lt;svg');
+  });
+
+  // Found live: GitHub leaves `title` EMPTY for every referrer and puts the
+  // host in `dimension`, so reading `title` alone printed "Leading referrer:
+  // , 193 views" on the real archive.
+  it('names a referrer from its dimension when the title is empty', () => {
+    const d = data();
+    d.dimensions.referrers.latest = [
+      { dimension: 'Google', title: '', count: 193, uniques: 53 },
+    ];
+    const html = renderSummaryHtml(buildSummary(d));
+    expect(html).toContain('Leading referrer over the trailing 14 days: Google,');
+  });
+
+  it('keeps the raw path beside a path that has a page title', () => {
+    const html = renderSummaryHtml(buildSummary(data()));
+    expect(html).toContain('Overview (/x)');
+  });
+
+  it('does not repeat the name when the label and the dimension are the same', () => {
+    const d = data();
+    d.dimensions.paths.latest = [{ dimension: '/only', title: '', count: 2, uniques: 1 }];
+    expect(renderSummaryHtml(buildSummary(d))).toContain('/only, 2 views');
+  });
+
+  it('agrees in number with the figure it is attached to', () => {
+    const d = data();
+    d.series.repo.subscribers = [1];
+    d.series.forks = { dates: ['2026-08-19'], total: [1] };
+    const html = renderSummaryHtml(buildSummary(d));
+    expect(html).toContain('1 watcher and');
+    expect(html).toContain('1 fork');
+    expect(html).not.toContain('1 watchers');
+    expect(html).not.toContain('1 forks');
+  });
+
+  it('labels the resolution the bundle actually carries', () => {
+    expect(renderSummaryHtml(buildSummary(data({ downsampled: true })))).toContain(
+      'weekly resolution',
+    );
+    expect(renderSummaryHtml(buildSummary(data()))).toContain('daily resolution');
+  });
+});
+
+describe('renderDatasetJsonLd', () => {
+  it('carries measured values and the archive coverage', () => {
+    const json = renderDatasetJsonLd(buildSummary(data()), 'https://example.com/backspace/');
+    const parsed = JSON.parse(json.replace(/^<script[^>]*>|<\/script>$/g, '').trim()) as {
+      temporalCoverage: string;
+      url: string;
+      variableMeasured: Array<{ name: string; value?: number }>;
+      distribution: Array<{ contentUrl: string }>;
+    };
+    expect(parsed.temporalCoverage).toBe('2026-08-18/2026-08-19');
+    // The trailing slash on the configured URL must not produce a double slash.
+    expect(parsed.url).toBe('https://example.com/backspace/insights/');
+    expect(parsed.distribution[0]?.contentUrl).toBe(
+      'https://example.com/backspace/insights/data.json',
+    );
+    expect(parsed.variableMeasured.find((v) => v.name === 'stars')?.value).toBe(64);
+  });
+
+  it('names an unmeasured variable but attaches no value to it', () => {
+    const d = data();
+    d.series.forks = { dates: [], total: [] };
+    const parsed = JSON.parse(
+      renderDatasetJsonLd(buildSummary(d), 'https://example.com')
+        .replace(/^<script[^>]*>|<\/script>$/g, '')
+        .trim(),
+    ) as { variableMeasured: Array<{ name: string; value?: number }> };
+    const forks = parsed.variableMeasured.find((v) => v.name === 'forks');
+    expect(forks).toBeDefined();
+    expect(forks?.value).toBeUndefined();
+  });
+
+  it('omits temporalCoverage entirely for an empty archive', () => {
+    const parsed = JSON.parse(
+      renderDatasetJsonLd(buildSummary(empty()), 'https://example.com')
+        .replace(/^<script[^>]*>|<\/script>$/g, '')
+        .trim(),
+    ) as Record<string, unknown>;
+    expect(parsed['temporalCoverage']).toBeUndefined();
+  });
+
+  it('escapes a closing script tag so the block cannot be broken out of', () => {
+    // jsonLd escapes `<`; without it a value containing `</script>` would end
+    // the block and everything after it would parse as markup.
+    const json = renderDatasetJsonLd(buildSummary(data()), 'https://x.test/</script><b>');
+    expect(json).not.toContain('</script><b>');
+  });
+});
+
+describe('replaceRegion', () => {
+  it('replaces only what lies between the markers', () => {
+    const out = replaceRegion('a<!-- BUILD:X -->old<!-- /BUILD:X -->b', 'X', 'new');
+    expect(out).toBe('a<!-- BUILD:X -->\nnew\n<!-- /BUILD:X -->b');
+  });
+
+  // Silently returning the input would publish the committed fallback — a page
+  // with no figures — and the deploy would still be green.
+  it('throws rather than returning the page unchanged when a marker is missing', () => {
+    expect(() => replaceRegion('no markers here', 'X', 'new')).toThrow(/refusing to publish/);
+    expect(() => replaceRegion('<!-- BUILD:X -->only an opener', 'X', 'n')).toThrow();
+  });
+
+  it('throws when the markers are in the wrong order', () => {
+    expect(() => replaceRegion('<!-- /BUILD:X --><!-- BUILD:X -->', 'X', 'n')).toThrow();
+  });
+});

--- a/scripts/metrics/src/summary.test.ts
+++ b/scripts/metrics/src/summary.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildSummary,
   renderSummaryHtml,
+  buildDatasetJsonLd,
   renderDatasetJsonLd,
   replaceRegion,
 } from './summary.ts';
@@ -212,8 +213,10 @@ describe('renderSummaryHtml', () => {
 
 describe('renderDatasetJsonLd', () => {
   it('carries measured values and the archive coverage', () => {
-    const json = renderDatasetJsonLd(buildSummary(data()), 'https://example.com/backspace/');
-    const parsed = JSON.parse(json.replace(/^<script[^>]*>|<\/script>$/g, '').trim()) as {
+    const parsed = buildDatasetJsonLd(
+      buildSummary(data()),
+      'https://example.com/backspace/',
+    ) as unknown as {
       temporalCoverage: string;
       url: string;
       variableMeasured: Array<{ name: string; value?: number }>;
@@ -231,22 +234,16 @@ describe('renderDatasetJsonLd', () => {
   it('names an unmeasured variable but attaches no value to it', () => {
     const d = data();
     d.series.forks = { dates: [], total: [] };
-    const parsed = JSON.parse(
-      renderDatasetJsonLd(buildSummary(d), 'https://example.com')
-        .replace(/^<script[^>]*>|<\/script>$/g, '')
-        .trim(),
-    ) as { variableMeasured: Array<{ name: string; value?: number }> };
+    const parsed = buildDatasetJsonLd(buildSummary(d), 'https://example.com') as unknown as {
+      variableMeasured: Array<{ name: string; value?: number }>;
+    };
     const forks = parsed.variableMeasured.find((v) => v.name === 'forks');
     expect(forks).toBeDefined();
     expect(forks?.value).toBeUndefined();
   });
 
   it('omits temporalCoverage entirely for an empty archive', () => {
-    const parsed = JSON.parse(
-      renderDatasetJsonLd(buildSummary(empty()), 'https://example.com')
-        .replace(/^<script[^>]*>|<\/script>$/g, '')
-        .trim(),
-    ) as Record<string, unknown>;
+    const parsed = buildDatasetJsonLd(buildSummary(empty()), 'https://example.com');
     expect(parsed['temporalCoverage']).toBeUndefined();
   });
 

--- a/scripts/metrics/src/summary.ts
+++ b/scripts/metrics/src/summary.ts
@@ -292,7 +292,10 @@ export function renderSummaryHtml(facts: SummaryFacts): string {
  * variable with no measurement behind it keeps its name and drops the value,
  * for the same reason the prose omits it.
  */
-export function renderDatasetJsonLd(facts: SummaryFacts, siteUrl: string): string {
+export function buildDatasetJsonLd(
+  facts: SummaryFacts,
+  siteUrl: string,
+): Record<string, unknown> {
   const base = siteUrl.replace(/\/+$/, '');
   const variables: Array<Record<string, unknown>> = [];
   const add = (name: string, unit: string, dated: DatedValue | null): void => {
@@ -355,7 +358,20 @@ export function renderDatasetJsonLd(facts: SummaryFacts, siteUrl: string): strin
     dataset['temporalCoverage'] = `${facts.from}/${facts.to}`;
   }
 
-  return `<script type="application/ld+json">\n${jsonLd(dataset)}\n</script>`;
+  return dataset;
+}
+
+/**
+ * The same object, wrapped in its `<script>` tag.
+ *
+ * Split from `buildDatasetJsonLd` so callers that want to inspect the
+ * structured data — the tests, above all — read the object instead of
+ * pulling it back out of a string. A test that regex-strips a `<script>`
+ * wrapper to reach its payload is parsing HTML with a regex, which is both
+ * fragile and, correctly, something the security scanner objects to.
+ */
+export function renderDatasetJsonLd(facts: SummaryFacts, siteUrl: string): string {
+  return `<script type="application/ld+json">\n${jsonLd(buildDatasetJsonLd(facts, siteUrl))}\n</script>`;
 }
 
 /**

--- a/scripts/metrics/src/summary.ts
+++ b/scripts/metrics/src/summary.ts
@@ -1,0 +1,380 @@
+import { escapeHtml, jsonLd } from './datapage.ts';
+import type { DashboardData } from './bundle.ts';
+
+/**
+ * Static, pre-rendered facts injected into `site/insights/index.html` at
+ * deploy time.
+ *
+ * The charted dashboard draws every figure in the browser from `data.json`,
+ * which means the URL people actually share carries prose and no numbers in
+ * its own text layer. `/insights/data/` exists for readers that want the raw
+ * tables, but a fetcher that reads the charted page and stops never follows
+ * the link — and that is the common case for a crawler or an assistant asked
+ * to "look at this page". This module puts the headline measurements into the
+ * served HTML so the shared URL answers on its own.
+ *
+ * It is deliberately NOT a second implementation of the at-a-glance cards.
+ * Those cards are range-dependent and carry 30-day deltas with their own
+ * reasons for declining to state one; duplicating that logic in a second
+ * language would create two sets of rules that drift apart, and the drift
+ * would be invisible until the two disagreed in public. What is generated
+ * here is a summary built from rules simple enough to be obviously correct:
+ * the latest measured value of each counter with the date it was measured,
+ * the peak day of each traffic series, and the leading referrer and path.
+ *
+ * The absent-versus-zero rule governs here as everywhere else. A figure with
+ * no measurement behind it is OMITTED FROM THE SENTENCE rather than printed
+ * as zero or as a dash, because this text is read by machines that will quote
+ * whatever number they find next to a label.
+ */
+
+/** One headline figure: a measured value and the date it was measured on. */
+export interface DatedValue {
+  value: number;
+  date: string;
+}
+
+/** A traffic series' busiest measured day. */
+export interface PeakDay {
+  value: number;
+  uniques: number | null;
+  date: string;
+}
+
+export interface SummaryFacts {
+  /** Earliest and latest date any series covers, or null for an empty archive. */
+  from: string | null;
+  to: string | null;
+  /** `daily` unless the bundle was downsampled to fit its size budget. */
+  resolution: string;
+  stars: DatedValue | null;
+  forks: DatedValue | null;
+  watchers: DatedValue | null;
+  contributors: DatedValue | null;
+  viewsPeak: PeakDay | null;
+  clonesPeak: PeakDay | null;
+  viewsDays: number;
+  clonesDays: number;
+  topReferrer: { label: string; detail: string | null; count: number; uniques: number } | null;
+  topPath: { label: string; detail: string | null; count: number; uniques: number } | null;
+  latestRelease: { tag: string; date: string } | null;
+}
+
+/**
+ * The last index of `values` holding a measurement, paired with its date.
+ *
+ * Walks backwards rather than filtering, because these arrays are aligned
+ * with `dates` by index and the pairing is the whole point: a value reported
+ * without the date it was measured on is exactly the kind of figure this
+ * project exists not to publish.
+ */
+function newestMeasured(
+  dates: readonly string[],
+  values: ReadonlyArray<number | null>,
+): DatedValue | null {
+  for (let i = Math.min(dates.length, values.length) - 1; i >= 0; i--) {
+    const value = values[i];
+    const date = dates[i];
+    if (value === null || value === undefined || date === undefined) continue;
+    return { value, date };
+  }
+  return null;
+}
+
+/** The measured day with the highest count. Ties keep the earliest day. */
+function peakDay(
+  dates: readonly string[],
+  counts: ReadonlyArray<number | null>,
+  uniques: ReadonlyArray<number | null>,
+): PeakDay | null {
+  let best: PeakDay | null = null;
+  for (let i = 0; i < Math.min(dates.length, counts.length); i++) {
+    const value = counts[i];
+    const date = dates[i];
+    if (value === null || value === undefined || date === undefined) continue;
+    if (best !== null && value <= best.value) continue;
+    best = { value, uniques: uniques[i] ?? null, date };
+  }
+  return best;
+}
+
+function countMeasured(values: ReadonlyArray<number | null>): number {
+  let n = 0;
+  for (const value of values) if (value !== null) n++;
+  return n;
+}
+
+/** The latest date across every dated series, or null when nothing is dated. */
+function latestDate(data: DashboardData): string | null {
+  const candidates: string[] = [];
+  for (const series of Object.values(data.series)) {
+    const last = series.dates[series.dates.length - 1];
+    if (last !== undefined) candidates.push(last);
+  }
+  for (const dimension of Object.values(data.dimensions)) {
+    const last = dimension.snapshots[dimension.snapshots.length - 1];
+    if (last !== undefined) candidates.push(last);
+  }
+  if (candidates.length === 0) return null;
+  return candidates.reduce((a, b) => (a > b ? a : b));
+}
+
+/**
+ * The name to show for a referrer or a path.
+ *
+ * Mirrors `displayLabel` in the dashboard exactly — trimmed `title` when it
+ * has one, `dimension` otherwise — because the two must never disagree about
+ * what a row is called. GitHub fills `title` for paths (a path's page title,
+ * e.g. "Overview") and leaves it EMPTY for referrers, where the host in
+ * `dimension` is the name; reading `title` alone prints nothing at all for
+ * every referrer, which is how this was found.
+ *
+ * `detail` is the raw `dimension` when it differs from the label, so a path
+ * called "Overview" is still identifiable as `/TheZwiss/backspace`.
+ */
+function labelled(entry: {
+  dimension: string;
+  title: string;
+  count: number;
+  uniques: number;
+}): { label: string; detail: string | null; count: number; uniques: number } {
+  const title = entry.title.trim();
+  const label = title !== '' ? title : entry.dimension;
+  return {
+    label,
+    detail: label === entry.dimension ? null : entry.dimension,
+    count: entry.count,
+    uniques: entry.uniques,
+  };
+}
+
+export function buildSummary(data: DashboardData): SummaryFacts {
+  const { views, clones, stars, forks, contributors, repo } = data.series;
+  const referrer = data.dimensions.referrers.latest[0];
+  const path = data.dimensions.paths.latest[0];
+  // `releases` is sorted (date asc, tag asc) by the archive's own comparator,
+  // so the newest is the last element rather than a re-sort here.
+  const release = data.releases[data.releases.length - 1];
+
+  return {
+    from: data.collection_started,
+    to: latestDate(data),
+    resolution: data.downsampled ? 'weekly' : 'daily',
+    stars: newestMeasured(stars.dates, stars.total),
+    forks: newestMeasured(forks.dates, forks.total),
+    watchers: newestMeasured(repo.dates, repo.subscribers),
+    contributors: newestMeasured(contributors.dates, contributors.total),
+    viewsPeak: peakDay(views.dates, views.count, views.uniques),
+    clonesPeak: peakDay(clones.dates, clones.count, clones.uniques),
+    viewsDays: countMeasured(views.count),
+    clonesDays: countMeasured(clones.count),
+    topReferrer: referrer === undefined ? null : labelled(referrer),
+    topPath: path === undefined ? null : labelled(path),
+    latestRelease: release === undefined ? null : { tag: release.tag, date: release.date },
+  };
+}
+
+/** `1234` -> `1,234`. Grouped so a long figure stays readable in prose. */
+function num(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+/**
+ * `1 watcher`, `7 watchers`. Every noun this renders is regular, so the rule
+ * is the rule; it exists because "1 watchers" in a sentence a model is going
+ * to quote reads as carelessness about the numbers themselves.
+ */
+function count(value: number, singular: string): string {
+  return `${num(value)} ${singular}${value === 1 ? '' : 's'}`;
+}
+
+/**
+ * The visible summary paragraph.
+ *
+ * Every clause is skipped rather than filled with a placeholder when its
+ * measurement is missing, so an archive that has only just started produces a
+ * shorter sentence instead of a sentence full of dashes. An archive with
+ * nothing in it produces no figures at all, and the caller gets a paragraph
+ * that says so plainly.
+ */
+export function renderSummaryHtml(facts: SummaryFacts): string {
+  const counters: string[] = [];
+  if (facts.stars !== null) counters.push(count(facts.stars.value, 'star'));
+  if (facts.forks !== null) counters.push(count(facts.forks.value, 'fork'));
+  if (facts.watchers !== null) counters.push(count(facts.watchers.value, 'watcher'));
+  if (facts.contributors !== null) {
+    counters.push(count(facts.contributors.value, 'contributor'));
+  }
+
+  const sentences: string[] = [];
+
+  // The date every counter is "as of" is taken from the stars row rather than
+  // from the clock: it is the date those values were actually measured on,
+  // and the counters are collected in one pass so they share it.
+  const asOf = facts.stars?.date ?? facts.forks?.date ?? facts.watchers?.date ?? null;
+  if (counters.length > 0) {
+    const list =
+      counters.length === 1
+        ? counters[0]
+        : `${counters.slice(0, -1).join(', ')} and ${counters[counters.length - 1]}`;
+    sentences.push(asOf === null ? `${list}.` : `${list}, measured ${escapeHtml(asOf)}.`);
+  }
+
+  if (facts.viewsPeak !== null) {
+    const uniques =
+      facts.viewsPeak.uniques === null
+        ? ''
+        : ` from ${count(facts.viewsPeak.uniques, 'unique visitor')}`;
+    sentences.push(
+      `Busiest day for page views: ${count(facts.viewsPeak.value, 'view')}${uniques} on ` +
+        `${escapeHtml(facts.viewsPeak.date)}, across ${count(facts.viewsDays, 'measured day')}.`,
+    );
+  }
+  if (facts.clonesPeak !== null) {
+    sentences.push(
+      `Busiest day for clones: ${count(facts.clonesPeak.value, 'clone')} on ` +
+        `${escapeHtml(facts.clonesPeak.date)}, across ${count(facts.clonesDays, 'measured day')}.`,
+    );
+  }
+  const named = (d: { label: string; detail: string | null }): string =>
+    d.detail === null
+      ? escapeHtml(d.label)
+      : `${escapeHtml(d.label)} (${escapeHtml(d.detail)})`;
+
+  if (facts.topReferrer !== null) {
+    sentences.push(
+      `Leading referrer over the trailing 14 days: ${named(facts.topReferrer)}, ` +
+        `${count(facts.topReferrer.count, 'view')} from ` +
+        `${count(facts.topReferrer.uniques, 'unique visitor')}.`,
+    );
+  }
+  if (facts.topPath !== null) {
+    sentences.push(
+      `Most-visited path over the same window: ${named(facts.topPath)}, ` +
+        `${count(facts.topPath.count, 'view')}.`,
+    );
+  }
+  if (facts.latestRelease !== null) {
+    sentences.push(
+      `Latest release: ${escapeHtml(facts.latestRelease.tag)}, published ` +
+        `${escapeHtml(facts.latestRelease.date)}.`,
+    );
+  }
+
+  const coverage =
+    facts.from === null || facts.to === null
+      ? 'The archive holds no measurements yet.'
+      : `The archive covers ${escapeHtml(facts.from)} to ${escapeHtml(facts.to)} at ` +
+        `${escapeHtml(facts.resolution)} resolution.`;
+
+  // The closing clause says "above", so it is only true when something was
+  // stated above it. An archive with nothing in it gets the shorter form.
+  const body =
+    sentences.length === 0
+      ? `${coverage} The series will appear in the ` +
+        '<a href="data/">plain tables</a> and in <a href="data.json"><code>data.json</code></a> ' +
+        'as soon as there is anything to record.'
+      // No link out of this clause: the paragraph directly above it already
+      // carries both, and repeating them four lines later reads as a page
+      // that has lost track of what it has said.
+      : `<strong>Latest measurements.</strong> ${sentences.join(' ')} ${coverage} ` +
+        'Every figure above is a recorded measurement, not an estimate.';
+
+  return `<p class="sec-copy static-figures">${body}</p>`;
+}
+
+/**
+ * The `Dataset` block, regenerated so it carries the archive's real coverage
+ * and its current values rather than only the names of the things measured.
+ *
+ * `variableMeasured` becomes `PropertyValue` entries with a `value` where one
+ * has been measured, which is the form consumers read a figure out of. A
+ * variable with no measurement behind it keeps its name and drops the value,
+ * for the same reason the prose omits it.
+ */
+export function renderDatasetJsonLd(facts: SummaryFacts, siteUrl: string): string {
+  const base = siteUrl.replace(/\/+$/, '');
+  const variables: Array<Record<string, unknown>> = [];
+  const add = (name: string, unit: string, dated: DatedValue | null): void => {
+    const entry: Record<string, unknown> = { '@type': 'PropertyValue', name, unitText: unit };
+    if (dated !== null) {
+      entry['value'] = dated.value;
+      entry['measurementTechnique'] = `Measured ${dated.date}`;
+    }
+    variables.push(entry);
+  };
+  add('stars', 'stars', facts.stars);
+  add('forks', 'forks', facts.forks);
+  add('watchers', 'watchers', facts.watchers);
+  add('contributors', 'contributors', facts.contributors);
+  for (const name of [
+    'page views',
+    'unique visitors',
+    'repository clones',
+    'unique cloners',
+    'open issues',
+    'release asset downloads',
+    'referring sites',
+    'popular paths',
+  ]) {
+    variables.push({ '@type': 'PropertyValue', name });
+  }
+
+  const dataset: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: 'Backspace repository traffic and growth archive',
+    description:
+      "Daily archive of the Backspace repository's GitHub traffic, stars, forks, contributors " +
+      'and releases. GitHub discards repository traffic data after 14 days; this archive records ' +
+      'it once per day and retains it indefinitely. Every figure is measured, never estimated; a ' +
+      'value that was not measured is recorded as absent rather than as zero.',
+    url: `${base}/insights/`,
+    license: 'https://www.gnu.org/licenses/agpl-3.0.html',
+    isAccessibleForFree: true,
+    creator: { '@type': 'Organization', name: 'Backspace' },
+    measurementTechnique:
+      'GitHub REST API, collected once daily by a scheduled job and committed to a public git branch',
+    variableMeasured: variables,
+    distribution: [
+      {
+        '@type': 'DataDownload',
+        encodingFormat: 'application/json',
+        contentUrl: `${base}/insights/data.json`,
+        name: 'Complete archive bundle (JSON)',
+      },
+      {
+        '@type': 'DataDownload',
+        encodingFormat: 'text/html',
+        contentUrl: `${base}/insights/data/`,
+        name: 'The same archive as static HTML tables',
+      },
+    ],
+  };
+  if (facts.from !== null && facts.to !== null) {
+    dataset['temporalCoverage'] = `${facts.from}/${facts.to}`;
+  }
+
+  return `<script type="application/ld+json">\n${jsonLd(dataset)}\n</script>`;
+}
+
+/**
+ * Replaces the content between `<!-- BUILD:NAME -->` and `<!-- /BUILD:NAME -->`.
+ *
+ * Throws when a region is missing rather than returning the document
+ * unchanged. A silent no-op here publishes the committed fallback — a page
+ * with no figures in it — and it would look exactly like a successful deploy,
+ * which is the failure mode this whole subsystem is built to avoid.
+ */
+export function replaceRegion(html: string, name: string, replacement: string): string {
+  const open = `<!-- BUILD:${name} -->`;
+  const close = `<!-- /BUILD:${name} -->`;
+  const start = html.indexOf(open);
+  const end = html.indexOf(close);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(
+      `summary: no ${open} ... ${close} region in the page; refusing to publish it unchanged`,
+    );
+  }
+  return html.slice(0, start + open.length) + '\n' + replacement + '\n' + html.slice(end);
+}

--- a/site/index.html
+++ b/site/index.html
@@ -917,6 +917,12 @@ footer a:hover { color: var(--txt); }
     <div class="nums" id="nums" hidden></div>
     <p class="nums-note" id="nums-note" hidden></p>
     <a class="btn btn-glass" href="insights/">See the full archive</a>
+    <p class="sec-copy">
+      The charted view needs a browser. If you would rather read the numbers, or have something
+      else read them, the same archive is published as
+      <a href="insights/data/">plain tables</a> and as one file,
+      <a href="insights/data.json">data.json</a>.
+    </p>
   </div>
 </section>
 
@@ -998,6 +1004,7 @@ footer a:hover { color: var(--txt); }
       <a href="https://github.com/TheZwiss/backspace/blob/main/docs/comparison.md">Comparison</a>
       <a href="https://github.com/TheZwiss/backspace/blob/main/CONTRIBUTING.md">Contributing</a>
       <a href="insights/">Insights</a>
+      <a href="insights/data/">Data</a>
     </span>
   </div>
 </footer>

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -11,6 +11,7 @@
      methodology on this page but has no way to discover that data.json exists,
      because every value here is fetched and drawn client-side. Kept in sync by
      hand with the copy datapage.ts emits; both point at the same two URLs. -->
+<!-- BUILD:JSONLD -->
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -43,6 +44,7 @@
   ]
 }
 </script>
+<!-- /BUILD:JSONLD -->
 <link rel="icon" type="image/png" href="../assets/logo.png" />
 <link rel="apple-touch-icon" href="../assets/logo.png" />
 <meta name="robots" content="index, follow" />
@@ -86,6 +88,9 @@
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html { scroll-behavior: smooth; }
+.static-figures { margin-top: 18px; }
+.static-figures strong { color: var(--txt); font-weight: 600; }
+
 @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
 body {
   background: var(--base);
@@ -534,6 +539,20 @@ footer a:hover { color: var(--txt); }
         the charts cannot render. <a href="data/">The same archive as plain tables</a> needs none.
       </p>
     </noscript>
+
+    <!-- The figures below are written into this file at deploy time by
+         cli-bundle.ts, from the same bundle the charts are drawn from, so the
+         served page states its headline measurements without running any
+         JavaScript. What is committed here is the pre-build fallback: it names
+         where the numbers live rather than guessing at them, because a stale
+         figure baked into source would outlive whatever made it true. -->
+    <!-- BUILD:SUMMARY -->
+    <p class="sec-copy static-figures">
+      The headline measurements are written into this page at deploy time. If you are reading this
+      sentence instead of them, this copy was not built by the deploy pipeline: the figures are in
+      the <a href="data/">plain tables</a> and in <a href="data.json"><code>data.json</code></a>.
+    </p>
+    <!-- /BUILD:SUMMARY -->
     <p class="provenance">
       <span><span class="k">archive history</span> <span class="v" id="pv-since">checking</span></span>
       <span><span class="k">bundle built</span> <span class="v" id="pv-generated">checking</span></span>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -30,6 +30,7 @@
 - Repository insights, charted (traffic, growth, and referral figures, collected daily): https://thezwiss.github.io/backspace/insights/
 - The same archive as plain HTML tables, no JavaScript required: https://thezwiss.github.io/backspace/insights/data/
 - The same archive as one machine-readable JSON file: https://thezwiss.github.io/backspace/insights/data.json
+- Sitemap: https://thezwiss.github.io/backspace/sitemap.xml
 
 ## Repository metrics archive
 


### PR DESCRIPTION
## Why

`/insights/` draws every value client-side, so its served HTML carries the methodology and **not one number**. The static data page at `/insights/data/` solves that for a reader who follows the link — but a fetcher that reads the shared URL and stops never does, and that is the common case for a search crawler or an assistant asked to "look at this page".

Measured before changing anything: `/insights/` exposes **3,395 characters of prose and 0 dates**; `/insights/data/` exposes **5,715 characters and 160 dates**. Every URL returns `200` to GPTBot, OAI-SearchBot, ChatGPT-User and curl, with no `x-robots-tag` and no `meta noindex` — nothing is blocked. The gap is that the shared URL says nothing quotable, and nothing announces these pages exist.

## What this does

`cli-bundle.ts` writes two regions into `site/insights/index.html` from the same `DashboardData` the charts read, so the static text cannot disagree with them:

- **`<!-- BUILD:SUMMARY -->`** — headline measurements: each counter's latest measured value with the date it was measured, the peak day of views and clones, the leading referrer and path, and the archive's coverage and resolution.
- **`<!-- BUILD:JSONLD -->`** — the `Dataset` block regenerated so `variableMeasured` carries `PropertyValue` entries with real values and `temporalCoverage` states the actual span. Skipped without `METRICS_SITE_URL`, since every URL in it is absolute.

Rendered against the live archive:

> **Latest measurements.** 64 stars, 5 forks, 1 watcher and 4 contributors, measured 2026-09-02. Busiest day for page views: 174 views from 37 unique visitors on 2026-08-25, across 15 measured days. Busiest day for clones: 189 clones on 2026-09-01, across 15 measured days. Leading referrer over the trailing 14 days: Google, 193 views from 53 unique visitors. Most-visited path over the same window: Overview (/TheZwiss/backspace), 646 views. Latest release: v1.0.0, published 2026-07-03. The archive covers 2026-02-15 to 2026-09-02 at daily resolution. Every figure above is a recorded measurement, not an estimate.

Plus `site/sitemap.xml`, generated at deploy time, and direct links to the plain tables from the landing page and `llms.txt`.

## Design points

- **Not a second implementation of the at-a-glance cards.** Those are range-dependent and carry 30-day deltas with their own reasons for declining to state one. A second copy of those rules in TypeScript would drift, and the drift would be invisible until the two disagreed in public. `summary.ts` derives only figures whose rules are simple enough to be obviously correct.
- **The absent-versus-zero rule governs prose too.** A figure with no measurement loses its whole clause rather than printing `0` or a dash. This text is read by machines that quote whatever number sits next to a label, so a dash beside "watchers" is a worse outcome here than on a chart.
- **A missing marker throws.** `replaceRegion` refuses to return the page unchanged: the committed fallback says "not built by the pipeline", and publishing it silently would look exactly like a successful deploy.
- **`lastmod` describes content, not the build.** The two generated pages take it from the archive's newest date; the landing page carries none, because nothing in this pipeline knows when it last changed. A `lastmod` that lies tells a crawler not to come back.

## robots.txt cannot come from this repo

It is only honoured at a domain root, and this site is a project page at `thezwiss.github.io/backspace/`. That root currently returns GitHub's "Site not found" — there is no `thezwiss.github.io` user-pages repository. A 404 there is permissive, so nothing is blocked, but the sitemap cannot be declared from it either. Documented in `metrics.md`; being handled separately.

## Bug caught while verifying against the real archive

GitHub leaves `title` **empty for every referrer** and puts the host in `dimension` (it fills `title` only for paths). Reading `title` alone rendered *"Leading referrer over the trailing 14 days: , 193 views"*. `labelled()` now mirrors the dashboard's own `displayLabel` — trimmed `title` when non-empty, `dimension` otherwise — and a test pins it. A pluralisation bug ("1 watchers") was fixed in the same pass.

## Verification

- `tsc --noEmit` clean
- **307 tests across 12 files** (up from 280; 27 new across `summary.test.ts` and `sitemap.test.ts`, covering the trailing-null skip, omission rather than zero, the empty archive, XSS escaping of referrer and path names in both the title and the raw dimension, the empty-title referrer, pluralisation, `temporalCoverage` omission, marker-missing and marker-order failures, and sitemap URL joining and escaping)
- **44 browser assertions at 1440 / 1280 / 768 / 390** against a real build from the live archive: five sections, no collapsed panels, no horizontal overflow, no console errors, chart ink unchanged
- Screenshotted the built page top; the injected paragraph sits in the intro and reads as part of it