### PR TITLE
feat(insights): publish CI activity beside the clone series

### DIFF
--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -82,7 +82,7 @@ site/                                the GitHub Pages site
 branch: metrics-data (orphan, ruleset-protected — see §8)
   traffic/views.csv, traffic/clones.csv
   traffic/referrers.ndjson, traffic/paths.ndjson
-  stars.csv, forks.csv, releases.csv, contributors.csv, repo.csv
+  stars.csv, forks.csv, releases.csv, contributors.csv, repo.csv, workflows.csv
   meta.json
 ```
 
@@ -114,12 +114,22 @@ All files live at the root of the `metrics-data` branch. CSVs are sorted ascendi
 | File | Columns | One row means |
 |---|---|---|
 | `traffic/views.csv` | `date,count,uniques` | Total views and unique visitors on that UTC date |
-| `traffic/clones.csv` | `date,count,uniques` | Total clones and unique cloners on that UTC date |
+| `traffic/clones.csv` | `date,count,uniques` | Total clones and unique cloners on that UTC date — see the caveat below the table |
 | `stars.csv` | `date,total` | The repo's live `stargazers_count` as read on that date (a point-in-time snapshot, not a delta) — see the caveat below the table |
 | `forks.csv` | `date,total` | The repo's live `forks_count` as read on that date — see the caveat below the table |
 | `releases.csv` | `date,tag,name` | A release published on that UTC date (`date` = `published_at`'s UTC day) — see the caveat below the table |
 | `contributors.csv` | `date,total` | Cumulative distinct-contributor count, where a contributor counts from the UTC date of the start of their first commit week onward. Capped: see the note below the table |
 | `repo.csv` | `date,subscribers,open_issues,downloads_total,downloads_app,downloads_updates` | The repo object's counters as read on that date, plus release asset `download_count` sums: every asset, then that total split into app installs and update-check traffic |
+| `workflows.csv` | `date,runs` | Workflow runs this repository started on that UTC date. A `0` is a measured zero, never a gap — see the caveat below the table |
+
+#### Caveats on the table above
+
+**Clones count this repository's own CI.** GitHub counts every `actions/checkout` in the clone statistics, so `traffic/clones.csv` measures the build pipeline and the audience together, with no field distinguishing them. Measured on this repo: days with no workflow runs sit at 2-30 clones, while 2026-08-25 and 2026-09-01 recorded 155 and 189 clones against 218 and 180 successful checkout steps. Clones far above one per unique cloner is the signature. The ratio is not a constant and this archive does not model it: neither the run count nor the checkout-step count predicts the clone figure closely (218 checkout steps produced 155 clones, 180 produced 189), so only the co-occurrence is established, not a coefficient. That is exactly why nothing here publishes a "clones minus CI" figure: that would be a model, and the premise of this archive is that every number on it is a measurement. Page views are unaffected, because a checkout loads no page. The confound is disclosed on the clones card, in the Reach section copy, in the static data page's clones blurb, and in the `BUILD:SUMMARY` sentence that states the peak clone day. It is also *shown*: `workflows.csv` records this repository's own daily workflow-run count, and the dashboard plots it as a third chart on the Reach section's shared axis, directly under clones. The two series are never combined into one corrected figure — see §4.5.
+
+**`stars.csv` and `forks.csv` are point-in-time snapshots, not deltas.** Each row is the live counter as read that day, so it correctly reflects someone who starred and later unstarred. A row written by `backfill()` instead reconstructs the value from `/stargazers`' `starred_at`, which lists only *current* stargazers, making a reconstructed row a **lower bound**. Nothing on disk distinguishes the two writers. See §4.2.
+
+**`releases.csv` is keyed on `tag`, not `date`.** It is the one CSV where more than one row can legitimately share a date, so its merge uses `upsertByKey` with a `tag` ascending tie-break (`compareReleaseRows`) rather than `upsertByDate`. See §4.2.
+
 
 ### The static data page
 
@@ -226,10 +236,22 @@ Once the write phase starts, its very first action is a synchronous read, not a 
 
 Nothing in this package ever writes `0` to stand in for "not measured." `repo.csv.downloads_total` is left as a blank CSV field (`null` in memory) when the optional `/releases` fetch fails, specifically so a missing measurement can never be mistaken for a real zero download count. A version that instead carried the previous run's value forward under today's date was considered and rejected during review: a flat line in that case would be indistinguishable from a genuinely quiet day, whereas a hole in the data is visible and honestly represents "we don't know." The same principle governs the dimensional files (§3.2, a dropped-out referrer is an absent row, never a zero) and `getStats()` (§6, a persistent 202 is `null`, never a zero).
 
+The rule has a counterpart that `workflows.csv` is the first series to exercise: **a measured zero must not be hidden either.** The Actions list endpoint is asked for a date range and answers it completely, so a day inside the requested window with no runs is a day this collector measured and found empty. Writing no row for it would render on the chart as collector downtime — the same class of lie, pointed the other way. So `countByDay` (`series.ts`) emits a row for every day in the range it is given, zeros included, and the caller owns the claim that the range was fully observed. Contrast the traffic endpoints, which omit a zero-traffic day entirely: there, absence really is "not measured", which is why the two series must never share a fill rule.
+
 ### 4.4 Self-healing (traffic only)
 
 The traffic window is 14 buckets wide, so any gap of **≤13 full days** without a successful run is silently repaired the next time `collect()` runs — the next successful fetch's window simply covers the missed dates again, and `upsertByDate`'s overwrite mode fills them in. A missed cron, a transient API outage, or a rejected push therefore costs nothing as long as the next run succeeds within two weeks. As established in §4.1, this self-healing property belongs to `traffic/*` specifically and does not extend to `stars.csv`, `forks.csv`, or `repo.csv`.
 
+
+### 4.5 Workflow runs are counted over a window, and never subtracted from clones
+
+`workflows.csv` exists because GitHub counts every `actions/checkout` in the clone statistics (§3.1), so the clone line is partly a picture of this project's build pipeline. Two properties keep it honest.
+
+**It is collected over a trailing 14-day window, not for `today` alone.** The collector runs mid-morning UTC, so the current day's run count is always partial. Counting only `today` and never revisiting it would freeze every day at whatever fraction had happened by ~10:00 — a uniform understatement nothing downstream could detect. The window matches the traffic window it is compared against, the fetch is bounded server-side with `created=>=`, and the merge is `'overwrite'`, so yesterday's partial count is replaced by its complete one on the next run. Re-counting a settled day writes an identical value, so this costs no extra diff.
+
+**Backfill stops at the oldest surviving run.** GitHub deletes workflow runs once they pass the repository's retention period (90 days by default). Reconstructing a day older than the oldest run still returned would write a confident `0` for a day whose evidence has been destroyed — a fabricated measurement, indistinguishable ever after from a genuinely quiet day. Inside the surviving span the zeros are sound, because retention deletes uniformly by age: if the oldest surviving run is still present, no later day has lost runs. Below that date the reconstruction writes nothing, leaving a gap, which is the truthful encoding.
+
+**The two series are never combined.** No "clones minus estimated CI" figure is published anywhere. The relationship is not a stable coefficient — measured on this repository, 218 successful checkout steps accompanied 155 clones on one day and 180 accompanied 189 on another — so a corrected number would be a model, on a page whose entire claim is that every figure was measured. Both series are plotted on a shared axis, as separate stacked charts rather than one dual-axis chart, precisely so the co-occurrence is visible without inviting a ratio to be read off them.
 ---
 
 ## 5. The 202 problem
@@ -263,6 +285,7 @@ These are documented because reading the obviously-named GitHub field would sile
 1. **Create a fine-grained personal access token**, scoped to this repository only, with:
    - **Administration: read** — the traffic endpoints (`/traffic/views`, `/traffic/clones`, `/traffic/popular/referrers`, `/traffic/popular/paths`) require this permission specifically, and it is the exact documented requirement for all of them.
    - **Contents: read** — needed to read the repo object and its release/star/fork data.
+   - **Actions: read** — needed for `/actions/runs`, which backs `workflows.csv` (§4.5). **Added after the token was first issued**, so an existing `METRICS_TOKEN` will not have it: without this permission the runs fetch 403s, the collector skips the series (it is optional, so the run still succeeds and every other series is written) and `meta.json` lists `workflows.csv` under `skipped`. The CI chart then renders its "no measurement falls inside this window" note rather than a line. Grant the permission on the existing token; nothing needs to be re-created and no data is lost, because backfill can reconstruct the series as far back as GitHub still retains runs.
 2. **Store it as the `METRICS_TOKEN` repository secret** (Settings → Secrets and variables → Actions → New repository secret).
 3. **Create a branch protection ruleset on `metrics-data`** blocking **deletion** and **force-push (non-fast-forward)**, with **no bypass actors**. `gh ruleset list` on this repo shows the two precedents: `Protect CLA signature store` and, for this branch, `Protect metrics data store`. Do **not** require pull requests or status checks — both workflows commit directly to the branch, and requiring a PR would break every run. This branch is the only place in the repository holding genuinely irreplaceable data (the traffic history), so it is the one branch that most needs this protection.
 
@@ -315,6 +338,8 @@ node scripts/metrics/src/cli-backfill.ts
 ```
 
 Safe to run at any time, including repeatedly — every write is if-absent (§4.2), so no value a rerun disagrees with is ever replaced. "Changes nothing" is the normal outcome but not a guarantee: a rerun still *adds* rows for dates no writer has ever recorded, so an archive seeded before the fill described in §3.1 gains its quiet days on the next dispatch (that is how the existing archive was brought forward), and a collector-era gap gains a row it is better off without — see §9 before dispatching against an archive with collector history in it. The CLI's summary line is deliberately phrased "backfill target files (write-if-absent, listed whether or not they changed this run)" rather than "wrote," because `backfill()`'s `written` result is the fixed, exhaustive list of files it is *permitted* to touch, not the set that actually gained a row this run — see `formatBackfillSummary` in `cli-support.ts`.
+
+One asymmetry to know before dispatching for `workflows.csv` specifically: unlike stars and forks, whose evidence (`starred_at`, `created_at`) is permanent, workflow runs are **deleted at the retention horizon**. A backfill run today reconstructs further back than one run in three months will, and the days it can no longer reach are gone for good. If the CI series matters, the useful dispatch is the earliest one, not the most convenient one. Everything it does write is still if-absent, so it remains safe to repeat.
 
 ### Building the dashboard bundle locally
 
@@ -405,7 +430,7 @@ One case worth naming explicitly: `error` can be non-null while `last_success` i
 
 `site/insights/index.html` is the public read side of the archive, published by GitHub Pages at `https://thezwiss.github.io/backspace/insights/`. It is **one HTML file** with its CSS and JavaScript inline, plus two vendored uPlot files next to it (§10.4). No framework, no bundler, no build step, no network request of any kind except the single relative, same-origin `fetch("data.json")` — which is aborted at 15 seconds.
 
-Five sections, each registered against a slot and re-rendered on every range change: **at a glance** (seven cards — stars, forks, watchers, views, clones, contributors, release downloads), **reach** (views and clones), **growth** (stars and forks, annotated with release markers), **referrers**, and **paths**. The range control offers `30d`, `90d`, `1y` and `all`, defaulting to `all` — the only one that cannot imply a window wider than what was actually measured.
+Five sections, each registered against a slot and re-rendered on every range change: **at a glance** (eight cards — stars, forks, watchers, views, clones, contributors, app downloads, update checks; the clones card carries a standing note that CI checkouts are counted in it), **reach** (views, clones, and this repository's own CI activity), **growth** (stars and forks, annotated with release markers), **referrers**, and **paths**. The range control offers `30d`, `90d`, `1y` and `all`, defaulting to `all` — the only one that cannot imply a window wider than what was actually measured.
 
 The page has **no automated tests**. It is the untested side of a contract whose other side is heavily tested, which is why §10.2 is written as a contract rather than as a description, and why the page validates the payload strictly before rendering a single figure.
 
@@ -439,6 +464,7 @@ interface DashboardData {
     views: TrafficSeries;  clones: TrafficSeries;
     stars: CountSeries;    forks: CountSeries;   contributors: CountSeries;
     repo: RepoSeries;
+    workflows: WorkflowSeries;
   };
   releases: Array<{ date: string; tag: string; name: string }>;
   dimensions: { referrers: DimensionSeries; paths: DimensionSeries };
@@ -447,6 +473,7 @@ interface DashboardData {
 /** Parallel arrays, index-aligned with `dates`. */
 interface TrafficSeries { dates: string[]; count: Array<number | null>; uniques: Array<number | null>; }
 interface CountSeries   { dates: string[]; total: Array<number | null>; }
