### PR TITLE
fix(desktop): ad-hoc sign macOS builds so Gatekeeper can open them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,3 +101,24 @@ jobs:
           # bundled x86_64 fpm (which can't run on the arm64 runner). No-op on
           # macOS/Windows, which don't build .deb.
           USE_SYSTEM_FPM: "true"
+
+      - name: Verify macOS code signature
+        if: runner.os == 'macOS'
+        working-directory: packages/desktop
+        # Backstop for the ad-hoc signing done in scripts/macSign.js. A bundle
+        # whose signature does not validate is reported by macOS as "Backspace
+        # is damaged and can't be opened", which no user can work around from
+        # the UI — so a broken seal must fail the release loudly rather than
+        # ship. macSign.js already verifies before packaging; this re-checks the
+        # final bundle, and also covers the case where that hook no-ops.
+        run: |
+          shopt -s nullglob
+          apps=(dist-electron/mac*/*.app)
+          if [ ${#apps[@]} -eq 0 ]; then
+            echo "::error::No packaged .app found under dist-electron/"
+            exit 1
+          fi
+          for app in "${apps[@]}"; do
+            echo "==> $app"
+            codesign --verify --deep --strict --verbose=2 "$app"
+          done

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ Grab the installer for your platform from the
 | Platform | File | Notes |
 |----------|------|-------|
 | Windows | `Backspace-<version>.exe` | Universal installer (x64 + arm64). SmartScreen may warn on first run; choose "More info" → "Run anyway". Auto-updates. |
-| macOS | `Backspace-<version>-arm64.dmg` (Apple Silicon) / `Backspace-<version>-x64.dmg` (Intel) | Builds are currently **unsigned**: on first launch, right-click the app → **Open** → **Open**. Auto-update is not available on macOS yet, so check the releases page for new versions. |
+| macOS | `Backspace-<version>-arm64.dmg` (Apple Silicon) / `Backspace-<version>-x64.dmg` (Intel) | Builds are ad-hoc signed but **not notarized**, so Gatekeeper blocks the first launch. Open it once, dismiss the warning, then go to **System Settings → Privacy & Security** and click **Open Anyway** next to the Backspace message. On macOS 14 and earlier, right-click the app → **Open** → **Open** works instead. Auto-update is not available on macOS yet, so check the releases page for new versions. |
 | Linux | `Backspace-<version>-x86_64.AppImage` / `-arm64.AppImage`, or `.deb` (`amd64` / `arm64`) | AppImage auto-updates; `.deb` installs update via new releases. |
 
 On first launch the app asks for your instance URL. Enter the address of the

--- a/docs/systems/desktop.md
+++ b/docs/systems/desktop.md
@@ -10,7 +10,8 @@ Source files:
 - `packages/web/src/platform/electron.d.ts` — TypeScript declarations for `window.backspace`
 - `packages/web/src/platform/platform.ts` — `isElectron()` / `isElectronMac()` / `getElectronAPI()` helpers
 - `packages/desktop/electron-builder.yml` — Build config, protocol registration, afterPack hook
-- `packages/desktop/scripts/afterPack.js` — Cross-platform native module cleanup (critical for builds)
+- `packages/desktop/scripts/afterPack.js` — Cross-platform native module cleanup (critical for builds), then macOS signing
+- `packages/desktop/scripts/macSign.js` — Ad-hoc macOS code signing fallback (critical: without it the app will not launch)
 - `packages/desktop/resources/games.json` — Bundled game dictionary seed (versioned)
 
 ---
@@ -243,11 +244,17 @@ autoInstallOnAppQuit: true
 Publish: GitHub (TheZwiss/backspace)
 ```
 
-**Signing status (as of v1.0.0):** all builds are unsigned. Consequences:
-- **macOS:** Squirrel.Mac refuses to apply unsigned updates — auto-update is
-  effectively disabled on macOS until a Developer ID certificate + notarization
-  are added to the CI build. Users update manually from the releases page.
-  First launch requires right-click → Open (Gatekeeper).
+**Signing status:** no Apple Developer ID or Windows certificate. macOS builds
+are ad-hoc signed by `scripts/macSign.js` (see below); Windows and Linux builds
+are unsigned. Consequences:
+- **macOS:** Squirrel.Mac refuses to apply updates without a real signing
+  identity — auto-update is effectively disabled on macOS until a Developer ID
+  certificate + notarization are added to the CI build. Users update manually
+  from the releases page. The app is not notarized, so first launch is blocked
+  by Gatekeeper and must be approved once via System Settings → Privacy &
+  Security → Open Anyway. Ad-hoc signatures also have no stable identity, so
+  the cdhash changes every release and macOS drops the Input Monitoring and
+  Screen Recording grants (global keybinds, screen share) on each update.
 - **Windows:** NSIS auto-update works unsigned; SmartScreen warns on first
   install only.
 - **Linux:** AppImage auto-update works unsigned.
@@ -922,6 +929,28 @@ output: dist-electron
 **Path resolution:** On macOS, resources live inside `{productName}.app/Contents/Resources/`; on Windows/Linux, under `resources/`. The hook resolves the correct path via `context.electronPlatformName`.
 
 **WARNING:** Removing or disabling this hook will cause Windows and Linux builds to crash on launch. This is documented in project memory as a critical constraint.
+
+3. **Ad-hoc sign (macOS only):** Delegates to `scripts/macSign.js`. Must run last — signing seals the bundle, so it has to follow every file mutation, including the deletions above.
+
+### macOS Ad-hoc Signing (CRITICAL)
+
+**File:** `scripts/macSign.js`
+
+**Problem:** electron-builder only signs when it can resolve a signing identity. With no Developer ID available, `MacPackager.sign()` bails out before signing at all (`findIdentity()` → `null` → `reportError()` → `return false`), leaving the bundle with only the linker-generated ad-hoc signatures baked into the prebuilt Electron binaries. Packaging then invalidates those: it renames the executable, rewrites `Info.plist`, injects `app.asar`, and deletes files from `Contents/Resources`.
+
+The result is not merely unsigned, it is **invalid** — `codesign --verify` reports `code has no resources but signature indicates they must be present`, and there is no `Contents/_CodeSignature` at all. macOS reports an invalid signature as *"Backspace.app is damaged and can't be opened. You should move it to the Trash."* That is a dead end: unlike the unnotarized-app warning, it offers no "Open Anyway" path. Every macOS user of v1.0.0 hit this (issue #38).
+
+**Solution:** Re-seal the bundle with an ad-hoc signature in `afterPack`:
+
+1. Sign every Mach-O under `Contents/Resources` (`.node`, `.dylib`). `codesign --deep` only reaches the standard nested-code locations, so native modules unpacked to `app.asar.unpacked` are otherwise sealed as plain resources and never signed.
+2. `codesign --force --deep --sign -` the bundle. `--deep` is discouraged for distribution signing because it applies one entitlement set to every nested binary; ad-hoc signatures carry no entitlements, so that does not apply here.
+3. `codesign --verify --deep --strict` immediately, so a bad bundle fails the build **before** electron-builder packages and publishes it. `.github/workflows/release.yml` re-checks the final bundle as a backstop.
+
+**Why `afterPack` and not `afterSign`:** electron-builder skips the `afterSign` hook entirely when no signing occurred (`didSign === false`), which is precisely this build's situation.
+
+**No-op conditions:** skips when `CSC_LINK` or `CSC_NAME` is set, so a real Developer ID identity takes over cleanly, and warns (rather than failing) on non-macOS hosts, which cannot run `codesign`.
+
+**WARNING:** Removing this hook makes macOS builds refuse to launch entirely.
 
 ### Icon Generation
 

--- a/packages/desktop/scripts/afterPack.js
+++ b/packages/desktop/scripts/afterPack.js
@@ -1,35 +1,40 @@
 // afterPack hook for electron-builder
-// Removes host-compiled native module artifacts so cross-platform builds
-// use the correct prebuilt binaries from the `prebuilds/` directory.
 //
-// Why this is needed:
+// Two jobs, in order:
+//   1. Remove host-compiled native module artifacts so cross-platform builds
+//      use the correct prebuilt binaries from the `prebuilds/` directory.
+//   2. On macOS, ad-hoc sign the bundle (see macSign.js).
+//
+// Order matters: signing seals the bundle's contents, so it must run after
+// every file mutation. afterPack is also the only hook available for this —
+// electron-builder skips the `afterSign` hook entirely when no signing
+// occurred, which is exactly the case this build is in.
+//
+// Why the native module cleanup is needed:
 //   `electron-rebuild` (postinstall) compiles uiohook-napi for the BUILD
 //   machine (e.g. macOS arm64), placing the binary in `build/Release/`.
 //   `node-gyp-build` checks `build/Release/` BEFORE `prebuilds/{platform}/`,
 //   so Windows/Linux packages would load the macOS binary and crash.
-//
-// What this does:
-//   1. Removes `build/`, `build.bak/`, `bin/` dirs (host-compiled artifacts)
-//   2. Strips prebuilts for platforms other than the target
 
 const fs = require('fs');
 const path = require('path');
 
-exports.default = async function afterPack(context) {
-  const platform = context.electronPlatformName; // 'darwin', 'linux', 'win32'
-  const appDir = path.join(
-    context.appOutDir,
-    // macOS bundles resources inside the .app
-    platform === 'darwin'
-      ? `${context.packager.appInfo.productFilename}.app/Contents/Resources`
-      : 'resources'
-  );
+const { signMacAppIfUnsigned } = require('./macSign');
 
+/**
+ * Strips host-compiled artifacts and foreign-platform prebuilts from the
+ * packaged copy of uiohook-napi.
+ *
+ * @param {string} appDir Resources directory of the packaged app.
+ * @param {string} platform electron-builder platform name.
+ * @returns {void}
+ */
+function cleanNativeModules(appDir, platform) {
   const asarUnpacked = path.join(appDir, 'app.asar.unpacked');
   const uiohookDir = path.join(asarUnpacked, 'node_modules', 'uiohook-napi');
 
   if (!fs.existsSync(uiohookDir)) {
-    console.log(`[afterPack] uiohook-napi not found in ${platform} build — skipping`);
+    console.log(`[afterPack] uiohook-napi not found in ${platform} build — skipping cleanup`);
     return;
   }
 
@@ -55,4 +60,21 @@ exports.default = async function afterPack(context) {
   }
 
   console.log(`[afterPack] Native module cleanup done for ${platform}`);
+}
+
+exports.default = async function afterPack(context) {
+  const platform = context.electronPlatformName; // 'darwin', 'linux', 'win32'
+  const isMac = platform === 'darwin';
+  const appName = `${context.packager.appInfo.productFilename}.app`;
+  const appDir = path.join(
+    context.appOutDir,
+    // macOS bundles resources inside the .app
+    isMac ? `${appName}/Contents/Resources` : 'resources'
+  );
+
+  cleanNativeModules(appDir, platform);
+
+  if (isMac) {
+    signMacAppIfUnsigned(path.join(context.appOutDir, appName));
+  }
 };

--- a/packages/desktop/scripts/macSign.js
+++ b/packages/desktop/scripts/macSign.js
@@ -1,0 +1,137 @@
+// Ad-hoc code signing fallback for macOS builds.
+//
+// Why this is needed:
+//   electron-builder only signs when it can resolve a signing identity. Without
+//   an Apple Developer ID, `MacPackager.sign()` bails out before signing at all
+//   (`findIdentity()` -> null -> `reportError()` -> return false), so the
+//   packaged bundle keeps only the linker-generated ad-hoc signatures that ship
+//   inside the prebuilt Electron binaries. Packaging then invalidates those:
+//   it renames the executable, rewrites Info.plist, injects app.asar, and
+//   (via afterPack.js) deletes files out of Contents/Resources.
+//
+//   The result is not merely unsigned, it is *invalid*:
+//     "code has no resources but signature indicates they must be present"
+//   macOS reports an invalid signature as "Backspace.app is damaged and can't
+//   be opened. You should move it to the Trash." — a dead end, with no "Open
+//   Anyway" affordance anywhere in the UI.
+//
+// What this does:
+//   Re-seals the bundle with an ad-hoc signature, giving it a real
+//   Contents/_CodeSignature, the correct bundle identifier, and a bound
+//   Info.plist. The app is still unnotarized, so first launch shows the usual
+//   Gatekeeper prompt — but that prompt is bypassable (System Settings ->
+//   Privacy & Security -> Open Anyway) and the app runs afterwards.
+//
+// What this does NOT do:
+//   Ad-hoc signatures carry no team identifier, so macOS auto-update stays
+//   unavailable and the cdhash changes every release, meaning macOS drops the
+//   Input Monitoring / Screen Recording grants on each update. Only a
+//   Developer ID certificate plus notarization fixes those.
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// `codesign --sign -` never contacts a timestamp server; pinning it to none
+// keeps the build hermetic rather than relying on that default.
+const AD_HOC_SIGN_ARGS = ['--force', '--sign', '-', '--timestamp=none'];
+
+/**
+ * True when electron-builder has a real identity to sign with, in which case
+ * this fallback must stay out of the way and let it sign properly.
+ *
+ * @returns {boolean}
+ */
+function hasRealSigningIdentity() {
+  return Boolean(process.env.CSC_LINK || process.env.CSC_NAME);
+}
+
+/**
+ * Collects Mach-O files under Contents/Resources.
+ *
+ * `codesign --deep` only reaches code in the standard nested locations
+ * (Frameworks, Helpers, PlugIns, XPCServices). Native modules unpacked to
+ * Resources/app.asar.unpacked sit outside those, so they are sealed as plain
+ * resources and never signed. Signing them explicitly first keeps every
+ * Mach-O in the bundle consistently signed across both architectures.
+ *
+ * @param {string} dir Directory to walk.
+ * @returns {string[]} Absolute paths of Mach-O files found.
+ */
+function collectResourceMachO(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const found = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      found.push(...collectResourceMachO(full));
+    } else if (entry.isFile() && (entry.name.endsWith('.node') || entry.name.endsWith('.dylib'))) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/**
+ * Ad-hoc signs a packaged .app bundle in place and verifies the result.
+ *
+ * Verification runs here rather than only in CI so an unusable bundle fails the
+ * build before electron-builder packages it into a .dmg/.zip and publishes it.
+ *
+ * @param {string} appPath Absolute path to the .app bundle.
+ * @returns {void}
+ * @throws {Error} If signing or verification fails.
+ */
+function adhocSignMacApp(appPath) {
+  const resourcesDir = path.join(appPath, 'Contents', 'Resources');
+
+  for (const binary of collectResourceMachO(resourcesDir)) {
+    execFileSync('codesign', [...AD_HOC_SIGN_ARGS, binary], { stdio: 'inherit' });
+    console.log(`[macSign] Ad-hoc signed ${path.relative(appPath, binary)}`);
+  }
+
+  // `--deep` is discouraged for distribution signing because it applies one set
+  // of entitlements to every nested binary. An ad-hoc signature carries no
+  // entitlements, so that concern does not apply here, and it is the only
+  // single-pass way to seal the Electron framework and helper apps.
+  execFileSync('codesign', [...AD_HOC_SIGN_ARGS, '--deep', appPath], { stdio: 'inherit' });
+  console.log(`[macSign] Ad-hoc signed bundle ${path.basename(appPath)}`);
+
+  execFileSync('codesign', ['--verify', '--deep', '--strict', appPath], { stdio: 'inherit' });
+  console.log(`[macSign] Signature verified for ${path.basename(appPath)}`);
+}
+
+/**
+ * afterPack entry point. Signs the bundle unless a real identity is configured
+ * or the build host cannot run codesign.
+ *
+ * @param {string} appPath Absolute path to the .app bundle.
+ * @returns {void}
+ */
+function signMacAppIfUnsigned(appPath) {
+  if (hasRealSigningIdentity()) {
+    console.log('[macSign] Signing identity configured — leaving signing to electron-builder');
+    return;
+  }
+
+  if (process.platform !== 'darwin') {
+    console.warn(
+      '[macSign] Cannot ad-hoc sign from a non-macOS host — this bundle will be rejected by Gatekeeper as damaged'
+    );
+    return;
+  }
+
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`[macSign] Expected app bundle at ${appPath}, but it does not exist`);
+  }
+
+  adhocSignMacApp(appPath);
+}
+
+module.exports = { signMacAppIfUnsigned };


