### PR TITLE
chore: release 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backspace",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Open, self-hosted communication platform — text, voice, video, and federation",
   "license": "AGPL-3.0-only",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/desktop",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backspace",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/shared",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/web",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/metrics",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",


### PR DESCRIPTION
Bumps all six workspace packages to 1.0.2 in lockstep.

## What ships in 1.0.2

**#69**, eleven commits closing the federation and DM issues raised in the fork review, one fix per commit with its own regression test, plus a two-instance end-to-end suite that gates them.

**#68**, the container image builds again. It had been unbuildable since 2026-08-25, when better-sqlite3 moved past the version that still shipped a Node 20 prebuild. This tag should publish a working image for the first time since July.

## Testing

974 server tests across 115 files, 488 web tests, tsc clean.

The end-to-end suites boot two real server instances as child processes with separate databases and peer them through the actual handshake. Before this, there was no two-instance test anywhere in the repo.

## Note

The remaining open PRs are the dependabot backlog and two community contributions. None belong in this release.