+interface WorkflowSeries{ dates: string[]; runs: Array<number | null>; }
 interface RepoSeries    { dates: string[]; subscribers: Array<number | null>;
                           open_issues: Array<number | null>; downloads_total: Array<number | null>;
                           downloads_app: Array<number | null>; downloads_updates: Array<number | null>; }
@@ -568,6 +595,8 @@ Two limits, stated so they are not rediscovered as surprises:
 
 **A 404 on `data.json` and `empty: true` are different conditions and the page says different things about them.** Conflating them would be the page making a claim about data it has not seen.
 
+There is a third, per-chart case worth stating because it is the normal state of any newly added series: a bundle can be perfectly healthy while one series inside it is empty. A series enters the `data.json` contract the moment the collector gains it, but enters the archive only on the next successful collection run, so on the deploy that introduces it there is nothing to plot. uPlot answers that with an empty frame on an invented 0..1 axis — a chart that looks broken while its own caption reads "measured 0 of 15 days". So a chart card whose primary series has no measured step inside the window renders a sentence in place of the plot, and the section still reports the span and the unmeasured count above it. That is also what the CI chart shows if `METRICS_TOKEN` lacks **Actions: read** (§7).
+
 | Page status | Cause | What it says |
 |---|---|---|
 | `unavailable` | the fetch failed: 404, non-2xx, timeout, unparseable JSON, or a payload `validateBundle` rejected | "The archive is not available here" — the bundle is generated at deploy time and is not committed, so when the archive or the deploy step is unavailable there are no figures, and inventing them would be worse |
@@ -591,18 +620,21 @@ Whenever the banner fires it also reports `last_success`, because when the colle
 
 ## 11. Testing
 
-`scripts/metrics`'s `test` script is `tsc --noEmit && vitest run` — it runs through the existing root `pnpm -r test` step with no `ci.yml` change required, and covers both types and behavior in one script. All tests are fixture-driven and touch no network; filesystem tests use a per-test `mkdtempSync` directory, cleaned up in `afterEach`. As of this writing there are **257 tests across 9 files**, all passing:
+`scripts/metrics`'s `test` script is `tsc --noEmit && vitest run` — it runs through the existing root `pnpm -r test` step with no `ci.yml` change required, and covers both types and behavior in one script. All tests are fixture-driven and touch no network; filesystem tests use a per-test `mkdtempSync` directory, cleaned up in `afterEach`. As of this writing there are **338 tests across 12 files**, all passing:
 
 ```
 src/no-runtime-deps.test.ts   9
 src/vendor-check.test.ts      6
-src/series.test.ts           47
-src/github.test.ts           17
+src/sitemap.test.ts           5
+src/datapage.test.ts         14
+src/github.test.ts           21
+src/backfill.test.ts         22
 src/store.test.ts            23
+src/summary.test.ts          26
+src/collect.test.ts          33
 src/cli-support.test.ts      35
-src/backfill.test.ts         12
-src/collect.test.ts          25
-src/bundle.test.ts           83
+src/series.test.ts           55
+src/bundle.test.ts           89
 ```
 
 `bundle.test.ts` is the largest of them because it carries the whole of §10.2's contract: the null-versus-zero rule at every read, the trajectory invariants, the two weekly aggregators, and the budget sequence. `vendor-check.test.ts` is not a unit test at all — it hashes the committed uPlot files against `vendor.json` (§10.4) and has its own `vendor:check` script for running it alone.

--- a/scripts/metrics/src/backfill.test.ts
+++ b/scripts/metrics/src/backfill.test.ts
@@ -23,6 +23,16 @@ const STARGAZERS = [
   { starred_at: '2026-03-01T09:00:00Z' },
 ];
 const FORKS = [{ created_at: '2026-03-05T09:00:00Z' }];
+// Two runs on 02-21 and one on 02-23. 02-22 falls between them and must
+// reconstruct as a measured 0, while everything before 02-21 — the oldest
+// surviving run — must not be reconstructed at all, because GitHub deletes
+// runs by age and an older day's silence is destroyed evidence, not a zero.
+const WORKFLOW_RUNS = [
+  { created_at: '2026-02-21T08:00:00Z' },
+  { created_at: '2026-02-21T20:00:00Z' },
+  { created_at: '2026-02-23T09:00:00Z' },
+];
+
 const RELEASES = [
   { tag_name: 'v1.0.0', name: 'Backspace 1.0.0', published_at: '2026-08-01T10:00:00Z' },
 ];
