### PR TITLE
ci(release): verify Electron fuses on every packaged platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,114 @@ jobs:
           # macOS/Windows, which don't build .deb.
           USE_SYSTEM_FPM: "true"
 
+      - name: Verify Electron security fuses
+        working-directory: packages/desktop
+        shell: bash
+        # Backstop for the fuse flip done in scripts/afterPack.js. That hook
+        # resolves the Electron binary path *per platform* (Linux reads
+        # `packager.executableName`, mac/win read `appInfo.productFilename`),
+        # so "it worked on macOS arm64" proves nothing about the other five
+        # artifacts this matrix ships — a wrong path there means either a build
+        # error or, worse, a binary that quietly ships with the fuses still off.
+        # Read the wire back out of every packaged binary and fail the release
+        # if any of the three is not in the state afterPack claims to have set.
+        # Runs before the signature check below, mirroring afterPack's own
+        # order (fuses are flipped, then the bundle is sealed).
+        #
+        # `npx --no` is deliberate: it runs the @electron/fuses already pinned
+        # in this package's devDependencies (1.8.0) and hard-fails instead of
+        # reaching the registry. A bare `npx` would silently fetch 2.x, which
+        # is ESM-only and requires Node >= 22.12 — this job is on Node 20.
+        run: |
+          set -euo pipefail
+
+          # Expected artifacts per runner, matching the build matrix above.
+          # Listed explicitly rather than globbed: a glob that matches nothing
+          # would skip silently, and a check that verifies nothing is worse
+          # than no check at all because it still reads as coverage.
+          case "$RUNNER_OS" in
+            macOS)
+              artifacts=(
+                "dist-electron/mac/Backspace.app"
+                "dist-electron/mac-arm64/Backspace.app"
+              )
+              ;;
+            Windows)
+              artifacts=(
+                "dist-electron/win-unpacked/Backspace.exe"
+                "dist-electron/win-arm64-unpacked/Backspace.exe"
+              )
+              ;;
+            Linux)
+              # Not "backspace": electron-builder names the Linux executable
+              # from package.json `name` ("@backspace/desktop") via
+              # sanitizeFileName().toLowerCase(), which drops the slash but
+              # keeps the leading "@" — the "@" is only special-cased for the
+              # .deb package name, not for the binary.
+              if [ "$RUNNER_ARCH" = "ARM64" ]; then
+                artifacts=("dist-electron/linux-arm64-unpacked/@backspacedesktop")
+              else
+                artifacts=("dist-electron/linux-unpacked/@backspacedesktop")
+              fi
+              ;;
+            *)
+              echo "::error::Unknown runner OS '$RUNNER_OS' — no expected artifact list, refusing to pass by default"
+              exit 1
+              ;;
+          esac
+
+          # Fuse name -> required state, exactly as scripts/afterPack.js sets them.
+          expected=(
+            "RunAsNode=Disabled"
+            "EnableNodeCliInspectArguments=Disabled"
+            "OnlyLoadAppFromAsar=Enabled"
+          )
+
+          esc="$(printf '\033')"
+          failed=0
+
+          for artifact in "${artifacts[@]}"; do
+            if [ ! -e "$artifact" ]; then
+              echo "::error::Expected packaged artifact not found: packages/desktop/$artifact — the fuses for this target were never checked"
+              failed=1
+              continue
+            fi
+
+            echo "==> $artifact"
+            # chalk colourises its output on GitHub Actions (it treats
+            # GITHUB_ACTIONS as a colour-capable terminal), and the escape
+            # codes wrap the very words matched below. FORCE_COLOR=0 turns
+            # that off; the sed strips any that survive anyway.
+            if ! fuses="$(FORCE_COLOR=0 npx --no @electron/fuses read --app "$artifact" 2>&1 \
+                | sed -e "s/${esc}\[[0-9;]*m//g")"; then
+              echo "$fuses"
+              echo "::error::${artifact}: could not read the Electron fuse wire (output above)"
+              failed=1
+              continue
+            fi
+            echo "$fuses"
+
+            for pair in "${expected[@]}"; do
+              name="${pair%%=*}"
+              want="${pair#*=}"
+              got="$(printf '%s\n' "$fuses" \
+                | sed -n -E "s/^[[:space:]]*${name} is ([A-Za-z]+)[[:space:]]*\$/\\1/p")"
+              if [ -z "$got" ]; then
+                echo "::error::${artifact}: fuse ${name} was not reported by @electron/fuses at all (expected ${want})"
+                failed=1
+              elif [ "$got" != "$want" ]; then
+                echo "::error::${artifact}: fuse ${name} is ${got}, expected ${want} — scripts/afterPack.js did not flip this binary"
+                failed=1
+              fi
+            done
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::Electron security fuse verification failed on $RUNNER_OS/$RUNNER_ARCH — do not ship this release."
+            exit 1
+          fi
+          echo "All three Electron security fuses verified on $RUNNER_OS/$RUNNER_ARCH."
+
       - name: Verify macOS code signature
         if: runner.os == 'macOS'
         working-directory: packages/desktop


### PR DESCRIPTION
PR #31 flips three Electron security fuses in `afterPack.js`. **They had only ever been verified on macOS arm64.**

That gap is not cosmetic. `flipElectronFuses()` resolves the binary path per platform — Linux reads `packager.executableName`, mac/win read `appInfo.productFilename` — so a wrong path on an unverified platform means either a build error or, worse, a binary that quietly ships with the security fuses still off.

This reads the fuse wire back out of every packaged artifact in the release matrix and fails the job if any of the three is not in the state `afterPack.js` claims to have set.

## Paths were observed, not reasoned

All six artifacts were built locally and the fuses read back from each:

| Platform / arch | Path under `packages/desktop/dist-electron/` |
|---|---|
| macOS x64 / arm64 | `mac/Backspace.app`, `mac-arm64/Backspace.app` |
| Windows x64 / arm64 | `win-unpacked/Backspace.exe`, `win-arm64-unpacked/Backspace.exe` |
| Linux x64 / arm64 | `linux-unpacked/@backspacedesktop`, `linux-arm64-unpacked/@backspacedesktop` |

The Linux name is the one reasoning gets wrong. `LinuxPackager.executableName` falls back to `sanitizeFileName("@backspace/desktop").toLowerCase()`, which strips the `/` but **keeps the leading `@`** → `@backspacedesktop`. electron-builder only special-cases the `@` for the .deb package name, not the binary. A guessed `backspace` would have failed both Linux legs on the first release.

## Failure output

Verified by writing a wrong fuse wire onto a copy of a real binary:

```
::error::…: fuse RunAsNode is Enabled, expected Disabled — scripts/afterPack.js did not flip this binary
::error::Electron security fuse verification failed on Linux/X64 — do not ship this release.
```

It reports every wrong fuse across every artifact rather than aborting on the first, and always prints the full dump. A missing artifact **fails** rather than skipping — a check that silently verifies nothing is worse than no check, because it still reads as coverage.

`actionlint` clean (with shellcheck available, so the `run:` body was linted too).

## Known limits, stated rather than glossed

- It verifies the unpacked directory, not the shipped installer. Those are built from these directories, but nothing here reads fuses out of the `.dmg`/`.exe`/`.AppImage` itself.
- `--publish always` uploads **before** this step runs, so a failure stops you shipping knowingly but does not un-publish. Releases are drafts, so nothing reaches users. Splitting build → verify → publish is a worthwhile follow-up.
- The expected-fuse table is a hand-maintained copy of `afterPack.js`; a fourth fuse added there would be ignored silently.