### PR TITLE
fix(docker): compile better-sqlite3 in a dedicated build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,45 @@
 # Backspace — Multi-stage Docker build
 # ============================================================
 
-# Stage 1: Install dependencies and build frontend
+# Stage 1: Production dependencies
+#
+# better-sqlite3 12.x ships prebuilt binaries for Node ABI v127, v137, v141 and
+# v147 (Node 22 and newer). It ships none for v115, which is the ABI of Node 20,
+# the version this repo pins. prebuild-install gets a 404 and falls back to
+# `node-gyp rebuild`, which needs Python and a C++ compiler; node:20-slim has
+# neither. The toolchain is installed here and nowhere else. The runtime stage
+# copies the resulting node_modules and runs no install of its own.
+FROM node:20-slim AS deps
+
+RUN corepack enable && corepack prepare pnpm@10.34.3 --activate
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 make g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy workspace config
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
+COPY tsconfig.base.json ./
+
+# Copy package.json files for all workspace packages
+COPY packages/shared/package.json packages/shared/
+COPY packages/server/package.json packages/server/
+COPY packages/web/package.json packages/web/
+
+# Copy patches (referenced by pnpm-lock.yaml)
+COPY patches/ patches/
+
+# The production dependency tree that ships in the runtime image
+RUN pnpm install --prod --frozen-lockfile
+
+# ============================================================
+# Stage 2: Build the frontend
+#
+# Installs only @backspace/web and what it depends on (@backspace/shared). That
+# keeps the server dependencies, better-sqlite3 among them, out of this stage, so
+# the native build runs once in `deps` and this stage needs no toolchain.
 FROM node:20-slim AS builder
 
 RUN corepack enable && corepack prepare pnpm@10.34.3 --activate
@@ -21,25 +59,24 @@ COPY packages/web/package.json packages/web/
 # Copy patches (referenced by pnpm-lock.yaml)
 COPY patches/ patches/
 
-# Install dependencies
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --filter @backspace/web...
 
 # Copy source code (excluding desktop — not needed in Docker)
 COPY packages/shared/ packages/shared/
-COPY packages/server/ packages/server/
 COPY packages/web/ packages/web/
 
 # Build the web frontend
 RUN pnpm --filter @backspace/web build
 
 # ============================================================
-# Stage 2: Production runtime
+# Stage 3: Production runtime
 FROM node:20-slim AS runtime
 
 RUN corepack enable && corepack prepare pnpm@10.34.3 --activate
 
 # Runtime deps only: ffmpeg (media processing) + gosu (drop to non-root in the
