### PR TITLE
fix(insights): draw each Reach chart on its own span

### DIFF
--- a/docs/systems/metrics.md
+++ b/docs/systems/metrics.md
@@ -124,7 +124,7 @@ All files live at the root of the `metrics-data` branch. CSVs are sorted ascendi
 
 #### Caveats on the table above
 
-**Clones count this repository's own CI.** GitHub counts every `actions/checkout` in the clone statistics, so `traffic/clones.csv` measures the build pipeline and the audience together, with no field distinguishing them. Measured on this repo: days with no workflow runs sit at 2-30 clones, while 2026-08-25 and 2026-09-01 recorded 155 and 189 clones against 218 and 180 successful checkout steps. Clones far above one per unique cloner is the signature. The ratio is not a constant and this archive does not model it: neither the run count nor the checkout-step count predicts the clone figure closely (218 checkout steps produced 155 clones, 180 produced 189), so only the co-occurrence is established, not a coefficient. That is exactly why nothing here publishes a "clones minus CI" figure: that would be a model, and the premise of this archive is that every number on it is a measurement. Page views are unaffected, because a checkout loads no page. The confound is disclosed on the clones card, in the Reach section copy, in the static data page's clones blurb, and in the `BUILD:SUMMARY` sentence that states the peak clone day. It is also *shown*: `workflows.csv` records this repository's own daily workflow-run count, and the dashboard plots it as a third chart on the Reach section's shared axis, directly under clones. The two series are never combined into one corrected figure — see §4.5.
+**Clones count this repository's own CI.** GitHub counts every `actions/checkout` in the clone statistics, so `traffic/clones.csv` measures the build pipeline and the audience together, with no field distinguishing them. Measured on this repo: days with no workflow runs sit at 2-30 clones, while 2026-08-25 and 2026-09-01 recorded 155 and 189 clones against 218 and 180 successful checkout steps. Clones far above one per unique cloner is the signature. The ratio is not a constant and this archive does not model it: neither the run count nor the checkout-step count predicts the clone figure closely (218 checkout steps produced 155 clones, 180 produced 189), so only the co-occurrence is established, not a coefficient. That is exactly why nothing here publishes a "clones minus CI" figure: that would be a model, and the premise of this archive is that every number on it is a measurement. Page views are unaffected, because a checkout loads no page. The confound is disclosed on the clones card, in the Reach section copy, in the static data page's clones blurb, and in the `BUILD:SUMMARY` sentence that states the peak clone day. It is also *shown*: `workflows.csv` records this repository's own daily workflow-run count, and the dashboard plots it as a third chart in the Reach section, directly under clones and joined to it by the shared cursor rather than by a shared x axis — see §10.7. The two series are never combined into one corrected figure — see §4.5.
 
 **`stars.csv` and `forks.csv` are point-in-time snapshots, not deltas.** Each row is the live counter as read that day, so it correctly reflects someone who starred and later unstarred. A row written by `backfill()` instead reconstructs the value from `/stargazers`' `starred_at`, which lists only *current* stargazers, making a reconstructed row a **lower bound**. Nothing on disk distinguishes the two writers. See §4.2.
 
@@ -251,7 +251,7 @@ The traffic window is 14 buckets wide, so any gap of **≤13 full days** without
 
 **Backfill stops at the oldest surviving run.** GitHub deletes workflow runs once they pass the repository's retention period (90 days by default). Reconstructing a day older than the oldest run still returned would write a confident `0` for a day whose evidence has been destroyed — a fabricated measurement, indistinguishable ever after from a genuinely quiet day. Inside the surviving span the zeros are sound, because retention deletes uniformly by age: if the oldest surviving run is still present, no later day has lost runs. Below that date the reconstruction writes nothing, leaving a gap, which is the truthful encoding.
 
-**The two series are never combined.** No "clones minus estimated CI" figure is published anywhere. The relationship is not a stable coefficient — measured on this repository, 218 successful checkout steps accompanied 155 clones on one day and 180 accompanied 189 on another — so a corrected number would be a model, on a page whose entire claim is that every figure was measured. Both series are plotted on a shared axis, as separate stacked charts rather than one dual-axis chart, precisely so the co-occurrence is visible without inviting a ratio to be read off them.
+**The two series are never combined.** No "clones minus estimated CI" figure is published anywhere. The relationship is not a stable coefficient — measured on this repository, 218 successful checkout steps accompanied 155 clones on one day and 180 accompanied 189 on another — so a corrected number would be a model, on a page whose entire claim is that every figure was measured. Both series are plotted as separate stacked charts rather than one dual-axis chart, precisely so the co-occurrence is visible without inviting a ratio to be read off them. They are joined by the page's shared cursor, not by a shared x axis; §10.7 says why.
 ---
 
 ## 5. The 202 problem