### PR DESCRIPTION
Closes #38.

## The bug

macOS builds are not merely unsigned — they are **invalidly** signed, which is a different and much worse failure.

`CSC_IDENTITY_AUTO_DISCOVERY: "false"` in `release.yml` means electron-builder never signs: `findIdentity()` returns null, `reportError()` runs, and `sign()` returns false. The bundle keeps only the linker signatures baked into the prebuilt Electron binaries — which packaging then invalidates by renaming the executable, rewriting `Info.plist`, injecting `app.asar`, and deleting files from `Contents/Resources` in `afterPack`.

Checked against the actual shipped v1.0.0 artifact:

```
Identifier=Electron                    # not com.backspace.desktop
flags=0x20002(adhoc,linker-signed)
Info.plist=not bound
Contents/_CodeSignature/             -> does not exist

$ codesign --verify --deep --strict Backspace.app
Backspace.app: code has no resources but signature indicates they must be present
```

macOS reports an invalid signature as *"is damaged and can't be opened"*, which has no Open Anyway path — unlike the unnotarized-app warning. Every macOS user hit this, on both arches.

## The fix

Seal the bundle with an ad-hoc signature at the end of `afterPack`, after every file mutation, and verify immediately so a bad bundle fails the build rather than shipping. `afterSign` is unusable here — electron-builder skips that hook entirely when no signing occurred.

Native modules under `Resources` are signed explicitly first; `--deep` does not reach outside the standard nested-code locations.

No-ops when `CSC_LINK`/`CSC_NAME` is set, so a real Developer ID identity would take over cleanly.

## Verification

`syspolicy_check distribution`, which is Gatekeeper's own verdict:

| | shipped v1.0.0 | this branch |
|---|---|---|
| Codesign Error | **Fatal** | gone |
| Notary Ticket Missing | Fatal | Fatal |

The remaining error is the ordinary, bypassable one. Also verified on fresh arm64 **and** x64 builds (`valid on disk`, `satisfies its Designated Requirement`), and the built app was launched to confirm it starts.

## What this does not fix

Ad-hoc signatures carry no team identifier, so macOS auto-update stays unavailable, and the cdhash changes every release — meaning macOS drops Input Monitoring and Screen Recording grants (global keybinds, screen share) on each update. Only Developer ID + notarization fixes those. Both are documented in `docs/systems/desktop.md` rather than left implicit.