-# entrypoint). No C toolchain — better-sqlite3 and sharp load prebuilt binaries.
+# entrypoint). No C toolchain. The native modules are compiled in `deps` and
+# copied in below.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg gosu && \
     rm -rf /var/lib/apt/lists/*
@@ -55,17 +92,16 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/server/package.json packages/server/
 COPY packages/web/package.json packages/web/
 
-# Copy patches (referenced by pnpm-lock.yaml)
-COPY patches/ patches/
-
-# Install production dependencies only (tsx is in server dependencies)
-RUN pnpm install --prod --frozen-lockfile
-
 # Copy shared source (needed at runtime since server imports types directly)
 COPY packages/shared/ packages/shared/
 
 # Copy server source
 COPY packages/server/ packages/server/
+
+# Production dependencies, built in the `deps` stage. All of pnpm's symlinks are
+# relative to /app, so the tree works unchanged after the copy.
+COPY --from=deps /app/node_modules node_modules
+COPY --from=deps /app/packages/server/node_modules packages/server/node_modules
 
 # Copy built frontend from builder stage
 COPY --from=builder /app/packages/web/dist packages/web/dist

--- a/docs/systems/deployment.md
+++ b/docs/systems/deployment.md
@@ -59,10 +59,13 @@ One installer, three modes, recorded as `DEPLOY_MODE` in `.env`. `install.sh` au
 
 ### Build: multi-stage Dockerfile
 
-`Dockerfile` has two stages:
+`Dockerfile` has three stages:
 
-1. **`builder`** (`node:20-slim`) — enables pnpm via corepack, installs the full workspace with `pnpm install --frozen-lockfile`, copies `shared`/`server`/`web` source, and runs `pnpm --filter @backspace/web build` to produce the static frontend (`packages/web/dist`).
-2. **`runtime`** (`node:20-slim`) — installs `ffmpeg` (media) + `gosu` (privilege drop) only — **no C toolchain**, since `better-sqlite3`/`sharp` load prebuilt binaries — installs production-only deps with `pnpm install --prod --frozen-lockfile` (`tsx` is a server runtime dependency), copies `shared` + `server` source and the prebuilt `web/dist`, creates `/app/data/uploads`, and runs the server **as the non-root `node` user** via `docker-entrypoint.sh` (which chowns `/app/data` as root, then `exec gosu node`) with `node --import tsx/esm src/index.ts` from `/app/packages/server`.
+1. **`deps`** (`node:20-slim`): enables pnpm via corepack, installs `python3`/`make`/`g++`, and produces the production dependency tree with `pnpm install --prod --frozen-lockfile` (`tsx` is a server runtime dependency). This is the only stage that carries a C toolchain, and the only one that compiles native modules.
+2. **`builder`** (`node:20-slim`): installs just the frontend's dependency subset with `pnpm install --frozen-lockfile --filter @backspace/web...`, copies `shared`/`web` source, and runs `pnpm --filter @backspace/web build` to produce the static frontend (`packages/web/dist`). The filter keeps the server's dependencies out of this stage, so no toolchain is needed here either.
+3. **`runtime`** (`node:20-slim`): installs `ffmpeg` (media) + `gosu` (privilege drop) only, with **no C toolchain**. Copies the production `node_modules` from `deps`, `shared` + `server` source, and the prebuilt `web/dist` from `builder`, creates `/app/data/uploads`, and runs the server **as the non-root `node` user** via `docker-entrypoint.sh` (which chowns `/app/data` as root, then `exec gosu node`) with `node --import tsx/esm src/index.ts` from `/app/packages/server`. It runs no `pnpm install` of its own.
+
+**Why the `deps` stage exists.** `better-sqlite3` 12.x publishes prebuilt binaries for Node ABI v127, v137, v141 and v147, which cover Node 22 and newer. It publishes none for v115, the ABI of Node 20, on any platform. This repo pins Node 20, so `prebuild-install` gets a 404 and falls back to `node-gyp rebuild`, which needs Python and a C++ compiler that `node:20-slim` does not have. Compiling it in a dedicated stage and copying only the resulting `node_modules` keeps the toolchain out of the published image. Verify this before assuming a future `better-sqlite3` bump restores the prebuild: check for a `-node-v115-` asset on the release, e.g. `better-sqlite3-v<version>-node-v115-linux-x64.tar.gz`.
 
 The server is run through `tsx` (no separate transpile step); TypeScript is executed directly at runtime.
 
@@ -80,8 +83,10 @@ container start, `docker-entrypoint.sh` runs as root only long enough to `chown`
 the `./data` bind mount to `node` (only entries not already node-owned, so it is
 near-instant after the first boot), then drops privileges via `gosu` and execs the
 server. The build toolchain (`python3`/`make`/`g++`) is not installed in the
-runtime stage — `better-sqlite3` and `sharp` load from prebuilt binaries — which
-shrinks the runtime attack surface. `ffmpeg` remains (a real runtime dependency).
+runtime stage. `sharp` loads a prebuilt binary; `better-sqlite3` is compiled in
+the separate `deps` stage and copied in, so neither needs a compiler at runtime.
+That keeps the runtime attack surface small. `ffmpeg` remains (a real runtime
+dependency).
 
 The published image carries an SBOM and SLSA provenance attestation, and the
 amd64 image is scanned by Trivy before publish (report-only). Note: only the


### PR DESCRIPTION
The container image has been unbuildable since 2026-08-25. Nobody noticed because `docker-publish.yml` only runs on a `v*` tag or manual dispatch, and no tag was cut between then and `v1.0.1`. The last successful publish was 2026-07-06.

## Root cause

better-sqlite3 stopped shipping a Node 20 prebuild. Node 20 is ABI v115, and the release assets tell the story:

| version | released | `-node-v115-linux-x64.tar.gz` |
|---|---|---|
| 12.9.0 | 2026-04-12 | 200 |
| 12.10.0 | 2026-05-12 | **404** |
| 12.11.1 | 2026-06-15 | **404** |

12.11.1 ships `v127, v137, v141, v147` only, which is Node 22 and up, across every platform. There is no v115 asset for any platform. Its `engines` field still claims `20.x`, so it installs happily and then compiles from source.

PR #41 moved the dependency to `^12.11.1`, past that cutoff. CI never caught it because GitHub's ubuntu runners have Python available, so `node-gyp` succeeds there. `node:20-slim` has no Python, `make` or `g++`, so the same install dies:

```
prebuild-install warn install No prebuilt binaries found
  (target=20.20.2 runtime=node arch=x64 libc= platform=linux)
gyp ERR! stack Error: Could not find any Python installation to use
```

The runtime stage had the same problem, not just the builder. It ran its own `pnpm install --prod`, so adding a toolchain to the builder alone would have moved the failure one stage down.

## The fix

Three stages instead of two:

1. `deps` is the only stage with `python3 make g++`. It runs the production install, compiling better-sqlite3 once.
2. `builder` has no toolchain. It installs only web and shared, so better-sqlite3 never enters it.
3. `runtime` keeps `ffmpeg` and `gosu`, and copies the production `node_modules` from `deps`. It runs no install at all.

## Verification

Built on both architectures, not reasoned about. arm64 native and amd64 under QEMU both succeed, and `docker buildx --platform linux/amd64,linux/arm64` passes, which covers both the single-arch scan build and the multi-arch push the workflow does.

The runtime image has no toolchain: `python3`, `python`, `make`, `g++`, `gcc` and `cc` are all absent. Native modules load from the copied tree.

The image got smaller, 377 MB to 279 MB on arm64, because the runtime stage no longer runs `pnpm install` and pnpm's store no longer lands in the image.

Container starts and answers on both arches:

```
{"status":"ok","timestamp":1788373485106}
Up 14 seconds (healthy)
Uid:  1000  1000  1000  1000
```

The frontend serves, `/api/instance/info` still reports its build commit so the AGPL section 13 stamping survives, and the DB is created under `/app/data`.

## Not verified

The GHCR push itself, since the builds used `--output type=cacheonly`. Trivy was not run. Everything ran on macOS Docker Desktop rather than a real Linux host, so the existing release-gate note in `deployment.md` about pull-testing on amd64 and the Pi still applies.