@@ -441,7 +441,7 @@ The bundler reads the nine archive files described in §3 and emits one JSON obj
 
 - **`meta.json`'s `series_last_date` is not published.** It is a per-file resume cursor — collector internals. Shipping it would hand a static page a map of the collector's file layout and invite the page to start depending on it. `DashboardMeta` carries `last_run`, `last_success` and `error`, and nothing else.
 - **Most of the dimensional history is discarded.** The archive holds every row of every snapshot; the bundle keeps only the *latest* snapshot's ranking plus a differenced trajectory for its top five dimensions, per file. Everything else in `referrers.ndjson`/`paths.ndjson` exists only on the `metrics-data` branch.
-- **Daily resolution of the six dated series, but only under pressure.** They are published day-by-day until the bundle would exceed its size budget, at which point every one of them is reduced to weekly buckets (§10.3). `releases` and `dimensions` are never bucketed.
+- **Daily resolution of the seven dated series, but only under pressure.** They are published day-by-day until the bundle would exceed its size budget, at which point every one of them is reduced to weekly buckets (§10.3). `releases` and `dimensions` are never bucketed.
 
 `bundle.ts` also declares its own types rather than reusing `types.ts`. `types.ts` describes what the collector writes; `bundle.ts` describes what the page reads. They coincide today — a `ReleaseEntry` and a `ReleaseRow` are the same three fields — but they are two contracts with two consumers, and the page must not silently acquire a field because a collector type grew one.
 