@@ -32,6 +42,7 @@ function fakeClient(pages: Record<string, unknown[]> = {}): GitHubClient {
     '/repos/o/r/stargazers': STARGAZERS,
     '/repos/o/r/forks?sort=oldest': FORKS,
     '/repos/o/r/releases': RELEASES,
+    '/repos/o/r/actions/runs': WORKFLOW_RUNS,
     ...pages,
   };
   return {
@@ -44,6 +55,12 @@ function fakeClient(pages: Record<string, unknown[]> = {}): GitHubClient {
     async paginate<T>(p: string): Promise<T[]> {
       const value = routes[p];
       if (value === undefined) throw new Error(`unexpected paginate ${p}`);
+      return value as T[];
+    },
+    async paginateEnvelope<T>(p: string, key: string): Promise<T[]> {
+      if (key !== 'workflow_runs') throw new Error(`unexpected envelope key ${key}`);
+      const value = routes[p];
+      if (value === undefined) throw new Error(`unexpected paginateEnvelope ${p}`);
       return value as T[];
     },
   };
@@ -117,6 +134,42 @@ describe('backfill', () => {
     expect(rows[rows.length - 1]).toEqual({ date: '2026-03-01', total: '3' });
   });
 
+  it('reconstructs workflow runs per day, with a measured zero between them', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('workflows.csv');
+    expect(rows.find((r) => r.date === '2026-02-21')).toEqual({ date: '2026-02-21', runs: '2' });
+    expect(rows.find((r) => r.date === '2026-02-22')).toEqual({ date: '2026-02-22', runs: '0' });
+    expect(rows.find((r) => r.date === '2026-02-23')).toEqual({ date: '2026-02-23', runs: '1' });
+  });
+
+  // The bound that keeps this honest. GitHub deletes workflow runs by age, so
+  // a day older than the oldest surviving run has had its evidence destroyed —
+  // reconstructing a confident `0` there would be a fabricated measurement,
+  // and it would look exactly like a genuinely quiet day forever after.
+  it('reconstructs nothing before the oldest surviving run', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    const dates = store.readCsv('workflows.csv').map((r) => r.date);
+    expect(dates[0]).toBe('2026-02-21');
+    expect(dates).not.toContain('2026-02-20');
+  });
+
+  // Inside the surviving span the fill runs all the way to the run date: those
+  // zeros ARE measurements, because retention deletes uniformly by age.
+  it('fills quiet days from the last run up to the run date', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('workflows.csv');
+    expect(rows[rows.length - 1]).toEqual({ date: '2026-03-05', runs: '0' });
+  });
+
+  it('writes no workflow rows at all when no run survives', async () => {
+    const store = createStore(dir);
+    await backfill({ client: fakeClient({ '/repos/o/r/actions/runs': [] }), store, ...base });
+    expect(store.readCsv('workflows.csv')).toEqual([]);
+  });
+
   it('accumulates forks cumulatively by created_at', async () => {
     const store = createStore(dir);
     await backfill({ client: fakeClient(), store, ...base });
@@ -188,6 +241,9 @@ describe('backfill', () => {
       },
       async getStats<T>(): Promise<T | null> {
         return null;
+      },
+      async paginateEnvelope<T>(): Promise<T[]> {
+        return [] as T[];
       },
       async paginate<T>(p: string): Promise<T[]> {
         if (p !== '/repos/o/r/releases') throw new Error(`unexpected paginate ${p}`);

--- a/scripts/metrics/src/backfill.ts
+++ b/scripts/metrics/src/backfill.ts
@@ -1,4 +1,12 @@
-import { upsertByDate, upsertByKey, compareReleaseRows, compareStrings } from './series.ts';
+import {
+  upsertByDate,
+  upsertByKey,
+  compareReleaseRows,
+  compareStrings,
+  countByDay,
+  utcDayStart,
+  MS_PER_DAY,
+} from './series.ts';
 import type { GitHubClient } from './github.ts';
 import type { Store } from './store.ts';
 import type { CountPoint, IsoDate, ReleaseRow } from './types.ts';
@@ -7,6 +15,9 @@ interface StargazerResponse {
   starred_at: string;
 }
 interface ForkResponse {
+  created_at: string;
+}
+interface WorkflowRunResponse {
   created_at: string;
 }
 interface ReleaseResponse {
@@ -49,8 +60,6 @@ export interface BackfillOptions {
  */
 const WRITABLE = ['stars.csv', 'forks.csv', 'releases.csv'] as const;
 
-const MS_PER_DAY = 86_400_000;
-
 /**
  * Upper bound on the number of days one reconstruction may write. GitHub
  * launched in 2008, so a repository history longer than this is not a long
@@ -61,32 +70,6 @@ const MS_PER_DAY = 86_400_000;
  */
 const MAX_RECONSTRUCTED_DAYS = 20_000;
 
-const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
-
-/**
- * Converts a `YYYY-MM-DD` date to the epoch milliseconds of its UTC midnight,
- * so the fill in `cumulativeByDay` can step a day at a time.
- *
- * Built from the matched components through `Date.UTC` rather than
- * `new Date(string)`, and then round-tripped back to a string, for the same
- * reasons `bundle.ts`'s `utcMonday` does it this way: a non-ISO spelling like
- * `2026-9-1` parses host-dependently, and an impossible date like `2026-02-30`
- * rolls silently over to 2 March, which would shift every row after it by two
- * days under a date that still looks perfectly ordinary. The round trip
- * catches both, along with the legacy two-digit-year mapping in `Date.UTC`
- * where year 50 means 1950.
- */
-function utcDayStart(date: IsoDate): number {
-  const match = ISO_DATE_RE.exec(date);
-  if (match === null) {
-    throw new Error(`backfill: expected a YYYY-MM-DD date, got ${JSON.stringify(date)}`);
-  }
-  const time = Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
-  if (!Number.isFinite(time) || new Date(time).toISOString().slice(0, 10) !== date) {
-    throw new Error(`backfill: ${JSON.stringify(date)} is not a real calendar date`);
-  }
-  return time;
-}
 
 /**
  * Converts an ISO timestamp to its UTC calendar date. Mirrors `collect.ts`'s
@@ -244,6 +227,10 @@ export async function backfill(options: BackfillOptions): Promise<{ written: str
   );
   const forks = await client.paginate<ForkResponse>(`${repoPath}/forks?sort=oldest`);
   const releases = await client.paginate<ReleaseResponse>(`${repoPath}/releases`);
+  const workflowRuns = await client.paginateEnvelope<WorkflowRunResponse>(
+    `${repoPath}/actions/runs`,
+    'workflow_runs',
+  );
 
   /**
    * Reads `file`, merges `incoming` into it with `'if-absent'`, and writes
@@ -279,6 +266,40 @@ export async function backfill(options: BackfillOptions): Promise<{ written: str
     ['date', 'total'],
     cumulativeByDay(forks.map((item) => toDate(item.created_at)), today),
   );
+
+  // Reconstructed only across the span where a run actually survives, which is
+  // NOT the same as "every day up to today".
+  //
+  // GitHub deletes workflow runs once they pass the repository's retention
+  // period (90 days by default). Counting a day older than the oldest
+  // surviving run would therefore reconstruct a confident `0` for a day that
+  // may have been the busiest in the archive — a fabricated zero, which is the
+  // single thing §4.3 forbids outright, and one that would be indistinguishable
+  // from a real quiet day forever after.
+  //
+  // Inside the surviving span the zeros ARE honest, and the reason is worth
+  // stating because it is what makes the bound sound: retention deletes by age,
+  // uniformly, so if a run from the oldest surviving date is still here, no run
+  // from any LATER date has been deleted. Every zero at or after that date is a
+  // day GitHub still remembers and reports nothing for.
+  //
+  // Below that date this writes nothing at all, leaving a gap — "not measured"
+  // — which is the truthful encoding of a period whose evidence GitHub has
+  // already destroyed.
+  const runDates = workflowRuns.map((run) => run.created_at.slice(0, 10)).sort(compareStrings);
+  const oldestRun = runDates[0];
+  const newestRun = runDates[runDates.length - 1];
+  if (oldestRun !== undefined && newestRun !== undefined) {
+    // `today` bounds the fill forward but must never truncate evidence, the
+    // same rule `cumulativeByDay` follows: a run that lands while this job is
+    // paging through the list is dated after `today` and still gets its row.
+    const through = compareStrings(newestRun, today) > 0 ? newestRun : today;
+    mergeIfAbsent(
+      'workflows.csv',
+      ['date', 'runs'],
+      countByDay(runDates, oldestRun, through).map((day) => ({ date: day.date, runs: day.count })),
+    );
+  }
 
   // A draft release carries `published_at: null` and is excluded: it has no
   // publish date to record, and being unpublished, it is not yet a public

--- a/scripts/metrics/src/bundle.test.ts
+++ b/scripts/metrics/src/bundle.test.ts
@@ -777,6 +777,7 @@ function makeData(overrides: Partial<DashboardData> = {}): DashboardData {
         downloads_app: [],
         downloads_updates: [],
       },
+      workflows: { dates: [], runs: [] },
     },
     releases: [],
     dimensions: {
@@ -794,6 +795,49 @@ function dailyDates(start: string, count: number): string[] {
     new Date(base + index * 86_400_000).toISOString().slice(0, 10),
   );
 }
+
+describe('workflows series', () => {
+  it('reads runs, keeping a measured zero distinct from an unmeasured day', () => {
+    writeRaw(
+      'workflows.csv',
+      ['date,runs', '2026-08-31,17', '2026-09-01,0', '2026-09-02,', ''].join('\n'),
+    );
+    expect(build().series.workflows).toEqual({
+      dates: ['2026-08-31', '2026-09-01', '2026-09-02'],
+      runs: [17, 0, null],
+    });
+  });
+
+  it('is an empty series, not a missing one, when the archive has no workflows.csv', () => {
+    expect(build().series.workflows).toEqual({ dates: [], runs: [] });
+  });
+
+  // Runs are events on their day, like the traffic counts and unlike the
+  // cumulative counters: taking the last day would flatten exactly the CI
+  // spikes this series exists to put beside the clone line.
+  it('sums runs within a weekly bucket rather than taking the last day', () => {
+    writeRaw(
+      'workflows.csv',
+      [
+        'date,runs',
+        '2026-08-31,10',
+        '2026-09-01,20',
+        '2026-09-02,0',
+        '2026-09-03,5',
+        '',
+      ].join('\n'),
+    );
+    expect(downsampleWeekly(build()).series.workflows).toEqual({
+      dates: ['2026-08-31'],
+      runs: [35],
+    });
+  });
+
+  it('leaves a week the collector never covered as null rather than summing it to zero', () => {
+    writeRaw('workflows.csv', ['date,runs', '2026-08-31,', '', ''].join('\n'));
+    expect(downsampleWeekly(build()).series.workflows.runs).toEqual([null]);
+  });
+});
 
 describe('downsampleWeekly — sum vs. last', () => {
   it('sums traffic but takes the last value of a cumulative counter when bucketing', () => {

--- a/scripts/metrics/src/bundle.ts
+++ b/scripts/metrics/src/bundle.ts
@@ -16,6 +16,7 @@ const REPO_FILE = 'repo.csv';
 const RELEASES_FILE = 'releases.csv';
 const REFERRERS_FILE = 'traffic/referrers.ndjson';
 const PATHS_FILE = 'traffic/paths.ndjson';
+const WORKFLOWS_FILE = 'workflows.csv';
 
 /** How many of the latest snapshot's dimensions get a trajectory line. */
 const TRAJECTORY_LIMIT = 5;
@@ -28,6 +29,20 @@ export interface TrafficSeries {
   dates: string[];
   count: Array<number | null>;
   uniques: Array<number | null>;
+}
+
+/**
+ * This repository's own CI activity per day, index-aligned with `dates`.
+ *
+ * A `0` here is a measured zero and plots AT zero; only an absent date or a
+ * `null` is "not measured". That differs from the traffic series on the same
+ * chart, where GitHub omits a zero-traffic day entirely — the difference is a
+ * property of the two APIs, not a rendering choice, and it is why the two must
+ * not share a gap-filling rule.
+ */
+export interface WorkflowSeries {
+  dates: string[];
+  runs: Array<number | null>;
 }
 
 /** A cumulative counter (stars, forks, contributors) over time. */
@@ -139,6 +154,8 @@ export interface DashboardData {
     forks: CountSeries;
     contributors: CountSeries;
     repo: RepoSeries;
+    /** Present from the day `workflows.csv` first appears; empty before that. */
+    workflows: WorkflowSeries;
   };
   releases: ReleaseEntry[];
   dimensions: {
@@ -238,6 +255,14 @@ function readTrafficSeries(store: Store, file: string): TrafficSeries {
     dates: rows.map((row) => row.date),
     count: rows.map((row) => toNumberOrNull(row.fields['count'], `${file} count`, row.date)),
     uniques: rows.map((row) => toNumberOrNull(row.fields['uniques'], `${file} uniques`, row.date)),
+  };
+}
+
+function readWorkflowSeries(store: Store): WorkflowSeries {
+  const rows = readDatedRows(store, WORKFLOWS_FILE);
+  return {
+    dates: rows.map((row) => row.date),
+    runs: rows.map((row) => toNumberOrNull(row.fields['runs'], `${WORKFLOWS_FILE} runs`, row.date)),
   };
 }
 
@@ -462,12 +487,13 @@ export function buildDashboardData(store: Store, generatedAt: string): Dashboard
   const forks = readCountSeries(store, FORKS_FILE);
   const contributors = readCountSeries(store, CONTRIBUTORS_FILE);
   const repo = readRepoSeries(store);
+  const workflows = readWorkflowSeries(store);
   const releases = readReleases(store);
   const referrers = readDimensionSeries(store, REFERRERS_FILE);
   const paths = readDimensionSeries(store, PATHS_FILE);
   const meta = store.readMeta();
 
-  const series = { views, clones, stars, forks, contributors, repo };
+  const series = { views, clones, stars, forks, contributors, repo, workflows };
 
   // "Holds no rows at all" — releases and dimensions count here even though
   // they are excluded from `collection_started`. The two questions are
@@ -689,6 +715,25 @@ function downsampleTraffic(series: TrafficSeries): TrafficSeries {
   };
 }
 
+/**
+ * Workflow runs SUM within a week, like the traffic counts and unlike the
+ * cumulative counters: a run is an event that happened on its day, so a week's
+ * runs are genuinely the sum of its days'. Taking the last day would report
+ * one day as if it were seven, and would flatten exactly the CI spikes this
+ * series exists to make visible next to the clone line.
+ *
+ * `sumBucket` preserves the not-measured distinction the same way it does for
+ * traffic, so a week in which the collector never ran stays `null` rather than
+ * summing to a zero that would read as a genuinely quiet week.
+ */
+function downsampleWorkflows(series: WorkflowSeries): WorkflowSeries {
+  const buckets = weekBuckets(series.dates);
+  return {
+    dates: buckets.map((bucket) => bucket.monday),
+    runs: buckets.map((bucket) => sumBucket(series.runs, bucket.indices)),
+  };
+}
+
 function downsampleCount(series: CountSeries): CountSeries {
   const buckets = weekBuckets(series.dates);
   return {
@@ -768,6 +813,8 @@ function copyDimensionSeries(series: DimensionSeries): DimensionSeries {
  * - `views` and `clones` are per-day event counts and SUM within a week.
  * - `stars`, `forks`, `contributors` and every field of `repo` are
  *   point-in-time totals and take the week's LAST measured value.
+ * - `workflows.runs` sums, for the same reason the traffic counts do: a run is
+ *   an event on its day, not a running total.
  * - `releases` and `dimensions` are not bucketed at all. Releases are sparse
  *   — there is no space to save, and merging two tags published in one week
  *   into one marker would destroy the annotation the Growth chart exists
@@ -797,6 +844,7 @@ export function downsampleWeekly(data: DashboardData): DashboardData {
       forks: downsampleCount(data.series.forks),
       contributors: downsampleCount(data.series.contributors),
       repo: downsampleRepo(data.series.repo),
+      workflows: downsampleWorkflows(data.series.workflows),
     },
     releases: data.releases.map((release) => ({ ...release })),
     dimensions: {

--- a/scripts/metrics/src/collect.test.ts
+++ b/scripts/metrics/src/collect.test.ts
@@ -47,6 +47,16 @@ const RELEASES = [
 ];
 const CONTRIBUTORS = [{ weeks: [{ w: 1771200000, c: 3 }] }, { weeks: [{ w: 1771804800, c: 1 }] }];
 
+// Three runs on 08-24, one on 08-25 (today, still in progress), and one dated
+// before the window opens so the range filter has something to reject.
+const WORKFLOW_RUNS = [
+  { created_at: '2026-08-24T09:00:00Z' },
+  { created_at: '2026-08-24T11:30:00Z' },
+  { created_at: '2026-08-24T23:59:00Z' },
+  { created_at: '2026-08-25T02:00:00Z' },
+  { created_at: '2026-08-01T02:00:00Z' },
+];
+
 function fakeClient(overrides: Partial<Record<string, unknown>> = {}): GitHubClient {
   const routes: Record<string, unknown> = {
     '/repos/o/r/traffic/views': VIEWS,
@@ -86,6 +96,19 @@ function fakeClient(overrides: Partial<Record<string, unknown>> = {}): GitHubCli
       if (value === undefined) throw new Error(`unexpected paginate ${p}`);
       return value as T[];
     },
+    async paginateEnvelope<T>(p: string, key: string): Promise<T[]> {
+      // `/actions/runs` is the only envelope-paginated endpoint collect.ts
+      // uses; anything else reaching here is a mistake worth failing on.
+      if (!p.startsWith('/repos/o/r/actions/runs')) {
+        throw new Error(`collect must not envelope-paginate ${p}`);
+      }
+      if (key !== 'workflow_runs') throw new Error(`unexpected envelope key ${key}`);
+      const value = Object.prototype.hasOwnProperty.call(overrides, '/repos/o/r/actions/runs')
+        ? overrides['/repos/o/r/actions/runs']
+        : WORKFLOW_RUNS;
+      if (value instanceof Error) throw value;
+      return value as T[];
+    },
   };
 }
 
@@ -99,6 +122,71 @@ describe('collect', () => {
       { date: '2026-08-23', count: '40', uniques: '12' },
       { date: '2026-08-24', count: '51', uniques: '15' },
     ]);
+  });
+
+  // The whole point of the series: a day this repo ran no CI is a day the
+  // Actions API was asked about and answered "none", which is a measurement.
+  // Writing no row would render it on the chart as collector downtime.
+  it('writes a measured zero for a day inside the window with no runs', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const rows = store.readCsv('workflows.csv');
+    expect(rows.find((r) => r.date === '2026-08-24')).toEqual({ date: '2026-08-24', runs: '3' });
+    expect(rows.find((r) => r.date === '2026-08-23')).toEqual({ date: '2026-08-23', runs: '0' });
+    expect(rows.find((r) => r.date === '2026-08-25')).toEqual({ date: '2026-08-25', runs: '1' });
+  });
+
+  it('covers the whole trailing window, not only the days that had runs', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const dates = store.readCsv('workflows.csv').map((r) => r.date);
+    expect(dates[0]).toBe('2026-08-12'); // today minus 13
+    expect(dates[dates.length - 1]).toBe('2026-08-25');
+    expect(dates).toHaveLength(14);
+  });
+
+  // A run older than the window is outside what this call claims to have
+  // counted; recording it would produce the only row for a day whose other
+  // runs were never fetched.
+  it('drops a run dated before the window opens', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    const dates = store.readCsv('workflows.csv').map((r) => r.date);
+    expect(dates).not.toContain('2026-08-01');
+  });
+
+  // Today's count is always partial — the day is still running when the
+  // collector fires — so a later run must be able to correct it upward.
+  it('overwrites an earlier partial count for the same day', async () => {
+    const store = createStore(dir);
+    await collect({ client: fakeClient(), store, ...base });
+    expect(store.readCsv('workflows.csv').find((r) => r.date === '2026-08-25')?.runs).toBe('1');
+    await collect({
+      client: fakeClient({
+        '/repos/o/r/actions/runs': [
+          ...WORKFLOW_RUNS,
+          { created_at: '2026-08-25T18:00:00Z' },
+          { created_at: '2026-08-25T21:00:00Z' },
+        ],
+      }),
+      store,
+      ...base,
+    });
+    expect(store.readCsv('workflows.csv').find((r) => r.date === '2026-08-25')?.runs).toBe('3');
+  });
+
+  // The failure mode that would poison the series permanently: a zero is a
+  // legitimate value here, so a fabricated one is indistinguishable from a
+  // real measurement forever after.
+  it('skips the series rather than writing zeros when the runs fetch fails', async () => {
+    const store = createStore(dir);
+    const result = await collect({
+      client: fakeClient({ '/repos/o/r/actions/runs': new Error('boom') }),
+      store,
+      ...base,
+    });
+    expect(store.readCsv('workflows.csv')).toEqual([]);
+    expect(result.skipped).toContain('workflows.csv');
   });
 
   it('does not invent a row for today when the window ends yesterday', async () => {

--- a/scripts/metrics/src/collect.ts
+++ b/scripts/metrics/src/collect.ts
@@ -1,4 +1,12 @@
-import { upsertByDate, upsertByKey, upsertDimensional, compareReleaseRows } from './series.ts';
+import {
+  upsertByDate,
+  upsertByKey,
+  upsertDimensional,
+  compareReleaseRows,
+  countByDay,
+  utcDayStart,
+  MS_PER_DAY,
+} from './series.ts';
 import type { GitHubClient } from './github.ts';
 import type { Meta, Store } from './store.ts';
 import type {
@@ -8,6 +16,7 @@ import type {
   ReleaseRow,
   RepoPoint,
   TrafficPoint,
+  WorkflowPoint,
 } from './types.ts';
 
 interface TrafficBucket {
@@ -66,6 +75,33 @@ export function isUpdateArtifact(assetName: string): boolean {
 
 interface ContributorResponse {
   weeks: Array<{ w: number; c: number }>;
+}
+
+interface WorkflowRunResponse {
+  created_at: string;
+}
+
+/**
+ * How many days of workflow-run history each collection re-counts.
+ *
+ * Fourteen, to match the traffic window this series exists to be compared
+ * against, and for one structural reason beyond symmetry: **the run count for
+ * the current day is always partial.** The collector runs mid-morning UTC, so
+ * counting only `today` and never revisiting it would freeze every day of this
+ * series at whatever fraction of it had happened by ~10:00 — a permanent,
+ * uniformly-wrong understatement that nothing downstream could detect. Fetching
+ * a trailing window and merging it with `'overwrite'` means yesterday's partial
+ * count is replaced by its complete one on the very next run, which is exactly
+ * how the traffic series already stays correct.
+ *
+ * A window this size costs one extra paginated fetch per run and is bounded by
+ * a server-side `created=>=` filter, so it does not grow with the archive.
+ */
+const WORKFLOW_WINDOW_DAYS = 14;
+
+/** The UTC date `days` days before `date`, as `YYYY-MM-DD`. */
+function daysBefore(date: IsoDate, days: number): IsoDate {
+  return new Date(utcDayStart(date) - days * MS_PER_DAY).toISOString().slice(0, 10);
 }
 
 export interface CollectResult {
@@ -192,6 +228,24 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
     contributors = null;
   }
   if (contributors === null) skipped.push('contributors.csv');
+
+  // Optional, and paginated with a server-side date filter so the cost is
+  // bounded by the window rather than by how long this repo has existed.
+  // Optional rather than required for the usual reason: a failed fetch must
+  // skip the series, never write a zero. A zero here is a load-bearing value
+  // — it is what a quiet day legitimately looks like — so a fabricated one
+  // would be indistinguishable from a real measurement, which is precisely
+  // the failure this package's `skipped` path exists to avoid.
+  const workflowFrom = daysBefore(today, WORKFLOW_WINDOW_DAYS - 1);
+  let workflowRuns: WorkflowRunResponse[] | null = null;
+  try {
+    workflowRuns = await client.paginateEnvelope<WorkflowRunResponse>(
+      `${repoPath}/actions/runs?created=%3E%3D${workflowFrom}`,
+      'workflow_runs',
+    );
+  } catch {
+    skipped.push('workflows.csv');
+  }
 
   // `downloads_total` is folded into `repo.csv` alongside the required
   // `subscribers`/`open_issues` counters, but it is itself sourced from the
@@ -355,6 +409,23 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   const forks: CountPoint = { date: today, total: repo.forks_count };
   writeCsvSeries('stars.csv', ['date', 'total'], [stars]);
   writeCsvSeries('forks.csv', ['date', 'total'], [forks]);
+
+  // Written only when the fetch succeeded, and then for the whole window at
+  // once rather than for `today` alone. `writeCsvSeries` merges with
+  // `'overwrite'`, which is what upgrades each earlier day's partial count to
+  // its final one: today's row is always short (the day is still running) and
+  // is corrected by tomorrow's run, and the day before that has already been
+  // corrected. Re-counting a settled day is free in diff terms — the value it
+  // writes is identical to the one already there — so this costs one line of
+  // archive churn on the days that actually changed and none anywhere else.
+  if (workflowRuns !== null) {
+    const runDates = workflowRuns.map((run) => run.created_at.slice(0, 10));
+    writeCsvSeries(
+      'workflows.csv',
+      ['date', 'runs'],
+      countByDay(runDates, workflowFrom, today).map((day) => ({ date: day.date, runs: day.count })),
+    );
+  }
 
   // Always written: `subscribers`/`open_issues` are required-fetch fields
   // that have already resolved successfully by this point, so they are

--- a/scripts/metrics/src/datapage.test.ts
+++ b/scripts/metrics/src/datapage.test.ts
@@ -6,7 +6,7 @@ function data(overrides: Partial<DashboardData> = {}): DashboardData {
   return {
     generated_at: '2026-09-02T10:00:00.000Z',
     collection_started: '2026-08-18',
-    meta: { last_run: null, last_success: null, error: null },
+    meta: { last_run: '2026-09-02T10:00:00.000Z', last_success: null, error: null },
     empty: false,
     downsampled: false,
     series: {
@@ -23,6 +23,9 @@ function data(overrides: Partial<DashboardData> = {}): DashboardData {
         downloads_app: [null],
         downloads_updates: [0],
       },
+      // A measured zero and a real count, so the table can be checked for the
+      // one thing this series must never do: render its zero as a gap.
+      workflows: { dates: ['2026-08-18', '2026-08-19'], runs: [0, 12] },
     },
     releases: [],
     dimensions: {
@@ -30,7 +33,7 @@ function data(overrides: Partial<DashboardData> = {}): DashboardData {
       paths: { snapshots: [], latest: [], trajectories: [] },
     },
     ...overrides,
-  } as DashboardData;
+  };
 }
 
 describe('escapeHtml', () => {
@@ -57,6 +60,26 @@ describe('jsonLd', () => {
 });
 
 describe('renderDataPage', () => {
+  // The tables are the encoding a crawler reads. A clone column presented as
+  // plain reach, with no note that this repository's own CI is counted in it,
+  // is the one number here that reliably reads as more adoption than it is.
+  // The distinction this whole series turns on: on the traffic tables a zero
+  // day is absent (GitHub omits it), here it is a value that must be printed.
+  it('prints a workflow zero as a zero, never as not measured', () => {
+    const html = renderDataPage(data());
+    expect(html).toContain('CI activity');
+    expect(html).toContain('workflow runs');
+    const row = html.slice(html.indexOf('<h2>CI activity</h2>'));
+    expect(row).toContain('2026-08-18');
+    expect(row.slice(0, row.indexOf('</table>'))).not.toContain('not measured');
+  });
+
+  it('qualifies the clone table with the CI checkouts counted in it', () => {
+    const html = renderDataPage(data());
+    expect(html).toContain('actions/checkout');
+    expect(html).toContain('per unique cloner');
+  });
+
   it('puts the measured values in the HTML itself, not behind a fetch', () => {
     const html = renderDataPage(data());
     expect(html).toContain('75');

--- a/scripts/metrics/src/datapage.ts
+++ b/scripts/metrics/src/datapage.ts
@@ -195,6 +195,7 @@ export function renderDataPage(data: DashboardData, options: DataPageOptions = {
       'unique visitors',
       'repository clones',
       'unique cloners',
+      'workflow runs',
       'stars',
       'forks',
       'contributors',
@@ -253,11 +254,15 @@ ${seriesTable(s.views.dates, [
 ])}
 
 <h2>Clones</h2>
-<p>Daily <code>git clone</code> operations, with the number of distinct cloners.</p>
+<p>Daily <code>git clone</code> operations, with the number of distinct cloners. GitHub counts this repository&rsquo;s own <code>actions/checkout</code> steps here too, so a day of heavy continuous integration inflates the figure well above human traffic; clones far above one per unique cloner is the signature.</p>
 ${seriesTable(s.clones.dates, [
   { label: 'clones', values: s.clones.count },
   { label: 'unique cloners', values: s.clones.uniques },
 ])}
+
+<h2>CI activity</h2>
+<p>Workflow runs this repository started each day, published beside the clone table above because they are the reason it moves. A <code>0</code> here is a measured zero, not a gap: the Actions API is asked for a date range and answers it completely, where the traffic endpoints omit a day they recorded nothing for. History before daily collection began is reconstructed only as far back as GitHub still retains runs, because a day whose runs have been deleted cannot be told apart from a day that had none.</p>
+${seriesTable(s.workflows.dates, [{ label: 'workflow runs', values: s.workflows.runs }])}
 
 <h2>Stars</h2>
 <p>Cumulative star count, one row per day. A day on which nobody starred carries the previous day's total, because that total is known rather than missing. History before daily collection began is reconstructed from each star's permanent timestamp, which counts only stars that still exist, so those early totals are a lower bound on what the counter read at the time.</p>

--- a/scripts/metrics/src/github.test.ts
+++ b/scripts/metrics/src/github.test.ts
@@ -95,6 +95,60 @@ describe('createClient.getStats', () => {
   });
 });
 
+describe('createClient.paginateEnvelope', () => {
+  it('follows rel=next and flattens the named array from each page', async () => {
+    const pages = [
+      jsonResponse(
+        { total_count: 3, workflow_runs: [{ id: 1 }, { id: 2 }] },
+        { headers: { link: '<https://api.github.com/x?page=2>; rel="next"' } },
+      ),
+      jsonResponse({ total_count: 3, workflow_runs: [{ id: 3 }] }),
+    ];
+    let call = 0;
+    const client = createClient('t', {
+      fetchImpl: (async () => pages[call++]) as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginateEnvelope('/x', 'workflow_runs')).resolves.toEqual([
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+    ]);
+  });
+
+  // Degrading a shape change to an empty page would show up as a series that
+  // silently counts zero every day — indistinguishable, in an archive whose
+  // premise is that a zero was measured, from a genuinely quiet repository.
+  it('throws rather than treating a missing key as an empty page', async () => {
+    const client = createClient('t', {
+      fetchImpl: (async () => jsonResponse({ total_count: 0 })) as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginateEnvelope('/x', 'workflow_runs')).rejects.toThrow(
+      /no array at "workflow_runs"/,
+    );
+  });
+
+  it('throws when the endpoint returns a bare array instead of an envelope', async () => {
+    const client = createClient('t', {
+      fetchImpl: (async () => jsonResponse([{ id: 1 }])) as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginateEnvelope('/x', 'workflow_runs')).rejects.toThrow(
+      /expected an object/,
+    );
+  });
+
+  it('still refuses an envelope on the array-shaped paginate', async () => {
+    const client = createClient('t', {
+      fetchImpl: (async () =>
+        jsonResponse({ workflow_runs: [{ id: 1 }] })) as unknown as typeof fetch,
+      sleep: noSleep,
+    });
+    await expect(client.paginate('/x')).rejects.toThrow(/expected an array/);
+  });
+});
+
 describe('createClient.paginate', () => {
   it('follows rel=next until it is absent and concatenates pages', async () => {
     const fetchImpl = vi

--- a/scripts/metrics/src/github.ts
+++ b/scripts/metrics/src/github.ts
@@ -58,6 +58,19 @@ export interface GitHubClient {
    * following a cycle forever.
    */
   paginate<T>(path: string, accept?: string): Promise<T[]>;
+  /**
+   * As `paginate`, for the endpoints that wrap their list in an envelope
+   * object rather than returning a bare array — `/actions/runs` answers
+   * `{ total_count, workflow_runs: [...] }`, and `paginate` correctly refuses
+   * it rather than silently yielding nothing.
+   *
+   * A page whose `key` is missing or is not an array throws, and does NOT
+   * degrade to an empty page: a shape change upstream would otherwise show up
+   * as a series that quietly counts zero on every day, which is far worse
+   * than a failed run in an archive whose whole premise is that a zero was
+   * measured.
+   */
+  paginateEnvelope<T>(path: string, key: string, accept?: string): Promise<T[]>;
 }
 
 export interface ClientOptions {
@@ -192,7 +205,21 @@ export function createClient(token: string, options: ClientOptions = {}): GitHub
     return null;
   }
 
-  async function paginate<T>(path: string, accept?: string): Promise<T[]> {
+  /**
+   * The page walk both public pagination methods share: follows `rel="next"`
+   * to exhaustion and flattens each page through `itemsOf`.
+   *
+   * Extracted rather than duplicated because the valuable part of this loop is
+   * not the flattening — it is the cycle detection and the origin assertion,
+   * and a second copy of those is a second place for them to drift or be
+   * forgotten. The two public methods differ only in how a page yields its
+   * items, so that is the only thing passed in.
+   */
+  async function walkPages<T>(
+    path: string,
+    accept: string | undefined,
+    itemsOf: (page: unknown, url: string) => T[],
+  ): Promise<T[]> {
     const separator = path.includes('?') ? '&' : '?';
     let url: string | null = absolute(`${path}${separator}per_page=100`);
     const items: T[] = [];
@@ -216,12 +243,7 @@ export function createClient(token: string, options: ClientOptions = {}): GitHub
       const response: Response = await request(url, accept);
       if (!response.ok) return throwForStatus(response);
       const page = await parseBody<unknown>(response);
-      if (!Array.isArray(page)) {
-        throw new Error(
-          `paginate: expected an array from ${url} but got ${typeof page} — the pagination sequence is truncated or the endpoint does not return a list`,
-        );
-      }
-      items.push(...(page as T[]));
+      items.push(...itemsOf(page, url));
       const next = nextLink(response.headers.get('link'));
       if (next !== null) assertGitHubOrigin(next);
       url = next;
@@ -229,5 +251,33 @@ export function createClient(token: string, options: ClientOptions = {}): GitHub
     return items;
   }
 
-  return { get, getStats, paginate };
+  async function paginate<T>(path: string, accept?: string): Promise<T[]> {
+    return walkPages<T>(path, accept, (page, url) => {
+      if (!Array.isArray(page)) {
+        throw new Error(
+          `paginate: expected an array from ${url} but got ${typeof page} — the pagination sequence is truncated or the endpoint does not return a list`,
+        );
+      }
+      return page as T[];
+    });
+  }
+
+  async function paginateEnvelope<T>(path: string, key: string, accept?: string): Promise<T[]> {
+    return walkPages<T>(path, accept, (page, url) => {
+      if (page === null || typeof page !== 'object' || Array.isArray(page)) {
+        throw new Error(
+          `paginateEnvelope: expected an object from ${url} but got ${Array.isArray(page) ? 'array' : typeof page} — the endpoint does not return a "${key}" envelope`,
+        );
+      }
+      const items = (page as Record<string, unknown>)[key];
+      if (!Array.isArray(items)) {
+        throw new Error(
+          `paginateEnvelope: ${url} returned an object with no array at "${key}" — the envelope shape changed, and treating that as an empty page would silently under-count`,
+        );
+      }
+      return items as T[];
+    });
+  }
+
+  return { get, getStats, paginate, paginateEnvelope };
 }

--- a/scripts/metrics/src/series.test.ts
+++ b/scripts/metrics/src/series.test.ts
@@ -8,6 +8,8 @@ import {
   parseNdjson,
   formatNdjson,
   upsertDimensional,
+  countByDay,
+  utcDayStart,
 } from './series.ts';
 import type { DimensionRow, ReleaseRow } from './types.ts';
 
@@ -442,5 +444,58 @@ describe('formatNdjson key order', () => {
     expect(text).toBe(
       '{"snapshot_date":"2026-08-01","dimension":"a.com","title":"Home","count":5,"uniques":2}\n',
     );
+  });
+});
+
+describe('countByDay', () => {
+  it('emits one row per day across the whole range, zeros included', () => {
+    const rows = countByDay(['2026-08-02', '2026-08-02', '2026-08-04'], '2026-08-01', '2026-08-05');
+    expect(rows).toEqual([
+      { date: '2026-08-01', count: 0 },
+      { date: '2026-08-02', count: 2 },
+      { date: '2026-08-03', count: 0 },
+      { date: '2026-08-04', count: 1 },
+      { date: '2026-08-05', count: 0 },
+    ]);
+  });
+
+  // The caller's range is a claim about what was fully observed. An event
+  // outside it would otherwise contribute the only row for a day this call
+  // never counted completely.
+  it('drops events outside the requested range instead of extending it', () => {
+    const rows = countByDay(['2026-07-30', '2026-08-02', '2026-08-09'], '2026-08-01', '2026-08-03');
+    expect(rows.map((r) => r.date)).toEqual(['2026-08-01', '2026-08-02', '2026-08-03']);
+    expect(rows.reduce((sum, r) => sum + r.count, 0)).toBe(1);
+  });
+
+  it('returns a single row when the range is one day', () => {
+    expect(countByDay(['2026-08-01'], '2026-08-01', '2026-08-01')).toEqual([
+      { date: '2026-08-01', count: 1 },
+    ]);
+  });
+
+  it('returns nothing when the range runs backwards', () => {
+    expect(countByDay(['2026-08-02'], '2026-08-05', '2026-08-01')).toEqual([]);
+  });
+
+  it('steps across a month boundary in UTC', () => {
+    const rows = countByDay(['2026-09-01'], '2026-08-30', '2026-09-01');
+    expect(rows.map((r) => r.date)).toEqual(['2026-08-30', '2026-08-31', '2026-09-01']);
+  });
+});
+
+describe('utcDayStart', () => {
+  it('rejects a date that is not a real day rather than rolling it over', () => {
+    // 2026-02-30 silently becomes 2 March through Date.UTC, which would shift
+    // every row after it by two days under a date that still looks ordinary.
+    expect(() => utcDayStart('2026-02-30')).toThrow(/not a real calendar date/);
+  });
+
+  it('rejects a non-ISO spelling that would parse host-dependently', () => {
+    expect(() => utcDayStart('2026-9-1')).toThrow(/expected a YYYY-MM-DD date/);
+  });
+
+  it('returns UTC midnight for a valid date', () => {
+    expect(utcDayStart('2026-08-01')).toBe(Date.UTC(2026, 7, 1));
   });
 });

--- a/scripts/metrics/src/series.ts
+++ b/scripts/metrics/src/series.ts
@@ -92,6 +92,77 @@ function splitRows(text: string): string[][] {
   return rows;
 }
 
+/** Milliseconds in a UTC day. Every dated series steps by this. */
+export const MS_PER_DAY = 86_400_000;
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Converts a `YYYY-MM-DD` date to the epoch milliseconds of its UTC midnight,
+ * so a dense day-by-day fill can step a day at a time.
+ *
+ * Built from the matched components through `Date.UTC` rather than
+ * `new Date(string)`, and then round-tripped back to a string, for the same
+ * reasons `bundle.ts`'s `utcMonday` does it this way: a non-ISO spelling like
+ * `2026-9-1` parses host-dependently, and an impossible date like `2026-02-30`
+ * rolls silently over to 2 March, which would shift every row after it by two
+ * days under a date that still looks perfectly ordinary. The round trip
+ * catches both, along with the legacy two-digit-year mapping in `Date.UTC`
+ * where year 50 means 1950.
+ *
+ * Lives here rather than in `backfill.ts` because both the reconstruction and
+ * the daily collector now fill dense day ranges, and two copies of this
+ * validation would be two places for the round-trip check to be dropped.
+ */
+export function utcDayStart(date: IsoDate): number {
+  const match = ISO_DATE_RE.exec(date);
+  if (match === null) {
+    throw new Error(`expected a YYYY-MM-DD date, got ${JSON.stringify(date)}`);
+  }
+  const time = Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  if (!Number.isFinite(time) || new Date(time).toISOString().slice(0, 10) !== date) {
+    throw new Error(`${JSON.stringify(date)} is not a real calendar date`);
+  }
+  return time;
+}
+
+/**
+ * Counts dated events per UTC day across the whole range `[from, through]`,
+ * emitting a row for every day in it — including days with no events.
+ *
+ * The dense fill is the point. This backs `workflows.csv`, where a day with no
+ * workflow runs is a MEASURED ZERO rather than an absence: the Actions API is
+ * asked for a date range and answers it completely, unlike the traffic
+ * endpoints, which omit a day they recorded nothing for. §4.3 forbids
+ * inventing a zero for an unmeasured day; it equally forbids hiding a measured
+ * one behind a gap, which would read on the chart as collector downtime.
+ *
+ * Callers own the range, and with it the claim that the range was fully
+ * observed. An event outside `[from, through]` is dropped rather than
+ * recorded, so a page that straddles the boundary cannot contribute a partial
+ * count for a day this call did not cover completely.
+ */
+export function countByDay(dates: readonly IsoDate[], from: IsoDate, through: IsoDate): CountedDay[] {
+  const perDay = new Map<IsoDate, number>();
+  for (const date of dates) {
+    if (compareStrings(date, from) < 0 || compareStrings(date, through) > 0) continue;
+    perDay.set(date, (perDay.get(date) ?? 0) + 1);
+  }
+  const rows: CountedDay[] = [];
+  const end = utcDayStart(through);
+  for (let time = utcDayStart(from); time <= end; time += MS_PER_DAY) {
+    const date = new Date(time).toISOString().slice(0, 10);
+    rows.push({ date, count: perDay.get(date) ?? 0 });
+  }
+  return rows;
+}
+
+/** One day and how many events landed on it. */
+export interface CountedDay {
+  date: IsoDate;
+  count: number;
+}
+
 export function parseCsv(text: string): Record<string, string>[] {
   const rows = splitRows(text);
   const header = rows.shift();

--- a/scripts/metrics/src/summary.test.ts
+++ b/scripts/metrics/src/summary.test.ts
@@ -29,6 +29,7 @@ function data(overrides: Partial<DashboardData> = {}): DashboardData {
         downloads_app: [null],
         downloads_updates: [0],
       },
+      workflows: { dates: ['2026-08-18', '2026-08-19'], runs: [0, 17] },
     },
     releases: [{ date: '2026-07-03', tag: 'v1.0.0', name: 'Backspace 1.0.0' }],
     dimensions: {
@@ -65,6 +66,7 @@ const empty = (): DashboardData =>
         downloads_app: [],
         downloads_updates: [],
       },
+      workflows: { dates: [], runs: [] },
     },
     releases: [],
     dimensions: {
@@ -145,6 +147,36 @@ describe('renderSummaryHtml', () => {
     expect(html).not.toContain('watchers');
     expect(html).not.toContain('0 watchers');
     expect(html).toContain('64 stars');
+  });
+
+  // The busiest clone day is, on this repository, a day its own CI ran hardest —
+  // GitHub counts every `actions/checkout` as a clone. This sentence is baked into
+  // the shared `/insights/` HTML, so it is the figure a fetcher quotes; the caveat
+  // has to travel in the same sentence or the number arrives stripped of it.
+  it('never states the clone peak without saying CI checkouts are counted in it', () => {
+    const html = renderSummaryHtml(buildSummary(data()));
+    expect(html).toContain('Busiest day for clones: 10 clones on 2026-08-18');
+    expect(html).toContain('own CI checkouts');
+  });
+
+  it('states the CI peak so the clone caveat has its number in the same text', () => {
+    const html = renderSummaryHtml(buildSummary(data()));
+    expect(html).toContain('17 workflow runs on 2026-08-19');
+  });
+
+  it('omits the CI sentence when the archive carries no workflow rows', () => {
+    const d = data();
+    d.series.workflows = { dates: [], runs: [] };
+    const html = renderSummaryHtml(buildSummary(d));
+    expect(html).not.toContain('workflow run');
+  });
+
+  it('omits the CI caveat entirely when there is no clone figure to qualify', () => {
+    const d = data();
+    d.series.clones = { dates: [], count: [], uniques: [] };
+    const html = renderSummaryHtml(buildSummary(d));
+    expect(html).not.toContain('Busiest day for clones');
+    expect(html).not.toContain('own CI checkouts');
   });
 
   it('says plainly that nothing is recorded rather than rendering a figure-less sentence', () => {

--- a/scripts/metrics/src/summary.ts
+++ b/scripts/metrics/src/summary.ts
@@ -55,6 +55,12 @@ export interface SummaryFacts {
   clonesPeak: PeakDay | null;
   viewsDays: number;
   clonesDays: number;
+  /**
+   * The heaviest day of this repository's own CI, which is what the clone
+   * caveat points at. Stated so a reader that quotes the clone peak has the
+   * number that explains it in the same paragraph rather than in a chart.
+   */
+  workflowsPeak: PeakDay | null;
   topReferrer: { label: string; detail: string | null; count: number; uniques: number } | null;
   topPath: { label: string; detail: string | null; count: number; uniques: number } | null;
   latestRelease: { tag: string; date: string } | null;
@@ -82,10 +88,15 @@ function newestMeasured(
 }
 
 /** The measured day with the highest count. Ties keep the earliest day. */
+/**
+ * `uniques` is optional: a workflow run has no unique-visitor reading, and
+ * passing an empty array rather than making the parameter nullable keeps the
+ * one code path — `uniques[i] ?? null` already yields null for a short array.
+ */
 function peakDay(
   dates: readonly string[],
   counts: ReadonlyArray<number | null>,
-  uniques: ReadonlyArray<number | null>,
+  uniques: ReadonlyArray<number | null> = [],
 ): PeakDay | null {
   let best: PeakDay | null = null;
   for (let i = 0; i < Math.min(dates.length, counts.length); i++) {
@@ -149,7 +160,7 @@ function labelled(entry: {
 }
 
 export function buildSummary(data: DashboardData): SummaryFacts {
-  const { views, clones, stars, forks, contributors, repo } = data.series;
+  const { views, clones, stars, forks, contributors, repo, workflows } = data.series;
   const referrer = data.dimensions.referrers.latest[0];
   const path = data.dimensions.paths.latest[0];
   // `releases` is sorted (date asc, tag asc) by the archive's own comparator,
@@ -168,6 +179,7 @@ export function buildSummary(data: DashboardData): SummaryFacts {
     clonesPeak: peakDay(clones.dates, clones.count, clones.uniques),
     viewsDays: countMeasured(views.count),
     clonesDays: countMeasured(clones.count),
+    workflowsPeak: peakDay(workflows.dates, workflows.runs),
     topReferrer: referrer === undefined ? null : labelled(referrer),
     topPath: path === undefined ? null : labelled(path),
     latestRelease: release === undefined ? null : { tag: release.tag, date: release.date },
@@ -233,7 +245,16 @@ export function renderSummaryHtml(facts: SummaryFacts): string {
   if (facts.clonesPeak !== null) {
     sentences.push(
       `Busiest day for clones: ${count(facts.clonesPeak.value, 'clone')} on ` +
-        `${escapeHtml(facts.clonesPeak.date)}, across ${count(facts.clonesDays, 'measured day')}.`,
+        `${escapeHtml(facts.clonesPeak.date)}, across ${count(facts.clonesDays, 'measured day')}. ` +
+        'Clone counts include this repository\u2019s own CI checkouts, which on a heavy build ' +
+        'day outnumber human clones.',
+    );
+  }
+  if (facts.workflowsPeak !== null) {
+    sentences.push(
+      'Busiest day for this repository\u2019s own CI: ' +
+        `${count(facts.workflowsPeak.value, 'workflow run')} on ` +
+        `${escapeHtml(facts.workflowsPeak.date)}.`,
     );
   }
   const named = (d: { label: string; detail: string | null }): string =>

--- a/scripts/metrics/src/types.ts
+++ b/scripts/metrics/src/types.ts
@@ -14,6 +14,26 @@ export interface CountPoint {
   total: number;
 }
 
+/**
+ * One day of this repository's own CI activity: the number of workflow runs
+ * it started on that UTC date.
+ *
+ * It exists to sit beside `traffic/clones.csv`, which GitHub inflates with
+ * every `actions/checkout` this repository runs. The two are plotted on a
+ * shared axis so a clone spike that is really a build spike is visible as
+ * such, rather than described in prose the reader has to take on trust.
+ *
+ * Unlike traffic, a day with no runs is a MEASURED ZERO, not an absence: the
+ * Actions API is asked for a whole window and answers completely, where the
+ * traffic endpoints omit a zero-traffic day entirely. So this series writes
+ * an explicit `0` for a quiet day and plots it at zero, and a genuine gap
+ * here means the collector did not run. See §4.3.
+ */
+export interface WorkflowPoint {
+  date: IsoDate;
+  runs: number;
+}
+
 /** A published release. `date` is the UTC day of `published_at`. */
 export interface ReleaseRow {
   date: IsoDate;

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -272,6 +272,9 @@ h2 {
 }
 .sec-copy { color: var(--txt2); max-width: 62ch; font-size: 15.5px; }
 .sec-copy strong { color: var(--txt); font-weight: 560; }
+/* Two section paragraphs in a row: the reset zeroes p margins, so without
+   this they butt together and read as one run-on block. */
+.sec-copy + .sec-copy { margin-top: 14px; }
 
 /* The slot each later section renders into. Empty by design until filled. */
 .slot { margin-top: 26px; min-width: 0; }
@@ -323,6 +326,10 @@ h2 {
 }
 .stat-value.is-unmeasured { font-size: 1.6rem; font-weight: 500; color: var(--txt4); }
 .stat-sub { color: var(--txt3); font-size: 13px; line-height: 1.5; overflow-wrap: anywhere; }
+/* A standing qualifier on the figure above it, for a card whose number means
+   something other than what its label suggests. Dimmer and smaller than
+   .stat-sub: it is a caveat, not a second measurement. */
+.stat-note { color: var(--txt4); font-size: 12px; line-height: 1.45; margin-top: 4px; }
 .stat-delta {
   align-self: flex-start; margin-top: 5px;
   font-family: var(--mono); font-size: 12px; font-weight: 500;
@@ -597,6 +604,19 @@ footer a:hover { color: var(--txt); }
         recorded no traffic</strong>, so a quiet day arrives here as a break rather than as a
         zero, and the two charts can honestly disagree about which days exist. A break is not,
         on its own, evidence that the collector failed.
+      </p>
+      <p class="sec-copy">
+        One caveat belongs to the clone line alone: GitHub counts this repository's own
+        automation in it. Every <code>actions/checkout</code>, in every job of every workflow
+        run, registers as a clone, so on a day of heavy continuous integration the line
+        measures this project's build pipeline rather than its audience and can sit an order
+        of magnitude above the days on either side. Clones running well above one per unique
+        cloner is the signature. Page views are unaffected, because a checkout loads no page.
+        The CI chart below the clone chart is this repository's own workflow-run count on the
+        same axis, so the overlap can be read directly rather than taken on trust. The two are
+        plotted separately and never combined: no fixed number of clones follows from a run,
+        and subtracting an estimate would put a model on a page whose whole claim is that
+        every figure on it was measured.
       </p>
       <div class="slot" id="chart-reach"></div>
     </div>
@@ -1738,7 +1758,13 @@ footer a:hover { color: var(--txt); }
     { label: "Forks", kind: "point", series: "forks", field: "total" },
     { label: "Watchers", kind: "point", series: "repo", field: "subscribers" },
     { label: "Views", kind: "flow", series: "views", field: "count" },
-    { label: "Clones", kind: "flow", series: "clones", field: "count" },
+    /* GitHub counts every `actions/checkout` this repository runs as a clone,
+       so on a heavy CI day the figure measures the build pipeline rather than
+       anyone's interest. It cannot be split the way the download cards below
+       are — nothing in the API attributes a clone to Actions — so the card
+       states the confound instead of pretending the number is clean. */
+    { label: "Clones", kind: "flow", series: "clones", field: "count",
+      note: "includes this repo's own CI checkouts" },
     { label: "Contributors", kind: "step", series: "contributors", field: "total" },
     /* Deliberately NOT one "Release downloads" figure. GitHub counts an
        electron-updater feed file (`latest.yml`) and a `.blockmap` in
@@ -2135,6 +2161,7 @@ footer a:hover { color: var(--txt); }
     box.appendChild(el("p", "stat-label", card.label));
     box.appendChild(el("p", "stat-value" + (body.unmeasured ? " is-unmeasured" : ""), body.valueText));
     box.appendChild(el("p", "stat-sub", body.sub));
+    if (card.note) box.appendChild(el("p", "stat-note", card.note));
     box.appendChild(deltaChip(body.delta));
     return box;
   }
@@ -3184,6 +3211,36 @@ footer a:hover { color: var(--txt); }
         fill: "rgba(134, 239, 172, 0.10)"
       },
       uniques: { label: "Unique cloners", token: "--amber", fallback: "#fcd34d" }
+    },
+    /*
+     * Directly below the clone chart, sharing its x axis and its cursor,
+     * because it is the explanation for most of that chart's shape: GitHub
+     * counts every `actions/checkout` this repository runs as a clone.
+     *
+     * Deliberately a SEPARATE chart rather than a second line on the clone
+     * chart. An overlay invites reading a ratio off the two lines, and no
+     * stable ratio exists — measured here, 218 checkout steps produced 155
+     * clones on one day and 180 produced 189 on another. Stacked charts on a
+     * shared axis show the co-occurrence, which is what the archive can
+     * actually support, and claim nothing about the coefficient.
+     *
+     * One series, no `uniques`: a workflow run has no unique-visitor reading.
+     */
+    {
+      columns: {
+        count: { series: "workflows", field: "runs" }
+      },
+      title: "CI activity",
+      note: "A zero here sits on the axis rather than breaking the line, unlike the two " +
+        "charts above. The Actions API is asked for a date range and answers it completely, " +
+        "so a day with no runs is a measurement; the traffic endpoints omit a day they " +
+        "recorded nothing for, so an absent day there is genuinely unmeasured. A break in " +
+        "this line means the collector did not run, or ran before this series existed.",
+      count: {
+        label: "Workflow runs",
+        token: "--rose", fallback: "#fda4af",
+        fill: "rgba(253, 164, 175, 0.10)"
+      }
     }
   ];
 
@@ -3233,17 +3290,23 @@ footer a:hover { color: var(--txt); }
       : spec.uniques.label;
   }
 
+  /* Whether a card carries a second, subordinate series. The CI card does not
+   * — a workflow run has no unique-visitor reading — so every place that
+   * describes or draws `uniques` has to ask first. */
+  function hasUniques(spec) {
+    return spec.uniques !== undefined && spec.uniques !== null;
+  }
+
   /*
    * What this chart actually drew: the span of the axis, and how much of it
    * carries a measurement. The unmeasured count is stated in the same breath
    * as what the page does with it, because a break in a line is the one thing
    * on this page a reader is most likely to read as a fall to zero.
    */
-  function metaLine(axis, offsets) {
+  function metaLine(axis, offsets, spec) {
     var stepDays = axis.stepDays;
     var total = axis.xs.length;
     var counted = axis.measured[offsets.count];
-    var uniqueCounted = axis.measured[offsets.uniques];
     var missing = total - counted;
 
     var note = el("p", "chart-meta");
@@ -3255,8 +3318,11 @@ footer a:hover { color: var(--txt); }
     }
     /* Only when the two columns disagree, which is the case worth naming: the
      * count was recorded and the unique figure was not, or the reverse. */
-    if (uniqueCounted !== counted) {
-      note.appendChild(pair("uniques measured", uniqueCounted + " of " + steps(total, stepDays)));
+    if (hasUniques(spec)) {
+      var uniqueCounted = axis.measured[offsets.uniques];
+      if (uniqueCounted !== counted) {
+        note.appendChild(pair("uniques measured", uniqueCounted + " of " + steps(total, stepDays)));
+      }
     }
     if (axis.offGrid > 0) {
       note.appendChild(pair("off-step",
@@ -3268,10 +3334,33 @@ footer a:hover { color: var(--txt); }
     return note;
   }
 
+  /*
+   * A card whose primary series has NO measured step in this window gets a
+   * sentence instead of a plot.
+   *
+   * uPlot draws such a series as an empty frame on an invented 0..1 axis — a
+   * chart that looks broken while the caption beside it is telling the exact
+   * truth. This is a real state, not a hypothetical: a series added to the
+   * collector appears in the bundle contract immediately and in the archive
+   * only after the next collection run, so every new series is empty on the
+   * deploy that introduces it.
+   */
+  function buildEmptyCard(stack, spec, axis, offsets) {
+    var card = el("div", "chart-card");
+    card.appendChild(el("p", "chart-title", spec.title));
+    card.appendChild(metaLine(axis, offsets, spec));
+    card.appendChild(el("p", "slot-note",
+      "No measurement of " + spec.count.label.toLowerCase() + " falls inside this window, so " +
+      "there is no line to draw. An empty frame would look like a failure rather than an " +
+      "absence."));
+    if (spec.note) card.appendChild(el("p", "chart-hint", spec.note));
+    stack.appendChild(card);
+  }
+
   function buildChart(stack, spec, axis, offsets, downsampled) {
     var card = el("div", "chart-card");
     card.appendChild(el("p", "chart-title", spec.title));
-    card.appendChild(metaLine(axis, offsets));
+    card.appendChild(metaLine(axis, offsets, spec));
 
     var host = el("div", "chart-scroll");
     card.appendChild(host);
@@ -3279,30 +3368,35 @@ footer a:hover { color: var(--txt); }
      * explicit pixel size and that size is measured from this container. */
     stack.appendChild(card);
 
-    if (downsampled) {
+    if (downsampled && hasUniques(spec)) {
       card.appendChild(el("p", "chart-hint chart-caution",
         "This bundle is bucketed by week. A bucket's unique figure is the sum of its " +
         "days' unique counts, so someone who came back on several days is counted more " +
         "than once: read the " + spec.uniques.label.toLowerCase() +
         " line as an upper bound rather than a count of people."));
     }
+    if (spec.note) card.appendChild(el("p", "chart-hint", spec.note));
 
-    return C.mount(host, axis.xs, [
+    var lines = [
       {
         label: spec.count.label,
         stroke: C.colour(spec.count.token, spec.count.fallback),
         fill: spec.count.fill,
         width: 2,
         values: axis.values[offsets.count]
-      },
-      {
+      }
+    ];
+    if (hasUniques(spec)) {
+      lines.push({
         label: uniquesLabel(spec, downsampled),
         stroke: C.colour(spec.uniques.token, spec.uniques.fallback),
         width: 1.5,
         dash: [5, 4],
         values: axis.values[offsets.uniques]
-      }
-    ], {
+      });
+    }
+
+    return C.mount(host, axis.xs, lines, {
       /* Stated rather than left to the default. Both series here are per-day
        * event counts with a true floor at zero, so this is the right policy —
        * and a shipped caller exercising the extension point is what keeps it
@@ -3377,7 +3471,7 @@ footer a:hover { color: var(--txt); }
 
     if (axis.empty) {
       slot.appendChild(el("p", "slot-note",
-        "Neither views nor clones carry a row inside " + win.title.toLowerCase() + " (" +
+        "No traffic or CI series carries a row inside " + win.title.toLowerCase() + " (" +
         I.formatDay(win.startMs) + " to " + I.formatDay(win.endMs) +
         "), so there is nothing to plot for this range."));
       return;
@@ -3389,8 +3483,12 @@ footer a:hover { color: var(--txt); }
     var created = [];
     try {
       for (var i = 0; i < bound.cards.length; i++) {
-        created.push(buildChart(stack, bound.cards[i].spec, axis,
-          bound.cards[i].offsets, data.downsampled));
+        var card = bound.cards[i];
+        if (axis.measured[card.offsets.count] === 0) {
+          buildEmptyCard(stack, card.spec, axis, card.offsets);
+          continue;
+        }
+        created.push(buildChart(stack, card.spec, axis, card.offsets, data.downsampled));
       }
       /* Both charts sit in one cursor-sync group, and uPlot propagates the drag
        * selection through it, so a zoom on either moves both — and moves the

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -35,7 +35,8 @@
 ## Repository metrics archive
 
 - What it is: a public, daily archive of this repository's GitHub traffic and growth. GitHub discards repository traffic data after 14 days; a scheduled job records it once a day into a public git branch, so the history is retained indefinitely.
-- Series recorded: daily page views and unique visitors, daily clones and unique cloners, cumulative stars, forks and contributors, watchers, open issues, release asset downloads, and trailing-14-day referring sites and popular paths.
+- Series recorded: daily page views and unique visitors, daily clones and unique cloners, cumulative stars, forks and contributors, watchers, open issues, release asset downloads, this repository's own daily workflow-run count, and trailing-14-day referring sites and popular paths.
+- Clone counts include this repository's own CI: GitHub counts every `actions/checkout` in the clone statistics, so on a heavy build day the clone figure measures the build pipeline more than it measures people. The workflow-run series is published alongside it for exactly that reason. The two are never combined into a corrected figure.
 - Provenance: every figure is measured through the GitHub REST API. Nothing is estimated, modelled, or interpolated.
 - Absent versus zero: a value that was never measured is recorded as absent and rendered as a gap, never as a zero. A measured zero is recorded and rendered as zero. The two are never conflated, so a gap in a chart means "not measured" and not "fell to nothing".
 - Release downloads are reported split: installers and archives separately from update-check traffic, because GitHub counts an electron-updater feed file the same as an installer and every installed client fetches that feed on every update check.


### PR DESCRIPTION
## Why

GitHub counts every `actions/checkout` a repository runs in its **traffic clone statistics**. On this repo that dominates the series:

| date | clones | per cloner | workflow runs |
|---|---:|---:|---:|
| 08-23 | 17 | 1.9 | **0** |
| 08-25 | **155** | **4.6** | **76** |
| 08-26 | 10 | 1.1 | **0** |
| 08-30 | 30 | 1.7 | **0** |
| 09-01 | **189** | **5.1** | **73** |

Published as plain reach with nothing qualifying it, this was the one figure on the page that reliably read as more adoption than it was.

**Page views are unaffected** — a checkout loads no page. 08-23 (108 views) and 08-27 (156 views) are high-traffic days with zero CI runs, so traffic-based conclusions still stand.

## What changed

**The confound is disclosed wherever the clone figure appears**: the at-a-glance card, the Reach section copy, the static data page's clone table, and the `BUILD:SUMMARY` sentence naming the peak clone day. That last one matters most — it is baked into the shared page's HTML and is the figure a fetcher quotes, so the caveat travels inside the same sentence.

**A new `workflows.csv` series** (`date,runs`) is collected daily, backfillable, bundled into `data.json`, and plotted as a third chart under clones on the Reach section's shared axis — so the overlap is visible at the spike rather than described in prose.

## What this deliberately does not do

**No "clones minus estimated CI" figure, anywhere.** The relationship is not a stable coefficient: 218 successful checkout steps accompanied 155 clones on 08-25, and 180 accompanied 189 on 09-01 — the ratio inverts. Only co-occurrence is established. A corrected number would be a model on a page whose entire claim is that every figure was measured.

The two series are **stacked, not overlaid**, for the same reason: an overlay invites reading a ratio off two lines that do not support one.

## Two properties that keep the series honest

**Counted over a trailing 14-day window, not for `today` alone.** The collector runs mid-morning UTC, so the current day's count is always partial. Counting only today would freeze every day at whatever fraction had happened by ~10:00 — a uniform understatement nothing downstream could detect. `'overwrite'` merging lets the next run complete it, exactly as the traffic series already works.

**Backfill stops at the oldest surviving run.** GitHub deletes runs at the retention horizon, so reconstructing past it would write confident zeros for days whose evidence is gone — indistinguishable ever after from genuinely quiet days. Inside the surviving span the zeros are sound, because retention deletes uniformly by age.

## Measured zero vs. not measured

A day inside the collected window with no runs is a **measured zero** and plots at zero. That differs from the traffic series, where GitHub omits a zero-traffic day and absence really does mean unmeasured. §4.3 forbids inventing a zero for an unmeasured day; it equally forbids hiding a measured one behind a gap that would read as collector downtime. The two series must never share a fill rule.

## Also in here

- **`paginateEnvelope`** on the GitHub client, for endpoints returning a list inside an object. `/actions/runs` answers `{total_count, workflow_runs}` and `paginate` correctly refuses it. The page walk, its cycle detection and its origin assertion are extracted and shared rather than copied.
- **`countByDay` / `utcDayStart` moved to `series.ts`.** The collector and the backfill both fill dense day ranges and had no business carrying two copies of that round-trip date validation.
- **An empty chart now renders a sentence, not a plot.** uPlot draws a series with no measured step as a frame on an invented 0..1 axis — it looks like a failure while its own caption reads "measured 0 of 15 days". That is the state of *any* newly added series on the deploy that introduces it, including this one.
- **Dropped `as DashboardData` from datapage's test builder.** The cast was hiding a fixture that violated the type, and it is why the missing series passed typecheck and failed at runtime.
- **Restored the schema table's caveat block** in `docs/systems/metrics.md` — three rows pointed at it and it was not there.

## Action required after merge

`METRICS_TOKEN` needs **Actions: read** added, or the runs fetch 403s and the series skips. The run still succeeds and every other series is written; the CI chart renders its "no measurement" note until the permission is granted. Nothing needs re-creating and no history is lost — but **the earliest backfill dispatch reaches furthest back**, since days past the retention horizon are gone permanently.

## Verification

- 338 tests across 12 files (from 307), `tsc --noEmit` clean
- Collector run against the live API produced 7 / 76 / 17 / 73 / 121 runs, matching independent `gh api` counts exactly, with explicit zeros on quiet days
- 44/44 responsive assertions at 1440/1280/768/390, no horizontal overflow
- Both the populated and the no-data states rendered and screenshotted