### PR TITLE
chore: release 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backspace",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Open, self-hosted communication platform — text, voice, video, and federation",
   "license": "AGPL-3.0-only",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backspace",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/shared",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/metrics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",


### PR DESCRIPTION
Bumps all six workspace packages to 1.0.1 in lockstep.

Only `packages/desktop` affects the built artifacts — electron-builder reads it for `artifactName` and the updater feed — but the repo has always moved them together.

## What ships in 1.0.1

- **#65** — macOS builds are ad-hoc signed, fixing #38. Every macOS user of 1.0.0 was blocked by *"Backspace.app is damaged and can't be opened"*; the bundle was not unsigned but **invalidly** signed, which Gatekeeper treats as a dead end with no Open Anyway path.
- **#31** — Electron hardening: `RunAsNode` and `EnableNodeCliInspectArguments` disabled, `OnlyLoadAppFromAsar` enabled, plus a `will-navigate` deny handler and `docs/systems/desktop-security.md`.
- **#66** — the release job now reads the fuse wire back out of all six packaged artifacts and fails if any fuse is not in its expected state.
- **#64** — keeps local working plans out of the repo.

No server-side changes. Tagging `v1.0.1` will still republish the container image and move the Docker `latest` tag, since both workflows trigger on `v*`.