@@ -453,7 +453,7 @@ The bundler reads the nine archive files described in §3 and emits one JSON obj
 interface DashboardData {
   /** ISO timestamp (with milliseconds) the bundle was generated. */
   generated_at: string;
-  /** Earliest date present in ANY of the six dated series, or null. */
+  /** Earliest date present in ANY of the seven dated series, or null. */
   collection_started: string | null;
   /** From meta.json, or null when the archive has none. */
   meta: { last_run: string; last_success: string | null; error: string | null } | null;
@@ -512,7 +512,7 @@ Neither is checked, and that is a decision rather than an oversight: rejecting a
 
 **`downsampleWeekly`, `rangeWindow` and `snapshotWindow` are one mechanism in three parts. Do not "fix" any of them in isolation.**
 
-- `downsampleWeekly` buckets the six dated series onto their UTC Monday and leaves `dimensions` **unbucketed**, on their own daily snapshot dates. Bucketing them would silently redefine "the difference between consecutive snapshots" into something else with the same name.
+- `downsampleWeekly` buckets the seven dated series onto their UTC Monday and leaves `dimensions` **unbucketed**, on their own daily snapshot dates. Bucketing them would silently redefine "the difference between consecutive snapshots" into something else with the same name.
 - `rangeWindow` anchors every window on the newest **dated series** row, deliberately excluding dimension snapshots, so a trailing 14-day aggregate cannot stretch a window past the last real daily measurement.
 - Those two are compatible on a daily bundle, where the two dates coincide. On a **downsampled** bundle they are not: series dates become Monday bucket keys while snapshots keep their daily dates, so the newest series day can sit up to six days *before* the newest snapshot. In the fixture that found this, every snapshot in the trailing partial week fell outside every window, `all` included — both dimension sections drew nothing, reported "N of the M the archive holds", and offered "a wider range takes in more", which no range did.
 - `snapshotWindow` exists to close exactly that gap. It extends only the **end** of the shared window, and only as far as a snapshot that actually exists; the start is left where the range control put it, and `extendedFrom` is set so the section states that the axis runs past the range's anchor rather than quietly drawing a wider span than the control implies.
@@ -604,7 +604,7 @@ There is a third, per-chart case worth stating because it is the normal state of
 | `empty` | the bundle loaded and validated, and `empty` is `true` | "Collection has not produced any rows yet" — the archive holds no traffic, no growth snapshots, no releases; figures appear after the collector's first successful run |
 | `ok` | loaded, validated, non-empty | the five sections render |
 
-`empty` is true when all six dated series, `releases`, and both dimension snapshot lists are empty — the state an archive is in immediately after the branch is bootstrapped, when it holds only `meta.json`. Note that `empty` and `collection_started` answer different questions: an archive holding only releases or only dimension snapshots is **not** empty yet has no dated series, so `collection_started` is `null` and the range control has nothing to anchor on.
+`empty` is true when all seven dated series, `releases`, and both dimension snapshot lists are empty — the state an archive is in immediately after the branch is bootstrapped, when it holds only `meta.json`. Note that `empty` and `collection_started` answer different questions: an archive holding only releases or only dimension snapshots is **not** empty yet has no dated series, so `collection_started` is `null` and the range control has nothing to anchor on.
 
 The **staleness banner** is separate from all three and is evaluated on any bundle that loaded, empty or not. It fails closed — anything it cannot confirm counts as stale, and the reason says which:
 
@@ -617,11 +617,32 @@ Whenever the banner fires it also reports `last_success`, because when the colle
 
 **One thing the bundle carries no evidence of.** A persistent `202` from `/stats/contributors` (§5) makes the collector skip `contributors.csv` for that run without recording an error anywhere. The contributors card and its coverage line therefore **understate** — never overstate — and nothing in `data.json` distinguishes "the count did not move" from "the count was not measured that day". The card's `step` kind exists partly for this: a contributors row is written when the total *changes*, so the age of its newest row says nothing about freshness and the daily-sample staleness test is deliberately not applied to it.
 
+### 10.7 Each chart is drawn on its own span, not on the section's
+
+**The rule: a chart's x axis spans the days *that chart* was measured on. Two charts share an axis only when they share a history.**
+
+`expand` in the chart toolkit lays a set of columns onto one evenly stepped axis running from the earliest to the latest day any of those columns holds. Handing it every card in a section gives them one axis, which is right for cards that started collecting together — Growth's stars and forks do, and they additionally *need* one axis, because one set of release markers is painted across both.
+
+Reach is the case where it is wrong. Its traffic series begin on the day the collector first ran; `workflows` is reconstructed from the Actions API and reaches back as far as that API still retains — 47 days further, when the CI chart shipped. Expanded together, all three cards got the CI series' span, and both traffic charts were drawn with their entire history crushed into the right-hand quarter of an otherwise blank frame. Every caption was accurate ("measured 15 of 62 days · unmeasured 47 days") and both charts still read as broken. So Reach calls `isolate(bound, card)` per card and expands each on its own columns.
+
+**What that gives up, and what it does not.** Peaks can no longer be compared across cards by their horizontal position — two charts on different spans put the same day at different pixels. Everything else survives, because the comparison never depended on the axis:
+
+- The cursor group syncs on scale **values**, not pixels, so hovering 08-25 anywhere lands on 08-25 in every chart whose span covers it. A chart that does not cover that day shows a dash rather than a value, which is the honest answer.
+- Drag-zoom propagates as a value range too, so dragging across any chart puts them all on that span.
+- Double-click returns **each** chart to its own span, not to a shared one.
+
+Each card's caption states the span it drew, and the CI card's note says outright that its span reaches further back than the two above it and why.
+
+**Two traps this creates for a later series.**
+
+1. `SERIES_NAMES` in the page's range control is the list of dated series allowed to move the window. A series left out of it can hold a row outside every other series' history, and that row is measured, bundled, and then silently clipped out of every range including `all`. `workflows` was added to that list for exactly this reason; add any new dated series to it in the same commit.
+2. `validateBundle` must gain a `checkSeries` line for any new series. Without one the bundle validates, and the failure surfaces later and further away — as a section-wide error note, or a throw inside the range control that is outside any section's error boundary. `series.workflows` was missing from it until this rule was written down.
+
 ---
 
 ## 11. Testing
 
-`scripts/metrics`'s `test` script is `tsc --noEmit && vitest run` — it runs through the existing root `pnpm -r test` step with no `ci.yml` change required, and covers both types and behavior in one script. All tests are fixture-driven and touch no network; filesystem tests use a per-test `mkdtempSync` directory, cleaned up in `afterEach`. As of this writing there are **338 tests across 12 files**, all passing:
+`scripts/metrics`'s `test` script is `tsc --noEmit && vitest run` — it runs through the existing root `pnpm -r test` step with no `ci.yml` change required, and covers both types and behavior in one script. All tests are fixture-driven and touch no network; filesystem tests use a per-test `mkdtempSync` directory, cleaned up in `afterEach`. As of this writing there are **340 tests across 12 files**, all passing:
 
 ```
 src/no-runtime-deps.test.ts   9
@@ -632,7 +653,7 @@ src/github.test.ts           21
 src/backfill.test.ts         22
 src/store.test.ts            23
 src/summary.test.ts          26
-src/collect.test.ts          33
+src/collect.test.ts          35
 src/cli-support.test.ts      35
 src/series.test.ts           55
 src/bundle.test.ts           89

--- a/scripts/metrics/src/bundle.test.ts
+++ b/scripts/metrics/src/bundle.test.ts
@@ -911,7 +911,7 @@ describe('downsampleWeekly — sum vs. last', () => {
   });
 
   it('sums clones and takes the last value of forks and contributors', () => {
-    // Each of the six series is bucketed by its own rule; this pins the
+    // Each of the seven series is bucketed by its own rule; this pins the
     // three not covered above so a mis-wired call site cannot hide behind a
     // series that happens to be tested elsewhere.
     writeRaw(

--- a/scripts/metrics/src/bundle.ts
+++ b/scripts/metrics/src/bundle.ts
@@ -437,7 +437,7 @@ function readDimensionSeries(store: Store, file: string): DimensionSeries {
 }
 
 /**
- * Earliest date across the six dated series, or null when none of them holds
+ * Earliest date across the seven dated series, or null when none of them holds
  * a row.
  *
  * Computed from the data rather than hardcoded or taken from `meta.json`, so
@@ -796,7 +796,7 @@ function copyDimensionSeries(series: DimensionSeries): DimensionSeries {
 }
 
 /**
- * Reduces the six dated series to weekly buckets, keyed on the UTC Monday.
+ * Reduces the seven dated series to weekly buckets, keyed on the UTC Monday.
  *
  * Pure, exactly as `buildDashboardData` is: no clock, no environment, no
  * writes, and no mutation of the argument — the caller keeps a usable daily

--- a/scripts/metrics/src/types.ts
+++ b/scripts/metrics/src/types.ts
@@ -19,9 +19,13 @@ export interface CountPoint {
  * it started on that UTC date.
  *
  * It exists to sit beside `traffic/clones.csv`, which GitHub inflates with
- * every `actions/checkout` this repository runs. The two are plotted on a
- * shared axis so a clone spike that is really a build spike is visible as
- * such, rather than described in prose the reader has to take on trust.
+ * every `actions/checkout` this repository runs. The two are plotted as
+ * stacked charts under one synced cursor so a clone spike that is really a
+ * build spike is visible as such, rather than described in prose the reader
+ * has to take on trust. They do NOT share an x axis: this series is
+ * reconstructed back to whatever the Actions API still retains, where traffic
+ * begins on the day the collector first ran, so each chart is drawn across
+ * its own measured days and the cursor carries the comparison.
  *
  * Unlike traffic, a day with no runs is a MEASURED ZERO, not an absence: the
  * Actions API is asked for a whole window and answers completely, where the

--- a/site/insights/index.html
+++ b/site/insights/index.html
@@ -612,11 +612,15 @@ footer a:hover { color: var(--txt); }
         measures this project's build pipeline rather than its audience and can sit an order
         of magnitude above the days on either side. Clones running well above one per unique
         cloner is the signature. Page views are unaffected, because a checkout loads no page.
-        The CI chart below the clone chart is this repository's own workflow-run count on the
-        same axis, so the overlap can be read directly rather than taken on trust. The two are
-        plotted separately and never combined: no fixed number of clones follows from a run,
-        and subtracting an estimate would put a model on a page whose whole claim is that
-        every figure on it was measured.
+        The CI chart below the clone chart is this repository's own workflow-run count, so the
+        overlap can be read directly rather than taken on trust. Its history reaches further
+        back than traffic collection does, because the Actions API can be asked about the past
+        and the traffic endpoints cannot, so each chart is drawn across its own measured days
+        rather than stretched over its neighbour's; hovering lands on the same day in every
+        chart whose span covers it, and dragging sideways across one puts them all on the same
+        span. The two are plotted separately and never combined: no fixed number of clones
+        follows from a run, and subtracting an estimate would put a model on a page whose
+        whole claim is that every figure on it was measured.
       </p>
       <div class="slot" id="chart-reach"></div>
     </div>
@@ -996,6 +1000,7 @@ footer a:hover { color: var(--txt); }
       checkSeries(d.series.contributors, "series.contributors", ["total"]) ||
       checkSeries(d.series.repo, "series.repo",
         ["subscribers", "open_issues", "downloads_total", "downloads_app", "downloads_updates"]) ||
+      checkSeries(d.series.workflows, "series.workflows", ["runs"]) ||
       checkReleases(d.releases);
     if (problem !== null) return problem;
 
@@ -1238,7 +1243,13 @@ footer a:hover { color: var(--txt); }
 
   /* ---------------------------------------------------------- range control */
 
-  var SERIES_NAMES = ["views", "clones", "stars", "forks", "contributors", "repo"];
+  /* Every dated series in the bundle contract. A series left out of this list
+   * cannot move the window, so a row it holds outside every other series'
+   * history would be measured, bundled, and then silently clipped out of the
+   * chart. `workflows` is the live case: it is reconstructed from the Actions
+   * API and reaches back to whatever the API still retains, which is under no
+   * obligation to start on the same day the star history does. */
+  var SERIES_NAMES = ["views", "clones", "workflows", "stars", "forks", "contributors", "repo"];
 
   function rangeDefinition(key) {
     for (var i = 0; i < RANGES.length; i++) {
@@ -2401,8 +2412,9 @@ footer a:hover { color: var(--txt); }
     }
     placeHint(node);
     node.textContent = livePlots > 1
-      ? "Hovering any chart moves the cursor on every chart on this page. Drag sideways across " +
-        "any of them to zoom the shared time axis; double-click to return to the full span."
+      ? "Hovering any chart moves the cursor to that day on every chart on this page whose " +
+        "span covers it. Drag sideways across any of them to put them all on that span; " +
+        "double-click to return every chart to its own."
       : "Drag sideways across the chart to zoom its time axis; double-click to return to the " +
         "full span.";
   }
@@ -2612,11 +2624,55 @@ footer a:hover { color: var(--txt); }
   }
 
   /*
+   * The columns ONE card reads, rebased onto an array of their own, so a
+   * section can give that card an axis fitted to its own history instead of
+   * to its neighbours'.
+   *
+   * `expand` spans the UNION of the columns it is handed, which is right when
+   * the cards cover the same days and wrong the moment one of them reaches
+   * further back. The CI series is exactly that case: it is reconstructed
+   * from the Actions API back to the first release, where traffic exists only
+   * from the day the collector first ran. Expanded together, the two traffic
+   * charts were drawn across 47 days they were never measured on and their
+   * whole history was squeezed into the right quarter of the frame — an
+   * accurate chart that reads as a broken one.
+   *
+   * What the shared axis existed for survives without it. The cursor group
+   * syncs on scale VALUES rather than pixels, so hovering 08-25 on the clone
+   * chart still lands on 08-25 in the CI chart however differently the two
+   * are scaled, and a drag-zoom still puts every chart on one span. What is
+   * given up is only the eyeball comparison of two peaks by their horizontal
+   * position, and each card's caption states the span it drew.
+   *
+   * Offsets are rebased in ascending order of their ORIGINAL offset rather
+   * than in enumeration order, so the rebased array holds the card's columns
+   * in the order `bind` pushed them however a host enumerates keys.
+   */
+  function isolate(bound, card) {
+    var names = [];
+    var name;
+    for (name in card.offsets) {
+      if (!Object.prototype.hasOwnProperty.call(card.offsets, name)) continue;
+      names.push(name);
+    }
+    names.sort(function (a, b) { return card.offsets[a] - card.offsets[b]; });
+
+    var columns = [];
+    var offsets = {};
+    for (var i = 0; i < names.length; i++) {
+      offsets[names[i]] = columns.length;
+      columns.push(bound.columns[card.offsets[names[i]]]);
+    }
+    return { columns: columns, offsets: offsets };
+  }
+
+  /*
    * Re-lay a set of columns onto a complete, evenly stepped time axis.
    *
    * `columns` is `[{ series, field }, ...]`; every column is placed on ONE
    * shared axis, so charts built from the same call line up exactly and the
-   * synced cursor points at the same day on all of them.
+   * synced cursor points at the same day on all of them. That is the right
+   * grouping only for cards whose histories start together; see `isolate`.
    *
    * Three decisions worth stating, because each of them is a way to get this
    * wrong that produces a plausible-looking chart:
@@ -3139,6 +3195,7 @@ footer a:hover { color: var(--txt); }
     bind: bind,
     colour: colour,
     expand: expand,
+    isolate: isolate,
     mount: mount,
     zeroBasedCounts: zeroBasedCounts
   };
@@ -3213,16 +3270,22 @@ footer a:hover { color: var(--txt); }
       uniques: { label: "Unique cloners", token: "--amber", fallback: "#fcd34d" }
     },
     /*
-     * Directly below the clone chart, sharing its x axis and its cursor,
-     * because it is the explanation for most of that chart's shape: GitHub
-     * counts every `actions/checkout` this repository runs as a clone.
+     * Directly below the clone chart, sharing its cursor, because it is the
+     * explanation for most of that chart's shape: GitHub counts every
+     * `actions/checkout` this repository runs as a clone.
      *
      * Deliberately a SEPARATE chart rather than a second line on the clone
      * chart. An overlay invites reading a ratio off the two lines, and no
      * stable ratio exists — measured here, 218 checkout steps produced 155
-     * clones on one day and 180 produced 189 on another. Stacked charts on a
-     * shared axis show the co-occurrence, which is what the archive can
-     * actually support, and claim nothing about the coefficient.
+     * clones on one day and 180 produced 189 on another. Stacked charts show
+     * the co-occurrence, which is what the archive can actually support, and
+     * claim nothing about the coefficient.
+     *
+     * It does NOT share the clone chart's x axis. This series is reconstructed
+     * from the Actions API and reaches back to the first release, where
+     * traffic begins on the day the collector first ran, so one axis for both
+     * would flatten the traffic charts against their right-hand edge. The
+     * cursor group carries the comparison instead; see `isolate`.
      *
      * One series, no `uniques`: a workflow run has no unique-visitor reading.
      */
@@ -3235,7 +3298,12 @@ footer a:hover { color: var(--txt); }
         "charts above. The Actions API is asked for a date range and answers it completely, " +
         "so a day with no runs is a measurement; the traffic endpoints omit a day they " +
         "recorded nothing for, so an absent day there is genuinely unmeasured. A break in " +
-        "this line means the collector did not run, or ran before this series existed.",
+        "this line means the collector did not run, or ran before this series existed. " +
+        "That same difference is why this chart's span reaches further back than the two " +
+        "above: each chart is drawn across its own measured days, so peaks cannot be " +
+        "compared by their position across charts. Hovering lands on the same day in every " +
+        "chart whose span covers it, and dragging sideways across one puts them all on the " +
+        "same span.",
       count: {
         label: "Workflow runs",
         token: "--rose", fallback: "#fda4af",
@@ -3303,13 +3371,25 @@ footer a:hover { color: var(--txt); }
    * as what the page does with it, because a break in a line is the one thing
    * on this page a reader is most likely to read as a fall to zero.
    */
-  function metaLine(axis, offsets, spec) {
+  function metaLine(axis, offsets, spec, win) {
     var stepDays = axis.stepDays;
     var total = axis.xs.length;
-    var counted = axis.measured[offsets.count];
-    var missing = total - counted;
 
     var note = el("p", "chart-meta");
+
+    /* A card with no measured row has no span of its own to state: `expand`
+     * found no first or last day for it, and printing the window as one would
+     * claim an axis this card never drew. The window is the only true thing
+     * left to say, so it is said under its own name. */
+    if (total === 0) {
+      note.appendChild(pair("window",
+        I.formatDay(win.startMs) + " → " + I.formatDay(win.endMs)));
+      note.appendChild(pair("measured", "nothing in this window"));
+      return note;
+    }
+
+    var counted = axis.measured[offsets.count];
+    var missing = total - counted;
     note.appendChild(pair("span", I.formatDay(axis.startMs) + " → " + I.formatDay(axis.endMs)));
     note.appendChild(pair("measured", counted + " of " + steps(total, stepDays)));
     if (missing > 0) {
@@ -3345,10 +3425,10 @@ footer a:hover { color: var(--txt); }
    * only after the next collection run, so every new series is empty on the
    * deploy that introduces it.
    */
-  function buildEmptyCard(stack, spec, axis, offsets) {
+  function buildEmptyCard(stack, spec, axis, offsets, win) {
     var card = el("div", "chart-card");
     card.appendChild(el("p", "chart-title", spec.title));
-    card.appendChild(metaLine(axis, offsets, spec));
+    card.appendChild(metaLine(axis, offsets, spec, win));
     card.appendChild(el("p", "slot-note",
       "No measurement of " + spec.count.label.toLowerCase() + " falls inside this window, so " +
       "there is no line to draw. An empty frame would look like a failure rather than an " +
@@ -3357,10 +3437,10 @@ footer a:hover { color: var(--txt); }
     stack.appendChild(card);
   }
 
-  function buildChart(stack, spec, axis, offsets, downsampled) {
+  function buildChart(stack, spec, axis, offsets, downsampled, win) {
     var card = el("div", "chart-card");
     card.appendChild(el("p", "chart-title", spec.title));
-    card.appendChild(metaLine(axis, offsets, spec));
+    card.appendChild(metaLine(axis, offsets, spec, win));
 
     var host = el("div", "chart-scroll");
     card.appendChild(host);
@@ -3412,9 +3492,10 @@ footer a:hover { color: var(--txt); }
    * code" — and send whoever reads it to the wrong repository entirely. So the
    * reader is told what the console is told: a date in the archive is wrong.
    */
-  function overrunNote(axis) {
-    var detail = "The traffic series would run from " + I.formatDay(axis.startMs) + " to " +
-      I.formatDay(axis.endMs) + ", which needs " + I.formatCount(axis.overrunSteps) +
+  function overrunNote(spec, axis) {
+    var detail = "The " + spec.title + " chart's series would run from " +
+      I.formatDay(axis.startMs) + " to " + I.formatDay(axis.endMs) + ", which needs " +
+      I.formatCount(axis.overrunSteps) +
       " points on the time axis — far longer than this archive can really cover. A date in " +
       "the archive itself is wrong. No chart is drawn, rather than one built around a date " +
       "that cannot be true.";
@@ -3454,22 +3535,51 @@ footer a:hover { color: var(--txt); }
     slot.appendChild(windowLine(win));
 
     var stepDays = I.resolutionStepDays();
-    /* One expansion for both charts, so both get the identical x axis and the
-     * synced cursor lands on the same day in each. The columns come from the
-     * cards that read them rather than from a literal of their own, so a card
-     * cannot be drawn from a column it does not name; see `bind`. */
+    /* ONE EXPANSION PER CARD, each axis spanning only the days that card was
+     * measured on.
+     *
+     * Expanding all three together gave them one axis, which was right while
+     * every card here was a traffic series collected from the same first day.
+     * It stopped being right when the CI series joined them: its history is
+     * reconstructed from the Actions API back to the first release, so the
+     * union reached 47 days further back than traffic does and both traffic
+     * charts were drawn with their entire history crushed into the right-hand
+     * quarter of an otherwise empty frame. The captions said so truthfully and
+     * the charts still looked broken.
+     *
+     * The comparison the shared axis was for is not lost with it: the cursor
+     * group syncs on scale values, so a hover still lands on the same day in
+     * every chart, and a drag-zoom still puts them all on one span. See
+     * `isolate`.
+     *
+     * The columns come from the cards that read them rather than from a
+     * literal of their own, so a card cannot be drawn from a column it does
+     * not name; see `bind`, which validates every card up front so a bundle
+     * missing a series fails the section rather than half-drawing it. */
     var bound = C.bind("chart-reach", data, CHARTS);
-    var axis = C.expand(bound.columns, win, stepDays);
 
-    /* Before the `empty` branch: an overrun sets `empty` too, as a fail-safe
-     * for a caller that forgets this check, and the specific reason is the
-     * more useful of the two. */
-    if (axis.overrun) {
-      slot.appendChild(overrunNote(axis));
-      return;
+    var i;
+    var drawable = [];
+    var plottable = 0;
+    for (i = 0; i < bound.cards.length; i++) {
+      var own = C.isolate(bound, bound.cards[i]);
+      var axis = C.expand(own.columns, win, stepDays);
+
+      /* Before the `empty` branch: an overrun sets `empty` too, as a fail-safe
+       * for a caller that forgets this check, and the specific reason is the
+       * more useful of the two. An impossible date is a fault in the archive
+       * rather than in one card, so it stops the section: publishing the two
+       * charts either side of it would present a section quietly missing a
+       * chart it says it draws. */
+      if (axis.overrun) {
+        slot.appendChild(overrunNote(bound.cards[i].spec, axis));
+        return;
+      }
+      if (!axis.empty) plottable++;
+      drawable.push({ spec: bound.cards[i].spec, axis: axis, offsets: own.offsets });
     }
 
-    if (axis.empty) {
+    if (plottable === 0) {
       slot.appendChild(el("p", "slot-note",
         "No traffic or CI series carries a row inside " + win.title.toLowerCase() + " (" +
         I.formatDay(win.startMs) + " to " + I.formatDay(win.endMs) +
@@ -3482,20 +3592,25 @@ footer a:hover { color: var(--txt); }
 
     var created = [];
     try {
-      for (var i = 0; i < bound.cards.length; i++) {
-        var card = bound.cards[i];
-        if (axis.measured[card.offsets.count] === 0) {
-          buildEmptyCard(stack, card.spec, axis, card.offsets);
+      for (i = 0; i < drawable.length; i++) {
+        var card = drawable[i];
+        /* `empty` first: an empty axis carries no `measured` entries at all,
+         * so the count lookup below is `undefined` rather than `0` for it. */
+        if (card.axis.empty || card.axis.measured[card.offsets.count] === 0) {
+          buildEmptyCard(stack, card.spec, card.axis, card.offsets, win);
           continue;
         }
-        created.push(buildChart(stack, card.spec, axis, card.offsets, data.downsampled));
+        created.push(buildChart(stack, card.spec, card.axis, card.offsets,
+          data.downsampled, win));
       }
-      /* Both charts sit in one cursor-sync group, and uPlot propagates the drag
-       * selection through it, so a zoom on either moves both — and moves the
-       * growth charts too, which join the same group. The sentence saying so is
-       * the toolkit's, not this section's: written here it disappeared whenever
-       * this section declined to draw, however many other charts were on the
-       * page. */
+      /* Every chart here sits in one cursor-sync group, and uPlot propagates
+       * the drag selection through it, so a zoom on any of them moves them all
+       * — and moves the growth charts too, which join the same group. That
+       * group, not a shared axis, is what keeps these charts readable against
+       * each other now that each is drawn on its own span. The sentence saying
+       * so is the toolkit's, not this section's: written here it disappeared
+       * whenever this section declined to draw, however many other charts were
+       * on the page. */
     } catch (error) {
       /* `live` is assigned only once every chart is built, so a throw part-way
        * leaves `created` referenced by nothing but this frame: the shell's


### PR DESCRIPTION
The Reach section expanded all three cards onto one time axis. `expand` spans the **union** of the columns it is handed, which was right while the section held only traffic series that began on the same day.

The CI series is reconstructed from the Actions API back to the first release — 47 days before traffic collection started — so that union became every card's axis, and both traffic charts were drawn across days they were never measured on, with their entire history crushed into the right quarter of an otherwise blank frame. The captions read `measured 15 of 62 days · unmeasured 47 days` and were accurate. The charts still looked broken.

## The fix

Reach now expands **per card**, through a new `isolate` helper in the chart toolkit that rebases one card's columns onto an array of their own. Growth keeps its shared axis: stars and forks begin together, and one set of release markers is painted across both.

| | before | after |
|---|---|---|
| Page views | span 07-03 → 09-02 · 15 of 62 days | span 08-18 → 09-01 · **15 of 15** |
| Repository clones | span 07-03 → 09-02 · 15 of 62 days | span 08-18 → 09-01 · **15 of 15** |
| CI activity | 62 of 62 | 62 of 62 (unchanged) |

Plot fill goes from roughly a quarter of the frame to **0.94–0.97 of frame width** at 1440, 1280, 768 and 390.

## What is given up, and what is not

Peaks can no longer be compared across cards by horizontal position — two charts on different spans put the same day at different pixels, and the CI card's note says so. Everything else survives, because the comparison never depended on the axis. Verified in a browser rather than assumed:

- The cursor group syncs on scale **values**, not pixels. Hovering the CI chart at 08-30 puts all three legends on `2026-08-30` with real values; at 08-16 the traffic charts show a dash, which is the honest answer for a day outside their history.
- Drag-zoom propagates as a value range: dragging across the CI chart set every chart's right edge to 08-23.
- Double-click returns **each** chart to its own span, not to a shared one.

## Two latent faults surfaced on the way

Both from the CI series being added without every place that enumerates series following.

1. **`SERIES_NAMES` omitted `workflows`.** That list decides which dated series may move the window. A workflow row outside every other series' history would have been measured, bundled, and then silently clipped out of every range including `all`. It works today only because the star backfill happens to reach the same first day.
2. **`validateBundle` never checked `series.workflows`.** A bundle missing it validated and then threw downstream — inside the range control, which is outside any section's error boundary. It now reports `series.workflows is missing` and the page degrades to its honest "archive not available" state.

## Other states checked

One empty card (renders `window … · measured nothing in this window` plus the explanatory sentence, no frame — an empty axis has no span of its own to state), all cards empty (section-level note), and a forced axis overrun (the note now names which card's dates are impossible).

## Docs

`docs/systems/metrics.md` gains **§10.7** stating the rule — a chart's x axis spans the days *that chart* was measured on — and both traps above, so the next dated series does not repeat them. The "shared axis" claims in §3.1, §4.5 and `types.ts` are corrected, and the stale "six dated series" count is now seven throughout.

## Verification

- `tsc --noEmit` clean, **340 tests** pass.
- The existing 44-assertion browser harness passes at 1440 / 1280 / 768 / 390, no console errors, no page-level horizontal scroll.
- Every preview build ran against a copy of `site/` in a scratch directory; the `BUILD:` regions of `site/insights/index.html` are untouched by this diff.
