### PR TITLE
security: outbound request validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,21 @@ REGISTRATION_OPEN=true
 # this automatically when you pick `tunnel` mode.
 MAX_UPLOAD_SIZE=104857600
 
+# ─── Federation ────────────────────────────────────────────
+# Peer origins reach this instance two ways. An admin can name one (the peering
+# screen, an approved peer row), or a caller can assert one (a friend handle
+# someone typed, a callback to a peering request that was never accepted).
+# Asserted origins must resolve to a public address before this instance will
+# send a request to them. Origins an admin named are unaffected either way, so
+# peering with a peer on a private address keeps working through the admin
+# screens.
+#
+# Turn this on for a LAN-only deployment: every instance sits on a private
+# address and users add each other by handle, so the asserted path has to be
+# allowed to reach a private address too. Leave it off anywhere reachable from
+# the public internet.
+# FEDERATION_ALLOW_PRIVATE_PEERS=false
+
 # ─── AGPL-3.0 § 13 Source Offer ────────────────────────────
 # Backspace is AGPL-3.0. Network users can obtain the source of the running
 # version via GET /api/instance/info and in-app "Source code (AGPL)" links.

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ site/sitemap.xml
 # committed to a public repo. See PR #51 / #52 for why this guard exists.
 docs/superpowers/plans/2026-07-12-federation-security-remediation.md
 docs/superpowers/plans/2026-09-02-security-pass-master.md
+docs/superpowers/plans/2026-09-02-plan-e-remediation.md

--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ The most important:
 | `BACKSPACE_IMAGE` / `BACKSPACE_IMAGE_TAG` | no | `ghcr.io/thezwiss/backspace` / `latest` | Prebuilt image to pull; pin a tag or point at your fork's registry |
 | `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` | no | none | Enable voice/video |
 | `COMPOSE_PROFILES`   | no       | none        | Set to `voice` to start the bundled LiveKit service |
+| `FEDERATION_ALLOW_PRIVATE_PEERS` | no | `false` | Set `true` only on a LAN-only deployment, so instances on private addresses can still peer when a user adds a handle. Admin-driven peering with a private peer works either way. |
 
 ## Voice & Video
 

--- a/docs/systems/embeds.md
+++ b/docs/systems/embeds.md
@@ -4,7 +4,8 @@ Source files:
 - `packages/server/src/utils/embedClassifier.ts` — URL classification and provider detection
 - `packages/server/src/utils/embedResolver.ts` — URL extraction, embed resolution pipeline, DB persistence, batch fetching
 - `packages/server/src/utils/metadataFetcher.ts` — OpenGraph/HTML metadata scraping with Cheerio
-- `packages/server/src/utils/ssrf.ts` — SSRF protection (DNS resolution, private IP blocking)
+- `packages/server/src/utils/ssrf.ts` — SSRF protection (URL validation, DNS resolution, per-hop redirect re-validation)
+- `packages/server/src/utils/ipClass.ts` (address classification: parses an IPv4, IPv6 or IPv4-mapped IPv6 address and reports which range it falls in)
 - `packages/web/src/components/chat/EmbedRenderer.tsx` — Client-side embed routing by type
 - `packages/web/src/components/chat/embeds/GenericEmbed.tsx` — Generic link preview card
 - `packages/web/src/components/chat/embeds/ImageEmbed.tsx` — Direct image embed with lightbox
@@ -146,23 +147,54 @@ All outbound fetches to user- or peer-supplied URLs go through `safeFetch()`, wh
 1. **URL parsing** — `new URL(url)` must succeed
 2. **Scheme check** — only `http:` and `https:` allowed
 3. **DNS resolution** — `dns.promises.lookup(hostname)` resolves hostname to IP
-4. **Private IP check** — `isPrivateIp(address)` rejects internal addresses
+4. **Private IP check** — `isPrivateIp(address)` rejects anything that is not a publicly routable address
+
+Step 3 resolves `URL.hostname` with the square brackets around an IPv6 literal
+stripped first, because `dns.lookup` does not accept them. That is also what
+makes an IPv6-literal URL usable: with the brackets attached, resolution always
+failed and the URL was refused for the wrong reason.
 
 ### Blocked IP Ranges
 
-`ssrf.ts:isPrivateIp()`
+`ssrf.ts:isPrivateIp()` is a thin wrapper: it calls `classifyAddress()`
+(`utils/ipClass.ts`) and reports true for anything that does not come back
+`public`. The classifier parses the address into octets or 16-bit groups and
+tests range membership, so a range's boundaries are exact rather than whatever
+a string prefix happens to cover.
 
-| Range | Description |
-|-------|-------------|
-| `127.*` | Loopback |
-| `0.*`, `0.0.0.0` | Unspecified |
-| `10.*` | Private class A |
-| `192.168.*` | Private class C |
-| `172.16.0.0/12` | Private class B (172.16–172.31, checked via integer parse of second octet) |
-| `169.254.*` | Link-local |
-| `::1` | IPv6 loopback |
-| `fc*`, `fd*` | IPv6 unique local |
-| `fe80*` | IPv6 link-local |
+`classifyAddress()` returns one of `public`, `loopback`, `private`,
+`link-local`, `cgnat`, `unspecified`, `multicast` or `reserved`. Only `public`
+is allowed out.
+
+| Range | Class | Description |
+|-------|-------|-------------|
+| `127.0.0.0/8` | `loopback` | Loopback, the whole /8 |
+| `0.0.0.0` | `unspecified` | Binds every interface |
+| `0.0.0.0/8` (rest) | `reserved` | This-network |
+| `10.0.0.0/8` | `private` | RFC 1918 |
+| `172.16.0.0/12` | `private` | RFC 1918, 172.16 through 172.31 inclusive and nothing either side of it |
+| `192.168.0.0/16` | `private` | RFC 1918 |
+| `169.254.0.0/16` | `link-local` | Includes the cloud instance-metadata address |
+| `100.64.0.0/10` | `cgnat` | RFC 6598 carrier-grade NAT |
+| `192.0.0.0/24`, `192.0.2.0/24`, `198.18.0.0/15`, `198.51.100.0/24`, `203.0.113.0/24` | `reserved` | Protocol assignments, benchmarking, TEST-NET-1/2/3 |
+| `224.0.0.0/4` | `multicast` | RFC 5771 |
+| `240.0.0.0/4` | `reserved` | Includes the broadcast address |
+| `::` | `unspecified` | Reaches loopback on most stacks |
+| `::1` | `loopback` | IPv6 loopback |
+| `fc00::/7` | `private` | Unique local, `fc` and `fd` |
+| `fe80::/10` | `link-local` | The full /10, `fe80` through `febf` |
+| `ff00::/8` | `multicast` | |
+
+**IPv4-mapped IPv6** is unwrapped to its IPv4 form before classification, in
+both spellings: the hex form `::ffff:7f00:1` that the WHATWG URL parser emits
+and the dotted form `::ffff:127.0.0.1` that glibc's `inet_ntop` emits. Which
+one arrives depends on the resolution path, so both are handled. A mapped
+address that unwraps to a public IPv4 stays `public`.
+
+**Fail-closed.** Anything the classifier cannot parse (an empty string, a
+malformed address, an out-of-range octet) returns `reserved`, never `public`.
+A classifier that answers "public" when it does not understand its input is
+worse than none at all, because callers read `public` as permission.
 
 ### Redirect Handling
 

--- a/docs/systems/federation.md
+++ b/docs/systems/federation.md
@@ -14,6 +14,7 @@ Source files:
   - `routes/federation/handlers/*.ts` -- Fastify route registrars, grouped by endpoint concern: `peerHandshake` (initiate/accept/ensure/rotate/denied), `peerAdmin` (peer list/CRUD/reset/recheck/rotate), `approvals` (approval queue + peering subscriptions/notifications + approve/deny helpers), `relay` (identity delete, relay, epoch, sync), `lookup` (user lookups), `attach` (verify-attach-proof, `/api/users/@me/reattach`)
     - `routes/federation/handlers/s2sAuth.ts` -- `authenticateS2SPeer(request, reply, opts?)`: the shared inbound S2S-HMAC auth preamble (parse headers → resolve active peer → optional per-peer rate limit **before** signature → verify HMAC signature → nonce replay). Adopted by the six endpoints whose preamble is byte-identical: `DELETE /identity`, `POST /relay`, `POST /sync` (`relay.ts`), `POST /users/lookup`, `POST /users/by-home-id` (`lookup.ts`), and `POST /verify-attach-proof` (`attach.ts`). Returns `{ ok: true, peer, nonce }` or, having already sent the rejection reply, `{ ok: false }` (caller must `return`). **Intentional non-adopters** (each keeps a load-bearing gate the helper would flatten, documented in its own docstring/comment): `POST /epoch` (revoked-only gate for peer recovery, 400 on missing headers, no nonce check), `POST /peer/rotate` (active-only, no nonce check), `POST /peer/denied` (`awaiting_approval` gate, synthetic no-grace secret verify).
 - `packages/server/src/utils/federationAuth.ts` -- HMAC signing, verification, header parsing, `getOurOrigin()`
+- `packages/server/src/utils/federationFetch.ts` -- The outbound path for peer-addressed requests: origin trust levels (`approved` / `asserted`), origin format checks, no redirect following. See §1b.
 - `packages/server/src/utils/federationOutbox.ts` -- Event queuing, coalescing, relay payload construction, mutation log, participant/target resolution
 - `packages/server/src/utils/federationLookup.ts` -- HMAC-signed remote-user lookups: `lookupRemoteUser` (by username) and `lookupRemoteUserByHomeId` (reverse lookup, used by stub backfill)
 - `packages/server/src/utils/federationPresence.ts` -- S2S presence relay: `queuePresenceRelay`, `snapshotPresenceForPeer` (relationship-scoped), `markPeerStubsOffline`
@@ -514,6 +515,120 @@ These S→C events are pushed to the acting user's connected clients by the fede
 | `federation_peer_rejected` | Outbox worker receives `403 PEERING_REQUIRES_APPROVAL` from a remote instance during auto-peering | `{ peerId: string, origin: string }` |
 | `federation_peer_active` | A previously `rejected` peer transitions to `active` (e.g., via manual `peer/initiate` or incoming `peer/accept`) | `{ peerId: string, origin: string }` |
 | `federation_peer_reset_detected` | A peer's advertised instance epoch differs from the trusted baseline (wipe-and-reinstall on the same domain) — emitted by `markPeerReset` after routing the peer to `needs_attention` | `{ origin: string }` (admin-only, via `sendToAdmins`) |
+
+---
+
+## 1b. Outbound Requests
+
+Requests this instance addresses to a peer's federation endpoints go through
+`federationFetch` (`utils/federationFetch.ts`). It takes the peer origin, the
+federation path, the fetch init, and one more argument: how this instance came
+to know the origin.
+
+```ts
+export type OriginTrust = 'approved' | 'asserted';
+export async function assertPeerOriginAllowed(origin: string, trust: OriginTrust): Promise<void>;
+export async function federationFetch(origin: string, path: string, init: RequestInit, trust: OriginTrust): Promise<Response>;
+```
+
+### Origin trust
+
+| Trust | Where the origin came from | Address rule |
+|-------|---------------------------|--------------|
+| `approved` | a `federation_peers` row, or the body of an admin-authenticated request | any address |
+| `asserted` | a party with no settled peering relationship: a peering-request row a remote wrote, a handle a local user typed, a callback to a request that was never accepted | must resolve to a publicly routable address |
+
+Both levels run the same format checks first. The origin must parse, must be
+`http:` or `https:`, and must carry no path, query or fragment, because an
+origin is scheme plus host plus port and nothing else. A value that fails those
+checks is a bug in whatever wrote it, wherever it came from, so it is refused at
+both levels rather than joined to a federation path.
+
+`approved` allows a private address deliberately. Peering across a LAN is a
+supported deployment shape, and the two-instance test harness peers on
+loopback. A rule of the form "peer origins must be public" would break both.
+What makes this level safe is not the address, it is that an admin named the
+origin or that the origin is already a row in the peer table.
+
+`asserted` is the level for an origin nobody on this instance has ruled on. It
+must resolve to a public address, so the party that supplied it does not get to
+choose which hosts this instance opens a connection to. The gate resolves the
+hostname once and classifies the result with `classifyAddress`
+(`utils/ipClass.ts`); anything the classifier does not read as `public` is
+refused, and an origin that does not resolve at all is refused too.
+
+The two levels do not circle back on each other. A `federation_peers` row only
+exists because the outbound path that created it was itself gated: either an
+admin typed the origin into `/peer/initiate`, or the handshake that created the
+row ran as `asserted`.
+
+### Call sites
+
+18 outbound sites carry a peer origin: 13 `approved`, 5 `asserted`.
+
+| Trust | Sites |
+|-------|-------|
+| `approved` | `federationEpoch` (`/epoch`), `federationLookup` (`/users/lookup`, `/users/by-home-id`), `federationAttach` (`/verify-attach-proof`, `/users/by-home-id`), `federationOutbox` (`/relay`), `federationWorker` (`/relay`, `/peer/rotate`), `federationPeerActivation` (`/sync`), `federationRecovery` (`/api/instance/info` reachability probe), `routes/users.ts` (`/identity`), `handlers/peerAdmin.ts` (`/peer/rotate`), `handlers/peerHandshake.ts` (`/peer/accept`) |
+| `asserted` | `handlers/approvals.ts` (`/peer/accept` from the inbound and outbound approve branches, `/peer/denied` from the deny branch), `federationPeering.ts:performHandshake` (`/peer/accept`), `storageJanitor.ts` (`/peer/denied` on request expiry) |
+
+**Trust is a property of the caller, not of the function.** `performHandshake`
+is the clearest case: it runs only when no settled peer row exists, and its
+origin reaches it from a handle a user typed (friend-add) or from
+`POST /api/federation/peer/ensure`, which carries `authenticate` and nothing
+more, so any logged-in user can call it. It is `asserted` wherever it runs.
+
+Two sites read as asserted from the outside and are not:
+
+- `handlers/peerHandshake.ts` issues `/peer/accept` from `/peer/initiate`,
+  which carries `preHandler: [authenticate, requireAdmin]`. The origin is the
+  admin's own request body, already through `validateOrigin`. Classifying it
+  `asserted` would break admin-initiated LAN peering, which `validateOrigin`
+  deliberately supports.
+- `federationRecovery.ts:probePeerReachable` has two callers and both iterate
+  `federation_peers` rows with `status='unreachable'`: the recovery tick in
+  `federationWorker.ts` and the admin-only recheck route in `peerAdmin.ts`. No
+  unapproved origin reaches it, and a private peer stays probeable.
+
+### `FEDERATION_ALLOW_PRIVATE_PEERS`
+
+Default `false`, read as `config.federation.allowPrivatePeers`. While it is off,
+the `asserted` address rule above applies. Turning it on skips that rule, so an
+asserted origin may resolve to a private address. `approved` is unaffected
+either way, which is why admin-driven peering with a peer on a private address
+works the same in both settings.
+
+Two situations call for it:
+
+1. **A LAN-only deployment**, where every instance sits on a private address and
+   users add each other by handle. The asserted path has to be allowed to reach
+   a private address there, or handle-driven peering cannot work at all.
+2. **The two-instance test harness** (`test/helpers/twoInstanceHarness.ts`),
+   which spawns every instance on `127.0.0.1` and sets the flag for exactly the
+   same reason. It is set there and only there.
+
+Off is the shipped default so that an instance reachable from the public
+internet gets the narrower behaviour without configuring anything, and the
+operator opts in knowingly. Documented in `.env.example`.
+
+### Redirects
+
+`federationFetch` sends with `redirect: 'manual'` and does not follow. Every
+federation endpoint answers directly, so a 3xx from a peer means the peer is
+misconfigured or the response is pointing the request somewhere else. Callers
+see the 3xx and handle it through the non-2xx branch they already have.
+
+### Other outbound paths
+
+Not every outbound request is addressed to a federation endpoint. The rest of
+the map, so the inventory stays complete:
+
+| Path | Helper | Notes |
+|------|--------|-------|
+| Replicated profile assets (`routes/federation/profile.ts`) | `safeFetch` (`utils/ssrf.ts`) | Fetches a file URL rather than a federation endpoint. Redirects are followed, with every hop's destination re-validated first, and the body is capped at `MAX_PROFILE_ASSET_BYTES` (8 MiB). See [Profile Image File Replication](#profile-image-file-replication). |
+| Federated file replication (`federationWorker.ts`) | `safeFetch` | Same helper, same per-hop re-validation. See [File Download Worker](#file-download-worker-federationworkertsprocessfilequeueentry). |
+| Link embeds, metadata scraping, invite snapshots | `safeFetch` | Not federation traffic at all. See `docs/systems/embeds.md` §3. |
+| Federated login self-heal (`routes/auth.ts`) | its own request | Posts to `https://${user.homeInstance}`, a value stored on the user row, over a fixed path. Scheme is forced to `https`. See `docs/systems/auth.md` §4. |
+| GIF search proxy (`routes/gif.ts`) | its own request | A fixed provider host, no caller-supplied origin. |
 
 ---
 

--- a/docs/systems/federation.md
+++ b/docs/systems/federation.md
@@ -1451,13 +1451,14 @@ Profile data is synced server-to-server. The home instance is authoritative — 
 When a `profile_update` relay carries avatar or banner absolute URLs, the receiving instance downloads the image files locally rather than storing remote URLs. This eliminates cross-origin dependencies — avatars render from the local `/api/uploads/` endpoint.
 
 **Flow:** `processProfileUpdateEvent` calls `downloadProfileAsset(url, sourceInstance)` for each of avatar/banner:
-1. SSRF check (URL hostname must match authenticated source instance)
-2. `fetch` with 10s timeout
+1. Origin check (URL hostname must match authenticated source instance). This constrains the first request only, which is why step 2 does not use bare `fetch`.
+2. `safeFetch` with 10s timeout. It validates the target and re-validates the destination of every redirect hop before following it, so the origin check cannot be sidestepped by a peer answering with a 30x.
 3. Content-type validation (`image/*` only)
-4. Stream to temp file (`temp_{snowflake}{ext}`), atomic rename to `{snowflake}{ext}`
-5. Store local bare filename in user row
+4. Size cap (`MAX_PROFILE_ASSET_BYTES`, 8 MiB). A declared `content-length` over the cap is refused before the file is opened; the body is then counted as it streams and the transfer is aborted the moment it exceeds the cap, so a peer cannot answer with an unbounded body.
+5. Stream to temp file (`temp_{snowflake}{ext}`), atomic rename to `{snowflake}{ext}`
+6. Store local bare filename in user row
 
-**Fallback:** On any download failure (timeout, HTTP error, non-image content, SSRF mismatch), the absolute URL is stored instead. This degrades to the pre-replication behavior — the avatar loads cross-origin from the home instance.
+**Fallback:** On any download failure (timeout, HTTP error, non-image content, origin mismatch, refused redirect target, over-cap body), the absolute URL is stored instead. The temp file is unlinked on every failure path. This degrades to the pre-replication behavior — the avatar loads cross-origin from the home instance.
 
 **File cleanup:** When avatar/banner changes, the old local file is deleted via `deleteUploadFile()`. The check `!oldValue.startsWith('http')` ensures only locally-downloaded files are deleted, not absolute URL strings.
 

--- a/docs/systems/uploads.md
+++ b/docs/systems/uploads.md
@@ -287,6 +287,17 @@ Strips the original extension, appends `_thumb.webp`.
 | `Accept-Ranges` | `bytes` | Advertises Range support |
 | `Content-Length` | File size in bytes | |
 
+**The served-file policy is enforcing, and it owns the response.** The app-wide
+CSP hook in `index.ts` attaches its report-only policy only when a route has
+not already set `Content-Security-Policy`, so it stands aside here rather than
+attaching a second, looser policy next to a sandbox. Any future route that sets
+an enforcing policy takes on the same ownership: the app policy will not be
+merged into it. One case is worth knowing about because it is easy to get
+backwards: the 404 branch returns before these headers are set, so a request
+for a missing file gets the ordinary app policy, not the sandbox. Both are
+asserted in `test/http-security-headers.test.ts`. Full construction and rollout
+state in `docs/systems/web-security.md`.
+
 ### Content-Disposition (Forced Download)
 
 Files that trigger `Content-Disposition: attachment`:

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -121,6 +121,23 @@ export const config = {
     apiSecret: envOptional('LIVEKIT_API_SECRET'),
   },
 
+  federation: {
+    /**
+     * Allow an origin that a stranger asserted to resolve to a private address.
+     *
+     * Off by default. While it is off, an origin supplied by someone with no
+     * established peering relationship must be publicly routable before this
+     * instance will send a request to it. Origins an admin approved are
+     * unaffected either way, so peering with a private peer keeps working
+     * through the admin routes.
+     *
+     * Turn it on for a LAN-only deployment where every instance sits on a
+     * private address and users add each other by handle. The two-instance
+     * test harness sets it for the same reason.
+     */
+    allowPrivatePeers: envBool('FEDERATION_ALLOW_PRIVATE_PEERS', false),
+  },
+
   uploadDir: env('UPLOAD_DIR', resolve(__dirname, '../../../data/uploads')),
   tusUploadDir: resolve(env('UPLOAD_DIR', resolve(__dirname, '../../../data/uploads')), '.tus'),
   tusExpirationMs: envInt('TUS_EXPIRATION_HOURS', 24) * 60 * 60 * 1000,

--- a/packages/server/src/routes/federation.approveOutbound.test.ts
+++ b/packages/server/src/routes/federation.approveOutbound.test.ts
@@ -17,6 +17,14 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These suites use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   getRawDb: () => sqlite,
@@ -31,6 +39,7 @@ vi.mock('../config.js', () => ({
     jwtSecret: 'test-secret-12345678901234567890123456789012',
     maxUploadSize: 100 * 1024 * 1024,
     registrationOpen: true,
+    federation: { allowPrivatePeers: false },
   },
 }));
 

--- a/packages/server/src/routes/federation.groupBootstrap.test.ts
+++ b/packages/server/src/routes/federation.groupBootstrap.test.ts
@@ -20,6 +20,14 @@ let sqlite: Database.Database;
 let testDb: TestDb;
 let tmpUploadDir: string;
 
+// downloadProfileAsset now goes through safeFetch, which resolves the target
+// host before requesting it. These cases use a real domain in their fixtures,
+// so without this stub the outcome would depend on the machine having working
+// DNS. Resolve to a fixed public address and keep the redirect handling real.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   getRawDb: () => sqlite,

--- a/packages/server/src/routes/federation.groupMetadataUpdate.test.ts
+++ b/packages/server/src/routes/federation.groupMetadataUpdate.test.ts
@@ -20,6 +20,14 @@ let sqlite: Database.Database;
 let testDb: TestDb;
 let tmpUploadDir: string;
 
+// downloadProfileAsset now goes through safeFetch, which resolves the target
+// host before requesting it. These cases use a real domain in their fixtures,
+// so without this stub the outcome would depend on the machine having working
+// DNS. Resolve to a fixed public address and keep the redirect handling real.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   getRawDb: () => sqlite,

--- a/packages/server/src/routes/federation.outboundApprove.test.ts
+++ b/packages/server/src/routes/federation.outboundApprove.test.ts
@@ -17,6 +17,14 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These suites use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   getRawDb: () => sqlite,
@@ -31,6 +39,7 @@ vi.mock('../config.js', () => ({
     jwtSecret: 'test-secret-12345678901234567890123456789012',
     maxUploadSize: 100 * 1024 * 1024,
     registrationOpen: true,
+    federation: { allowPrivatePeers: false },
   },
 }));
 

--- a/packages/server/src/routes/federation.outboundDeny.test.ts
+++ b/packages/server/src/routes/federation.outboundDeny.test.ts
@@ -17,6 +17,14 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These suites use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   getRawDb: () => sqlite,
@@ -31,6 +39,7 @@ vi.mock('../config.js', () => ({
     jwtSecret: 'test-secret-12345678901234567890123456789012',
     maxUploadSize: 100 * 1024 * 1024,
     registrationOpen: true,
+    federation: { allowPrivatePeers: false },
   },
 }));
 

--- a/packages/server/src/routes/federation.peerAccept.test.ts
+++ b/packages/server/src/routes/federation.peerAccept.test.ts
@@ -39,6 +39,14 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These suites use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   getRawDb: () => sqlite,

--- a/packages/server/src/routes/federation/handlers/approvals.ts
+++ b/packages/server/src/routes/federation/handlers/approvals.ts
@@ -11,6 +11,7 @@ import { randomBytes } from 'node:crypto';
 import type { ApprovalRequestSubscriberSummary, PeeringTriggerReason } from '@backspace/shared';
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { resolveLocalOrigin, sanitizePeer } from '../origin.js';
+import { federationFetch } from '../../../utils/federationFetch.js';
 
 /**
  * Queue an inbound peer/accept request for local-admin approval.
@@ -138,7 +139,10 @@ export async function handleInboundApprove(
       .where(eq(schema.instanceSettings.id, 1))
       .get()?.name ?? undefined;
 
-    const response = await fetch(`${approvalReq.origin}/api/federation/peer/accept`, {
+    // 'asserted': this origin was written into the approval-request row by the
+    // remote's own /peer/accept body. The admin is approving the request, but
+    // no outbound request to that origin has been vetted before now.
+    const response = await federationFetch(approvalReq.origin, '/api/federation/peer/accept', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -152,7 +156,7 @@ export async function handleInboundApprove(
         ...(approvalReq.approvalToken ? { approvalToken: approvalReq.approvalToken } : {}),
       }),
       signal: AbortSignal.timeout(10_000),
-    });
+    }, 'asserted');
 
     if (response.status === 202) {
       // Remote instance also has autoAcceptPeering off — they queued our request.
@@ -299,7 +303,10 @@ export async function handleOutboundApprove(
 
   let response: Response;
   try {
-    response = await fetch(`${approvalReq.origin}/api/federation/peer/accept`, {
+    // 'asserted': an outbound queue row's origin came from a handle a local
+    // user typed, and with autoAcceptPeering off no handshake has run against
+    // it yet, so this is the first outbound request to that origin.
+    response = await federationFetch(approvalReq.origin, '/api/federation/peer/accept', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -312,7 +319,7 @@ export async function handleOutboundApprove(
         // autoAcceptPeering setting to decide 200 vs 202.
       }),
       signal: AbortSignal.timeout(10_000),
-    });
+    }, 'asserted');
   } catch (err: unknown) {
     db.delete(schema.federationPeers)
       .where(eq(schema.federationPeers.id, peerId))
@@ -473,12 +480,13 @@ export async function handleInboundDeny(
 
   let notificationSent = false;
   try {
-    const response = await fetch(`${approvalReq.origin}/api/federation/peer/denied`, {
+    // 'asserted': same row, same provenance as the approve path above.
+    const response = await federationFetch(approvalReq.origin, '/api/federation/peer/denied', {
       method: 'POST',
       headers,
       body: denialBody,
       signal: AbortSignal.timeout(10_000),
-    });
+    }, 'asserted');
     notificationSent = response.ok;
   } catch {
     // Network error

--- a/packages/server/src/routes/federation/handlers/peerAdmin.ts
+++ b/packages/server/src/routes/federation/handlers/peerAdmin.ts
@@ -4,6 +4,7 @@ import { authenticate, requireAdmin } from '../../../utils/auth.js';
 import { buildFederationHeaders, generateHmacSecret } from '../../../utils/federationAuth.js';
 import { onPeerDeactivated } from '../../../utils/federationPeerActivation.js';
 import { probePeerReachable, recoverOrDetectReset } from '../../../utils/federationRecovery.js';
+import { federationFetch } from '../../../utils/federationFetch.js';
 import { homeInstanceMatch } from '../../../utils/federationReset.js';
 import { connectionManager } from '../../../ws/handler.js';
 import { and, eq, sql } from 'drizzle-orm';
@@ -378,12 +379,12 @@ export function registerPeerAdminRoutes(app: FastifyInstance): void {
         const rotateBody = JSON.stringify({ newSecret });
         const headers = buildFederationHeaders(rotateBody, peer.hmacSecret, localOrigin);
 
-        const response = await fetch(`${peer.origin}/api/federation/peer/rotate`, {
+        const response = await federationFetch(peer.origin, '/api/federation/peer/rotate', {
           method: 'POST',
           headers,
           body: rotateBody,
           signal: AbortSignal.timeout(10_000),
-        });
+        }, 'approved');
 
         if (!response.ok) {
           let errorMessage = `Remote instance rejected rotation (HTTP ${response.status})`;

--- a/packages/server/src/routes/federation/handlers/peerHandshake.ts
+++ b/packages/server/src/routes/federation/handlers/peerHandshake.ts
@@ -12,6 +12,7 @@ import type { FastifyInstance } from 'fastify';
 import { queueApprovalRequest } from './approvals.js';
 import { resolveLocalOrigin, sanitizePeer, validateOrigin } from '../origin.js';
 import { isAcceptRateLimited, isEnsureRateLimited } from '../rateLimits.js';
+import { federationFetch } from '../../../utils/federationFetch.js';
 
 export function registerPeerHandshakeRoutes(app: FastifyInstance): void {
   // ─── POST /api/federation/peer/initiate ────────────────────────────────────
@@ -110,7 +111,9 @@ export function registerPeerHandshakeRoutes(app: FastifyInstance): void {
 
       // Initiate the server-to-server handshake
       try {
-        const response = await fetch(`${remoteOrigin}/api/federation/peer/accept`, {
+        // 'approved': remoteOrigin is the body of an admin-authenticated
+        // request on this route, so a private peer address is allowed.
+        const response = await federationFetch(remoteOrigin, '/api/federation/peer/accept', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -124,7 +127,7 @@ export function registerPeerHandshakeRoutes(app: FastifyInstance): void {
             instanceId: getInstanceId(),
           }),
           signal: AbortSignal.timeout(10_000),
-        });
+        }, 'approved');
 
         if (response.status === 202) {
           // Remote instance queued our request for admin approval

--- a/packages/server/src/routes/federation/profile.download.test.ts
+++ b/packages/server/src/routes/federation/profile.download.test.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+
+// The download writes through config.uploadDir. Point it at a throwaway
+// directory before config.ts is imported, so a test that is *supposed* to
+// abandon a file cannot leave one in the repo's real data/uploads.
+const UPLOAD_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'bs-profile-dl-'));
+process.env.UPLOAD_DIR = UPLOAD_DIR;
+
+// Real safeFetch semantics: validate, then fetch with redirect:'manual', then
+// re-validate the Location before following. The point of this suite is that
+// downloadProfileAsset goes through that loop at all, so the double is honest
+// rather than permissive.
+const validate = vi.fn<(url: string) => Promise<void>>();
+const rawFetch = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>();
+
+vi.mock('../../utils/ssrf.js', () => ({
+  isPrivateIp: () => false,
+  validateExternalUrl: (u: string) => validate(u),
+  safeFetch: async (url: string, init?: RequestInit) => {
+    let current = url;
+    for (let hop = 0; hop <= 5; hop++) {
+      await validate(current);
+      const res = await rawFetch(current, { ...init, redirect: 'manual' });
+      if (res.status >= 300 && res.status < 400) {
+        const loc = res.headers.get('location');
+        if (!loc) return res;
+        current = new URL(loc, current).toString();
+        continue;
+      }
+      return res;
+    }
+    throw new Error('Too many redirects');
+  },
+}));
+
+// A bare global fetch here would mean the code under test bypassed safeFetch.
+// Make that loud rather than letting it fall through to the real network.
+vi.stubGlobal('fetch', vi.fn(async () => {
+  throw new Error('global fetch called: downloadProfileAsset bypassed safeFetch');
+}));
+
+const { downloadProfileAsset, MAX_PROFILE_ASSET_BYTES } = await import('./profile.js');
+const { setWorkerId } = await import('../../utils/snowflake.js');
+
+// downloadProfileAsset names its temp file with a snowflake, and the generator
+// refuses to run before startup has assigned a worker ID. Without this every
+// case past the hostname check dies on that instead of on what it is testing.
+setWorkerId(1);
+
+afterAll(() => {
+  try { fs.rmSync(UPLOAD_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('downloadProfileAsset', () => {
+  beforeEach(() => {
+    validate.mockReset();
+    validate.mockResolvedValue(undefined);
+    rawFetch.mockReset();
+  });
+
+  it('refuses a URL whose host does not match the authenticated source instance', async () => {
+    const result = await downloadProfileAsset('https://elsewhere.test/a.png', 'https://peer.test');
+    expect(result).toBeNull();
+    expect(rawFetch).not.toHaveBeenCalled();
+  });
+
+  it('re-validates the destination of a redirect instead of following it blindly', async () => {
+    rawFetch.mockResolvedValueOnce(
+      new Response(null, { status: 302, headers: { location: 'http://127.0.0.1:9200/logo.png' } }),
+    );
+    validate.mockReset();
+    validate.mockResolvedValueOnce(undefined)                                   // first hop, the peer
+            .mockRejectedValueOnce(new Error('Private IP not allowed'));        // the redirect target
+
+    const result = await downloadProfileAsset('https://peer.test/a.png', 'https://peer.test');
+
+    expect(result).toBeNull();
+    expect(validate).toHaveBeenCalledWith('http://127.0.0.1:9200/logo.png');
+    expect(rawFetch).toHaveBeenCalledTimes(1); // the second hop was never issued
+  });
+
+  it('rejects a response that is not an image', async () => {
+    rawFetch.mockResolvedValueOnce(
+      new Response('hello', { status: 200, headers: { 'content-type': 'text/plain' } }),
+    );
+    expect(await downloadProfileAsset('https://peer.test/a.png', 'https://peer.test')).toBeNull();
+    // Without this the case is vacuous: any transport failure also returns
+    // null, so a null result alone does not show the content-type branch ran.
+    expect(rawFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('abandons a body that exceeds the cap instead of streaming it to disk', async () => {
+    const oversize = new Uint8Array(MAX_PROFILE_ASSET_BYTES + 1024);
+    rawFetch.mockResolvedValueOnce(
+      new Response(oversize, { status: 200, headers: { 'content-type': 'image/png' } }),
+    );
+    expect(await downloadProfileAsset('https://peer.test/a.png', 'https://peer.test')).toBeNull();
+    expect(rawFetch).toHaveBeenCalledTimes(1);
+    // Same reason, plus the claim in the test name: nothing is left behind,
+    // neither the temp file nor a renamed final one.
+    expect(fs.readdirSync(UPLOAD_DIR)).toEqual([]);
+  });
+});

--- a/packages/server/src/routes/federation/profile.ts
+++ b/packages/server/src/routes/federation/profile.ts
@@ -6,6 +6,7 @@ import { deleteUploadFile } from '../../utils/fileCleanup.js';
 import { sanitizeUser } from '../../utils/sanitize.js';
 import { generateSnowflake } from '../../utils/snowflake.js';
 import { collectProfileBroadcastTargetIds } from '../../utils/userDeletion.js';
+import { safeFetch } from '../../utils/ssrf.js';
 import { connectionManager } from '../../ws/handler.js';
 import { and, eq, or, sql } from 'drizzle-orm';
 import { Readable } from 'node:stream';
@@ -76,6 +77,14 @@ export async function hydrateReplicatedUserProfile(
 
 
 /**
+ * Cap on a replicated avatar or banner. Peers are admin-approved but explicitly
+ * untrusted; without a cap a peer answers the download with an unbounded body
+ * and fills the instance's disk. 8 MiB is well above any real avatar and well
+ * below anything that matters on a volume.
+ */
+export const MAX_PROFILE_ASSET_BYTES = 8 * 1024 * 1024;
+
+/**
  * Download a profile image (avatar or banner) from a remote instance.
  * Returns the local filename on success, or null on failure.
  * On failure, the caller stores the absolute URL as a display fallback.
@@ -104,7 +113,10 @@ export async function downloadProfileAsset(
   const finalPath = path.join(config.uploadDir, finalFilename);
 
   try {
-    const response = await fetch(url, {
+    // safeFetch, not fetch: the hostname check above constrains the FIRST hop
+    // only, and bare fetch follows redirects without re-checking. safeFetch
+    // re-validates every hop, so a 302 into the local network is refused.
+    const response = await safeFetch(url, {
       signal: AbortSignal.timeout(10_000),
     });
 
@@ -119,11 +131,34 @@ export async function downloadProfileAsset(
       return null;
     }
 
+    // Content-Length is a claim, not a guarantee, but when it is present and
+    // already over the cap there is no reason to open the file at all.
+    const declared = Number(response.headers.get('content-length') ?? '');
+    if (Number.isFinite(declared) && declared > MAX_PROFILE_ASSET_BYTES) {
+      console.warn(`[federation] Profile asset rejected: declared ${declared} bytes exceeds cap`);
+      return null;
+    }
+
     // Ensure upload directory exists
     fs.mkdirSync(config.uploadDir, { recursive: true });
 
-    // Stream to temp file
-    const nodeStream = Readable.fromWeb(response.body as ReadableStream);
+    // Stream to temp file, counting bytes, so the cap is enforced on what
+    // actually arrives rather than on what the peer said it would send. The
+    // controller.error() below rejects the pipeline, and the catch block
+    // removes the partial temp file.
+    let received = 0;
+    const capped = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        received += chunk.byteLength;
+        if (received > MAX_PROFILE_ASSET_BYTES) {
+          controller.error(new Error('Profile asset exceeds size cap'));
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    });
+
+    const nodeStream = Readable.fromWeb(response.body.pipeThrough(capped) as ReadableStream);
     const writeStream = fs.createWriteStream(tempPath);
     await pipeline(nodeStream, writeStream);
 

--- a/packages/server/src/routes/users.ts
+++ b/packages/server/src/routes/users.ts
@@ -11,6 +11,7 @@ import { deleteUploadFile, deleteAttachmentByFilename } from '../utils/fileClean
 import { tombstoneUser, collectDeletionBroadcastTargets, collectProfileBroadcastTargetIds } from '../utils/userDeletion.js';
 import { queueOutboxEvent, isFederationRelayEnabled, appendMutationLog } from '../utils/federationOutbox.js';
 import { generateSnowflake } from '../utils/snowflake.js';
+import { federationFetch } from '../utils/federationFetch.js';
 import { resizeProfileImage } from '../utils/thumbnail.js';
 import { config } from '../config.js';
 import { buildFederationHeaders, getOurOrigin, normalizeOriginForCompare, canonicalizeHomeInstance } from '../utils/federationAuth.js';
@@ -843,12 +844,14 @@ export async function userRoutes(app: FastifyInstance): Promise<void> {
           const timeout = setTimeout(() => controller.abort(), 15_000);
 
           try {
-            const response = await fetch(`${origin}/api/federation/identity`, {
+            // 'approved': the block above refused anything without a
+            // matching federation_peers row in 'active'.
+            const response = await federationFetch(origin, '/api/federation/identity', {
               method: 'DELETE',
               headers,
               body,
               signal: controller.signal,
-            });
+            }, 'approved');
 
             clearTimeout(timeout);
 

--- a/packages/server/src/utils/federationAttach.ts
+++ b/packages/server/src/utils/federationAttach.ts
@@ -1,4 +1,5 @@
 import { buildFederationHeaders, verifySignature, getOurOrigin } from './federationAuth.js';
+import { federationFetch } from './federationFetch.js';
 
 export interface PeerForAttach {
   origin: string;
@@ -21,12 +22,12 @@ export async function verifyAttachProofWithPeer(
 
   let res: Response;
   try {
-    res = await fetch(`${peer.origin}/api/federation/verify-attach-proof`, {
+    res = await federationFetch(peer.origin, '/api/federation/verify-attach-proof', {
       method: 'POST',
       headers,
       body,
       signal: AbortSignal.timeout(10_000),
-    });
+    }, 'approved');
   } catch {
     return { valid: false };
   }
@@ -75,12 +76,12 @@ export async function fetchHomeProfileByHomeId(
 
   let res: Response;
   try {
-    res = await fetch(`${peer.origin}/api/federation/users/by-home-id`, {
+    res = await federationFetch(peer.origin, '/api/federation/users/by-home-id', {
       method: 'POST',
       headers,
       body,
       signal: AbortSignal.timeout(10_000),
-    });
+    }, 'approved');
   } catch {
     return null;
   }

--- a/packages/server/src/utils/federationEpoch.ts
+++ b/packages/server/src/utils/federationEpoch.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { getDb, schema } from '../db/index.js';
 import { buildFederationHeaders, verifySignature, getOurOrigin } from './federationAuth.js';
+import { federationFetch } from './federationFetch.js';
 
 let cached: string | null = null;
 
@@ -50,12 +51,12 @@ export async function fetchPeerEpoch(peer: PeerForEpoch): Promise<string | null>
 
   let res: Response;
   try {
-    res = await fetch(`${peer.origin}/api/federation/epoch`, {
+    res = await federationFetch(peer.origin, '/api/federation/epoch', {
       method: 'POST',
       headers,
       body,
       signal: AbortSignal.timeout(10000),
-    });
+    }, 'approved');
   } catch {
     // Network error / timeout — benign no-op, retry later.
     return null;

--- a/packages/server/src/utils/federationFetch.test.ts
+++ b/packages/server/src/utils/federationFetch.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const lookup = vi.fn<(host: string) => Promise<{ address: string; family: number }>>();
+vi.mock('dns', () => ({ default: { promises: { lookup: (h: string) => lookup(h) } } }));
+
+const allowPrivate = vi.fn<() => boolean>(() => false);
+vi.mock('../config.js', () => ({
+  config: { get federation() { return { allowPrivatePeers: allowPrivate() }; } },
+}));
+
+const { assertPeerOriginAllowed, federationFetch } = await import('./federationFetch.js');
+
+// Block bodies, never concise arrows: a concise arrow returns the mock, and
+// Vitest treats a value returned from a hook as a teardown callback it then
+// invokes with no arguments after every test.
+describe('assertPeerOriginAllowed', () => {
+  beforeEach(() => {
+    lookup.mockReset();
+    allowPrivate.mockReset().mockReturnValue(false);
+  });
+
+  it('refuses a private address asserted by a stranger', async () => {
+    lookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+    await expect(assertPeerOriginAllowed('http://localhost:3000', 'asserted'))
+      .rejects.toThrow(/not reachable on the public internet/);
+  });
+
+  it('refuses a v4-mapped private address asserted by a stranger', async () => {
+    lookup.mockResolvedValue({ address: '::ffff:a9fe:a9fe', family: 6 });
+    await expect(assertPeerOriginAllowed('https://metadata.test', 'asserted'))
+      .rejects.toThrow(/not reachable on the public internet/);
+  });
+
+  it('refuses an asserted origin that does not resolve', async () => {
+    lookup.mockRejectedValue(Object.assign(new Error('nope'), { code: 'ENOTFOUND' }));
+    await expect(assertPeerOriginAllowed('https://gone.test', 'asserted'))
+      .rejects.toThrow(/did not resolve/);
+  });
+
+  it('allows a public address asserted by a stranger', async () => {
+    lookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(assertPeerOriginAllowed('https://peer.test', 'asserted')).resolves.toBeUndefined();
+    expect(lookup).toHaveBeenCalledWith('peer.test');
+  });
+
+  it('allows a private address for a peer an admin approved', async () => {
+    lookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+    await expect(assertPeerOriginAllowed('http://localhost:3000', 'approved')).resolves.toBeUndefined();
+    // The approved path must not spend a DNS round trip it does not need. This
+    // also pins that 'approved' short-circuits rather than merely tolerating
+    // whatever the resolver happened to answer.
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('allows a private asserted address once the operator opts in', async () => {
+    allowPrivate.mockReturnValue(true);
+    lookup.mockResolvedValue({ address: '192.168.1.50', family: 4 });
+    await expect(assertPeerOriginAllowed('http://nas.local:3000', 'asserted')).resolves.toBeUndefined();
+  });
+
+  it('strips brackets from an IPv6 literal origin before resolving', async () => {
+    lookup.mockImplementation(async (host: string) => {
+      if (host.startsWith('[')) throw Object.assign(new Error('nope'), { code: 'ENOTFOUND' });
+      return { address: host, family: 6 };
+    });
+    await expect(assertPeerOriginAllowed('http://[::1]:3000', 'asserted'))
+      .rejects.toThrow(/not reachable on the public internet/);
+    expect(lookup).toHaveBeenCalledWith('::1');
+  });
+
+  it('refuses a non-http scheme at either trust level', async () => {
+    for (const trust of ['approved', 'asserted'] as const) {
+      await expect(assertPeerOriginAllowed('file:///etc/passwd', trust)).rejects.toThrow(/scheme/i);
+    }
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unparseable origin at either trust level', async () => {
+    for (const trust of ['approved', 'asserted'] as const) {
+      await expect(assertPeerOriginAllowed('not a url', trust)).rejects.toThrow(/Invalid peer origin/);
+    }
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('refuses an origin carrying a path, query or fragment', async () => {
+    await expect(assertPeerOriginAllowed('https://peer.test/api/x', 'approved')).rejects.toThrow(/origin/i);
+    await expect(assertPeerOriginAllowed('https://peer.test?a=1', 'approved')).rejects.toThrow(/origin/i);
+    await expect(assertPeerOriginAllowed('https://peer.test#f', 'approved')).rejects.toThrow(/origin/i);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});
+
+describe('federationFetch', () => {
+  const transport = vi.fn<(input: string, init?: RequestInit) => Promise<Response>>();
+
+  beforeEach(() => {
+    lookup.mockReset();
+    allowPrivate.mockReset().mockReturnValue(false);
+    transport.mockReset().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', transport);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not issue the request when the gate refuses the origin', async () => {
+    lookup.mockResolvedValue({ address: '127.0.0.1', family: 4 });
+    await expect(
+      federationFetch('http://localhost:3000', '/api/federation/relay', { method: 'POST' }, 'asserted'),
+    ).rejects.toThrow(/not reachable on the public internet/);
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it('joins the path onto the origin and keeps the caller init', async () => {
+    lookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    const signal = AbortSignal.timeout(5_000);
+    await federationFetch(
+      'https://peer.test',
+      '/api/federation/relay',
+      { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}', signal },
+      'asserted',
+    );
+    expect(transport).toHaveBeenCalledTimes(1);
+    const [target, init] = transport.mock.calls[0]!;
+    expect(target).toBe('https://peer.test/api/federation/relay');
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBe('{}');
+    expect(init?.signal).toBe(signal);
+  });
+
+  it('does not follow redirects', async () => {
+    lookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    transport.mockResolvedValue(
+      new Response(null, { status: 302, headers: { location: 'http://127.0.0.1:9200/x' } }),
+    );
+    const res = await federationFetch('https://peer.test', '/api/federation/epoch', {}, 'approved');
+    expect(res.status).toBe(302);
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(transport.mock.calls[0]![1]?.redirect).toBe('manual');
+  });
+});

--- a/packages/server/src/utils/federationFetch.ts
+++ b/packages/server/src/utils/federationFetch.ts
@@ -1,0 +1,88 @@
+import dns from 'dns';
+import { classifyAddress } from './ipClass.js';
+import { config } from '../config.js';
+
+/**
+ * How much this instance knows about where a peer origin came from.
+ *
+ * 'approved': the origin was read out of a `federation_peers` row, or it
+ *   arrived in the body of an admin-authenticated request. Any address is
+ *   allowed: peering across a LAN is a supported deployment shape and the
+ *   two-instance test harness peers on loopback.
+ * 'asserted': the origin was supplied by someone with no established peering
+ *   relationship. A peering-request body, a friend handle a user typed, an
+ *   expiry or denial callback to a request that was never accepted. It must
+ *   resolve to a publicly routable address, otherwise the party that supplied
+ *   it chooses which hosts this instance connects to.
+ *
+ * The two levels are not circular. A `federation_peers` row is only reachable
+ * because the outbound path that created it was itself gated: either an admin
+ * typed the origin, or the handshake ran under 'asserted'.
+ */
+export type OriginTrust = 'approved' | 'asserted';
+
+/**
+ * Throw if this origin may not be fetched at the given trust level.
+ *
+ * Format checks run at both levels: a malformed origin, a non-http scheme, or
+ * an origin carrying a path is a bug worth surfacing wherever it comes from.
+ * Address classification runs only for 'asserted', and only while
+ * FEDERATION_ALLOW_PRIVATE_PEERS is off.
+ */
+export async function assertPeerOriginAllowed(origin: string, trust: OriginTrust): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    throw new Error(`Invalid peer origin: ${origin}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Invalid peer origin scheme: ${parsed.protocol}`);
+  }
+
+  // An origin is scheme + host + port and nothing more. A value carrying a
+  // path, query or fragment is either a bug in whatever wrote it or an attempt
+  // to address one specific endpoint, so refuse it before it is joined to a
+  // federation path.
+  if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '') {
+    throw new Error('Invalid peer origin: must carry no path, query or fragment');
+  }
+
+  if (trust === 'approved') return;
+  if (config.federation.allowPrivatePeers) return;
+
+  // URL.hostname keeps the brackets around an IPv6 literal, and dns.lookup does
+  // not accept them.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+
+  let address: string;
+  try {
+    address = (await dns.promises.lookup(hostname)).address;
+  } catch {
+    throw new Error(`Peer origin did not resolve: ${parsed.origin}`);
+  }
+
+  if (classifyAddress(address) !== 'public') {
+    throw new Error(`Peer origin is not reachable on the public internet: ${parsed.origin}`);
+  }
+}
+
+/**
+ * The single outbound path for a request addressed to a peer instance.
+ *
+ * Redirects are not followed. Every federation endpoint answers directly, so a
+ * 3xx from a peer is a misconfiguration or an attempt to move the request
+ * elsewhere; callers see the 3xx and handle it through their existing
+ * non-2xx branch.
+ */
+export async function federationFetch(
+  origin: string,
+  path: string,
+  init: RequestInit,
+  trust: OriginTrust,
+): Promise<Response> {
+  await assertPeerOriginAllowed(origin, trust);
+  const target = new URL(path, origin).toString();
+  return fetch(target, { ...init, redirect: 'manual' });
+}

--- a/packages/server/src/utils/federationLookup.ts
+++ b/packages/server/src/utils/federationLookup.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import { getDb } from '../db/index.js';
 import * as schema from '../db/schema.js';
 import { buildFederationHeaders, getOurOrigin } from './federationAuth.js';
+import { federationFetch } from './federationFetch.js';
 import type { FederationUserLookupProfile, FederationUserLookupResponse } from '@backspace/shared';
 
 const LOOKUP_TIMEOUT_MS = 10_000;
@@ -38,12 +39,12 @@ export async function lookupRemoteUser(peerOrigin: string, username: string): Pr
 
   let response: Response;
   try {
-    response = await fetch(`${peerOrigin}/api/federation/users/lookup`, {
+    response = await federationFetch(peerOrigin, '/api/federation/users/lookup', {
       method: 'POST',
       headers,
       body,
       signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
-    });
+    }, 'approved');
   } catch {
     // Network error, timeout, AbortError — all unreachable.
     return { ok: false, reason: 'unreachable' };
@@ -112,12 +113,12 @@ export async function lookupRemoteUserByHomeId(peerOrigin: string, homeUserId: s
 
   let response: Response;
   try {
-    response = await fetch(`${peerOrigin}/api/federation/users/by-home-id`, {
+    response = await federationFetch(peerOrigin, '/api/federation/users/by-home-id', {
       method: 'POST',
       headers,
       body,
       signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
-    });
+    }, 'approved');
   } catch {
     return { ok: false, reason: 'unreachable' };
   }

--- a/packages/server/src/utils/federationOutbox.ts
+++ b/packages/server/src/utils/federationOutbox.ts
@@ -7,6 +7,7 @@ import type { FederationRelayEvent, FederationRelayParticipant, FederationRelayA
 import { getOurOrigin, buildFederationHeaders } from './federationAuth.js';
 import { extractDomain } from '../routes/federation.js';
 import { racePeering, ensurePeered, createAutoPlaceholderPeer } from './federationPeering.js';
+import { federationFetch } from './federationFetch.js';
 
 // ─── Settings Cache ──────────────────────────────────────────────────────────
 
@@ -693,12 +694,12 @@ export async function sendCallRelay(
   const headers = buildFederationHeaders(bodyStr, signingSecret, ourOrigin);
 
   try {
-    const res = await fetch(`${targetPeerOrigin}/api/federation/relay`, {
+    const res = await federationFetch(targetPeerOrigin, '/api/federation/relay', {
       method: 'POST',
       headers,
       body: bodyStr,
       signal: AbortSignal.timeout(10_000),
-    });
+    }, 'approved');
 
     if (res.ok) {
       // Parse response body to surface the undeliverable bucket. Old peers

--- a/packages/server/src/utils/federationPeerActivation.ts
+++ b/packages/server/src/utils/federationPeerActivation.ts
@@ -3,6 +3,7 @@ import * as schema from '../db/schema.js';
 import { and, eq } from 'drizzle-orm';
 import { isFederationRelayEnabled } from './federationOutbox.js';
 import { buildFederationHeaders, getOurOrigin } from './federationAuth.js';
+import { federationFetch } from './federationFetch.js';
 import { generateSnowflake } from './snowflake.js';
 import { healResetIncarnation } from './federationReset.js';
 import type { FederationRelayEvent } from '@backspace/shared';
@@ -169,10 +170,10 @@ export async function syncPeerMutationLog(
       if (contextType) bodyObj.contextType = contextType;
       const body = JSON.stringify(bodyObj);
       const headers = buildFederationHeaders(body, signingSecret, ourOrigin);
-      const resp = await fetch(`${activePeer.origin}/api/federation/sync`, {
+      const resp = await federationFetch(activePeer.origin, '/api/federation/sync', {
         method: 'POST', headers, body,
         signal: AbortSignal.timeout(30_000),
-      });
+      }, 'approved');
       if (!resp.ok) {
         console.warn(`[federation] Sync-pull ${contextType ?? 'dm'} pass HTTP ${resp.status} for ${activePeer.origin}`);
         return false;

--- a/packages/server/src/utils/federationPeering.approvalToken.test.ts
+++ b/packages/server/src/utils/federationPeering.approvalToken.test.ts
@@ -15,6 +15,14 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These suites use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   schema,

--- a/packages/server/src/utils/federationPeering.instanceName.test.ts
+++ b/packages/server/src/utils/federationPeering.instanceName.test.ts
@@ -15,6 +15,14 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These suites use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   schema,

--- a/packages/server/src/utils/federationPeering.outboundGate.test.ts
+++ b/packages/server/src/utils/federationPeering.outboundGate.test.ts
@@ -15,6 +15,22 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These cases use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address — except for the one
+// host the last case uses to drive the gate itself.
+const LOOPBACK_HOST = 'lan-only.example';
+vi.mock('dns', () => ({
+  default: {
+    promises: {
+      lookup: async (host: string) => (host === LOOPBACK_HOST
+        ? { address: '127.0.0.1', family: 4 }
+        : { address: '93.184.216.34', family: 4 }),
+    },
+  },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   schema,
@@ -524,5 +540,35 @@ describe('ensurePeered — outbound gate behavior across (autoAccept × peer-row
     expect(parents).toHaveLength(1);
     expect(parents[0]!.direction).toBe('outbound');
     expect(parents[0]!.origin).toBe('https://orbit.example');
+  });
+
+  // ─── Gate placement ─────────────────────────────────────────────────────
+  // Not a restatement of federationFetch.test.ts. That suite proves the gate
+  // decides correctly; this one proves performHandshake actually goes through
+  // it, which no assertion about the gate module can show. Against the code
+  // before the gate existed, fetch is called and the status is 'failed' for a
+  // transport reason, so both assertions below flip.
+  it('refuses to send the handshake to an origin that resolves onto the local network', async () => {
+    seedInstanceSettings(1);
+    seedUser('user1', 'alice');
+
+    const fetchSpy = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { ensurePeered } = await import('./federationPeering.js');
+    const result = await ensurePeered(`https://${LOOPBACK_HOST}`, {
+      kind: 'user_action',
+      userId: 'user1',
+      reason: 'friend_add',
+      target: `bob@${LOOPBACK_HOST}`,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.status === 'failed' && result.error).toMatch(/not reachable on the public internet/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // The placeholder row performHandshake creates is rolled back the same way
+    // a transport failure rolls it back, so a refused origin leaves no trace.
+    expect(testDb.select().from(schema.federationPeers).all()).toHaveLength(0);
   });
 });

--- a/packages/server/src/utils/federationPeering.ts
+++ b/packages/server/src/utils/federationPeering.ts
@@ -6,6 +6,7 @@ import { getOurOrigin, generateHmacSecret } from './federationAuth.js';
 import { validateOrigin } from '../routes/federation.js';
 import { onPeerActivated, onPeerDeactivated } from './federationPeerActivation.js';
 import { getInstanceId } from './federationEpoch.js';
+import { federationFetch } from './federationFetch.js';
 import type { EnsurePeeredCallerIntent } from '@backspace/shared';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -413,7 +414,11 @@ async function performHandshake(
   }
 
   try {
-    const response = await fetch(`${origin}/api/federation/peer/accept`, {
+    // 'asserted': performHandshake only runs when no settled peer row exists,
+    // and its origin reaches here from a handle a user typed (friend-add,
+    // POST /peer/ensure) or from a placeholder row local traffic created. No
+    // admin has named it, so it must be publicly routable.
+    const response = await federationFetch(origin, '/api/federation/peer/accept', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -423,7 +428,7 @@ async function performHandshake(
         instanceId: getInstanceId(),
       }),
       signal: AbortSignal.timeout(10_000),
-    });
+    }, 'asserted');
 
     if (response.status === 202) {
       // Capture the approval token from the 202 body if present. Stored on

--- a/packages/server/src/utils/federationRecovery.ts
+++ b/packages/server/src/utils/federationRecovery.ts
@@ -3,6 +3,7 @@ import * as schema from '../db/schema.js';
 import { and, eq, isNotNull, isNull, ne, or } from 'drizzle-orm';
 import { onPeerActivated } from './federationPeerActivation.js';
 import { markPeerReset } from './federationReset.js';
+import { federationFetch } from './federationFetch.js';
 
 /** Reachability-probe timeout (ms). */
 export const RECOVERY_PROBE_TIMEOUT_MS = 10_000;
@@ -32,9 +33,12 @@ export interface ProbeResult {
 export async function probePeerReachable(origin: string, signal?: AbortSignal): Promise<ProbeResult> {
   try {
     const timeout = AbortSignal.timeout(RECOVERY_PROBE_TIMEOUT_MS);
-    const response = await fetch(`${origin}/api/instance/info`, {
+    // 'approved': both callers pass a federation_peers row's origin (the
+    // recovery tick iterates 'unreachable' rows; the manual recheck route is
+    // admin-only), so a private peer address stays probeable.
+    const response = await federationFetch(origin, '/api/instance/info', {
       signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
-    });
+    }, 'approved');
     if (!response.ok) {
       return { reachable: false, instanceId: null };
     }

--- a/packages/server/src/utils/federationWorker.ts
+++ b/packages/server/src/utils/federationWorker.ts
@@ -11,6 +11,7 @@ import { getDmMessageWithUser } from '../routes/dm.js';
 import { connectionManager } from '../ws/handler.js';
 import { generateThumbnail } from './thumbnail.js';
 import { safeFetch } from './ssrf.js';
+import { federationFetch } from './federationFetch.js';
 import type { FederationRelayRequest, FederationRelayResponse, FederationRelayEvent } from '@backspace/shared';
 import { startupBootstrapSync, onPeerDeactivated } from './federationPeerActivation.js';
 import { probePeerReachable, recoverOrDetectReset, detectResetOnNeedsAttentionPeers, detectResetForPeer } from './federationRecovery.js';
@@ -251,7 +252,7 @@ export async function processOutboxTick(): Promise<void> {
     outboxAbortController = new AbortController();
 
     try {
-      const response = await fetch(`${peerOrigin}/api/federation/relay`, {
+      const response = await federationFetch(peerOrigin, '/api/federation/relay', {
         method: 'POST',
         headers,
         body: bodyString,
@@ -259,7 +260,7 @@ export async function processOutboxTick(): Promise<void> {
           outboxAbortController.signal,
           AbortSignal.timeout(OUTBOX_FETCH_TIMEOUT_MS),
         ]),
-      });
+      }, 'approved');
 
       if (response.ok) {
         const result = await response.json() as FederationRelayResponse;
@@ -1169,12 +1170,12 @@ async function processHealthCheckTick(): Promise<void> {
       const rotateBody = JSON.stringify({ newSecret });
       const headers = buildFederationHeaders(rotateBody, peer.hmacSecret, ourOrigin);
 
-      const response = await fetch(`${peer.origin}/api/federation/peer/rotate`, {
+      const response = await federationFetch(peer.origin, '/api/federation/peer/rotate', {
         method: 'POST',
         headers,
         body: rotateBody,
         signal: AbortSignal.timeout(10_000),
-      });
+      }, 'approved');
 
       if (response.ok) {
         // Store pending locally AFTER remote peer confirms acceptance

--- a/packages/server/src/utils/ipClass.test.ts
+++ b/packages/server/src/utils/ipClass.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { classifyAddress, isPublicAddress, type AddressClass } from './ipClass.js';
+
+// Each row is [address, expected class, why it matters]. The third column is
+// not decoration: it is what tells a future reader whether deleting a row is
+// safe. Rows marked (regression) were returning 'public' before this change.
+const CASES: Array<[string, AddressClass, string]> = [
+  // --- IPv4 ---
+  ['127.0.0.1', 'loopback', 'the obvious one'],
+  ['127.255.255.254', 'loopback', 'whole /8, not just 127.0.0.x'],
+  ['0.0.0.0', 'unspecified', 'binds to every interface'],
+  ['0.1.2.3', 'reserved', '0.0.0.0/8 this-network'],
+  ['10.0.0.1', 'private', 'RFC1918'],
+  ['172.15.255.255', 'public', 'just below the /12: must NOT be caught'],
+  ['172.16.0.1', 'private', 'RFC1918 lower bound'],
+  ['172.31.255.255', 'private', 'RFC1918 upper bound'],
+  ['172.32.0.1', 'public', 'just above the /12: must NOT be caught'],
+  ['192.168.1.1', 'private', 'RFC1918'],
+  ['169.254.169.254', 'link-local', 'cloud instance metadata'],
+  ['100.64.0.1', 'cgnat', '(regression) RFC6598'],
+  ['100.127.255.255', 'cgnat', '(regression) /10 upper bound'],
+  ['100.128.0.1', 'public', 'just above the /10: must NOT be caught'],
+  ['224.0.0.1', 'multicast', 'RFC5771'],
+  ['255.255.255.255', 'reserved', 'broadcast'],
+  ['8.8.8.8', 'public', 'the control: a real public address'],
+
+  // --- IPv6 ---
+  ['::1', 'loopback', 'the obvious one'],
+  ['::', 'unspecified', '(regression) connects to loopback on most stacks'],
+  ['fc00::1', 'private', 'unique local'],
+  ['fd12:3456::1', 'private', 'unique local'],
+  ['fe80::1', 'link-local', 'was caught only by the literal prefix'],
+  ['fe9a::1', 'link-local', '(regression) fe80::/10 is fe80-febf, not "fe80"'],
+  ['febf:ffff::1', 'link-local', '(regression) /10 upper bound'],
+  ['fec0::1', 'public', 'just above the /10: must NOT be caught'],
+  ['ff02::1', 'multicast', 'all-nodes'],
+  ['2606:4700::1111', 'public', 'the control: a real public address'],
+
+  // --- IPv4-mapped IPv6: both spellings, because both occur ---
+  ['::ffff:7f00:1', 'loopback', '(regression) hex form, what the URL parser emits'],
+  ['::ffff:127.0.0.1', 'loopback', '(regression) dotted form, what inet_ntop emits'],
+  ['::ffff:a00:1', 'private', '(regression) 10.0.0.1 mapped, hex'],
+  ['::ffff:10.0.0.1', 'private', '(regression) 10.0.0.1 mapped, dotted'],
+  ['::ffff:a9fe:a9fe', 'link-local', '(regression) 169.254.169.254 mapped'],
+  ['::ffff:808:808', 'public', 'a mapped PUBLIC address must stay public'],
+
+  // --- garbage ---
+  ['', 'reserved', 'empty string must not fall through to public'],
+  ['not-an-ip', 'reserved', 'unparseable must not fall through to public'],
+  ['999.1.1.1', 'reserved', 'out-of-range octet must not fall through to public'],
+];
+
+describe('classifyAddress', () => {
+  for (const [addr, expected, why] of CASES) {
+    it(`${addr || '(empty)'} -> ${expected} (${why})`, () => {
+      expect(classifyAddress(addr)).toBe(expected);
+    });
+  }
+});
+
+describe('isPublicAddress', () => {
+  it('is true only for the public rows', () => {
+    for (const [addr, expected] of CASES) {
+      expect(isPublicAddress(addr), addr).toBe(expected === 'public');
+    }
+  });
+
+  it('fails closed on anything it cannot parse', () => {
+    expect(isPublicAddress('::ffff:')).toBe(false);
+    expect(isPublicAddress('1.2.3')).toBe(false);
+    expect(isPublicAddress('0x7f000001')).toBe(false);
+  });
+});

--- a/packages/server/src/utils/ipClass.ts
+++ b/packages/server/src/utils/ipClass.ts
@@ -1,0 +1,145 @@
+/**
+ * Address classification for outbound-request safety.
+ *
+ * Pure and I/O-free on purpose: the SSRF path does DNS, which makes its tests
+ * slow and dependent on the host resolver. Range membership does not, so it is
+ * tested exhaustively here instead.
+ *
+ * Everything unparseable classifies as 'reserved', never 'public'. A classifier
+ * that answers "public" when it does not understand its input is worse than no
+ * classifier, because callers treat 'public' as permission.
+ */
+export type AddressClass =
+  | 'public'
+  | 'loopback'
+  | 'private'
+  | 'link-local'
+  | 'cgnat'
+  | 'unspecified'
+  | 'multicast'
+  | 'reserved';
+
+/** Parse dotted-quad IPv4 into four octets. Strict: rejects leading zeros. */
+function parseIpv4(ip: string): [number, number, number, number] | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^(0|[1-9][0-9]{0,2})$/.test(part)) return null;
+    const value = Number(part);
+    if (value > 255) return null;
+    octets.push(value);
+  }
+  return [octets[0]!, octets[1]!, octets[2]!, octets[3]!];
+}
+
+/**
+ * Unwrap an IPv4-mapped IPv6 address to its dotted-quad form.
+ *
+ * Both spellings occur and neither is exotic: the WHATWG URL parser emits the
+ * hex form (`::ffff:7f00:1`) while glibc's inet_ntop emits the dotted form
+ * (`::ffff:127.0.0.1`). Handling one and not the other leaves the hole open on
+ * whichever resolution path you did not test.
+ */
+function unmapIpv4(ip: string): string | null {
+  const match = /^::ffff:([0-9a-f.:]+)$/i.exec(ip);
+  if (!match) return null;
+  const tail = match[1]!;
+
+  if (tail.includes('.')) {
+    return parseIpv4(tail) ? tail : null;
+  }
+
+  const groups = tail.split(':');
+  if (groups.length < 1 || groups.length > 2) return null;
+  const values: number[] = [];
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/i.test(group)) return null;
+    values.push(Number.parseInt(group, 16));
+  }
+  // A single group is the low half: `::ffff:1` is 0.0.0.1.
+  const [hi, lo] = values.length === 2 ? [values[0]!, values[1]!] : [0, values[0]!];
+  return [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join('.');
+}
+
+function classifyIpv4(octets: [number, number, number, number]): AddressClass {
+  const [a, b] = octets;
+  if (a === 0) return octets.every(o => o === 0) ? 'unspecified' : 'reserved';
+  if (a === 127) return 'loopback';
+  if (a === 10) return 'private';
+  if (a === 172 && b >= 16 && b <= 31) return 'private';
+  if (a === 192 && b === 168) return 'private';
+  if (a === 169 && b === 254) return 'link-local';
+  if (a === 100 && b >= 64 && b <= 127) return 'cgnat';
+  if (a === 192 && b === 0 && octets[2] === 0) return 'reserved';    // IETF protocol assignments
+  if (a === 192 && b === 0 && octets[2] === 2) return 'reserved';    // TEST-NET-1
+  if (a === 198 && (b === 18 || b === 19)) return 'reserved';        // benchmarking
+  if (a === 198 && b === 51 && octets[2] === 100) return 'reserved'; // TEST-NET-2
+  if (a === 203 && b === 0 && octets[2] === 113) return 'reserved';  // TEST-NET-3
+  if (a >= 224 && a <= 239) return 'multicast';
+  if (a >= 240) return 'reserved';                                   // includes 255.255.255.255
+  return 'public';
+}
+
+/** Expand an IPv6 address to its eight 16-bit groups. Returns null if malformed. */
+function parseIpv6(ip: string): number[] | null {
+  if (!/^[0-9a-f:]+$/i.test(ip)) return null;
+  const halves = ip.split('::');
+  if (halves.length > 2) return null;
+
+  const toGroups = (part: string): number[] | null => {
+    if (part === '') return [];
+    const out: number[] = [];
+    for (const group of part.split(':')) {
+      if (!/^[0-9a-f]{1,4}$/i.test(group)) return null;
+      out.push(Number.parseInt(group, 16));
+    }
+    return out;
+  };
+
+  if (halves.length === 1) {
+    const groups = toGroups(halves[0]!);
+    return groups && groups.length === 8 ? groups : null;
+  }
+
+  const head = toGroups(halves[0]!);
+  const tail = toGroups(halves[1]!);
+  if (!head || !tail) return null;
+  const fill = 8 - head.length - tail.length;
+  if (fill < 0) return null;
+  return [...head, ...new Array<number>(fill).fill(0), ...tail];
+}
+
+export function classifyAddress(ip: string): AddressClass {
+  if (typeof ip !== 'string' || ip === '') return 'reserved';
+  const address = ip.trim().replace(/^\[|\]$/g, '');
+
+  const v4 = parseIpv4(address);
+  if (v4) return classifyIpv4(v4);
+
+  const mapped = unmapIpv4(address);
+  if (mapped) {
+    const parsed = parseIpv4(mapped);
+    return parsed ? classifyIpv4(parsed) : 'reserved';
+  }
+
+  const groups = parseIpv6(address);
+  if (!groups) return 'reserved';
+
+  if (groups.every(g => g === 0)) return 'unspecified';
+  if (groups.slice(0, 7).every(g => g === 0) && groups[7] === 1) return 'loopback';
+
+  const first = groups[0]!;
+  if ((first & 0xfe00) === 0xfc00) return 'private';      // fc00::/7
+  if ((first & 0xffc0) === 0xfe80) return 'link-local';   // fe80::/10
+  if ((first & 0xff00) === 0xff00) return 'multicast';    // ff00::/8
+  return 'public';
+}
+
+/**
+ * The only predicate callers should use. Fails closed: anything that does not
+ * classify cleanly as 'public' is refused.
+ */
+export function isPublicAddress(ip: string): boolean {
+  return classifyAddress(ip) === 'public';
+}

--- a/packages/server/src/utils/ssrf.test.ts
+++ b/packages/server/src/utils/ssrf.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const lookup = vi.fn<(host: string) => Promise<{ address: string; family: number }>>();
+vi.mock('dns', () => ({ default: { promises: { lookup: (h: string) => lookup(h) } } }));
+
+const { validateExternalUrl, isPrivateIp } = await import('./ssrf.js');
+
+describe('isPrivateIp', () => {
+  it('still answers the addresses it always answered', () => {
+    expect(isPrivateIp('127.0.0.1')).toBe(true);
+    expect(isPrivateIp('10.1.2.3')).toBe(true);
+    expect(isPrivateIp('8.8.8.8')).toBe(false);
+  });
+
+  it('answers the ones it used to miss', () => {
+    for (const ip of ['::ffff:7f00:1', '::ffff:127.0.0.1', '::', '100.64.0.1', 'fe9a::1']) {
+      expect(isPrivateIp(ip), ip).toBe(true);
+    }
+  });
+});
+
+describe('validateExternalUrl', () => {
+  // Block bodies, not concise arrows: a hook that RETURNS a function has that
+  // function registered as a teardown callback and invoked with no arguments at
+  // the end of the test. `mockReset()` returns the mock, so `() => m.mockReset()`
+  // silently calls the mock once per test — which an implementation that reads
+  // its argument then trips over.
+  beforeEach(() => {
+    lookup.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects a hostname whose AAAA record is a v4-mapped loopback', async () => {
+    lookup.mockResolvedValue({ address: '::ffff:7f00:1', family: 6 });
+    await expect(validateExternalUrl('https://rebind.example/x')).rejects.toThrow('Private IP not allowed');
+  });
+
+  it('rejects a hostname resolving into CGNAT', async () => {
+    lookup.mockResolvedValue({ address: '100.64.9.9', family: 4 });
+    await expect(validateExternalUrl('https://cgnat.example/x')).rejects.toThrow('Private IP not allowed');
+  });
+
+  it('accepts a public address', async () => {
+    lookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(validateExternalUrl('https://example.com/x')).resolves.toBeUndefined();
+  });
+
+  it('strips brackets before resolving, so an IPv6 literal is understood rather than accidentally ENOTFOUND', async () => {
+    lookup.mockImplementation(async (host: string) => {
+      // The old code passed '[::1]' straight to dns.lookup, which threw
+      // ENOTFOUND and produced the right answer for the wrong reason.
+      if (host.startsWith('[')) throw Object.assign(new Error('nope'), { code: 'ENOTFOUND' });
+      return { address: host, family: 6 };
+    });
+    await expect(validateExternalUrl('http://[::1]/x')).rejects.toThrow('Private IP not allowed');
+    expect(lookup).toHaveBeenCalledWith('::1');
+  });
+
+  it('lets a public IPv6 literal through, which it could not before', async () => {
+    lookup.mockImplementation(async (host: string) => ({ address: host, family: 6 }));
+    await expect(validateExternalUrl('https://[2606:4700::1111]/x')).resolves.toBeUndefined();
+    // The resolve alone is not evidence: with a doubled resolver the old code
+    // also resolved, because the bracketed string matched none of its prefixes.
+    // What the old code could not do is hand the resolver an address it could
+    // actually look up, so assert on the argument.
+    expect(lookup).toHaveBeenCalledWith('2606:4700::1111');
+  });
+
+  it('refuses non-http schemes before touching DNS', async () => {
+    await expect(validateExternalUrl('file:///etc/passwd')).rejects.toThrow('Invalid URL scheme');
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/utils/ssrf.ts
+++ b/packages/server/src/utils/ssrf.ts
@@ -1,18 +1,15 @@
 import dns from 'dns';
+import { classifyAddress } from './ipClass.js';
 
+/**
+ * True for any address that is not safely routable on the public internet.
+ *
+ * Kept as a named export with its original signature: four modules import it
+ * and `spaceInviteSnapshot.test.ts` mocks it by name. The classification moved
+ * to ipClass.ts; this is the adapter.
+ */
 export function isPrivateIp(ip: string): boolean {
-  // IPv4
-  if (ip.startsWith('127.') || ip.startsWith('0.') || ip === '0.0.0.0') return true;
-  if (ip.startsWith('10.')) return true;
-  if (ip.startsWith('192.168.')) return true;
-  if (ip.startsWith('169.254.')) return true;
-  if (ip.startsWith('172.')) {
-    const second = parseInt(ip.split('.')[1] ?? '', 10);
-    if (second >= 16 && second <= 31) return true;
-  }
-  // IPv6
-  if (ip === '::1' || ip.startsWith('fc') || ip.startsWith('fd') || ip.startsWith('fe80')) return true;
-  return false;
+  return classifyAddress(ip) !== 'public';
 }
 
 /**
@@ -31,9 +28,15 @@ export async function validateExternalUrl(url: string): Promise<void> {
     throw new Error('Invalid URL scheme');
   }
 
+  // URL.hostname keeps the square brackets around an IPv6 literal, and
+  // dns.lookup('[::1]') fails ENOTFOUND. That produced the right refusal for
+  // the wrong reason and made every legitimate IPv6 literal unreachable.
+  // Strip them and let the classifier decide.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+
   let address: string;
   try {
-    const result = await dns.promises.lookup(parsed.hostname);
+    const result = await dns.promises.lookup(hostname);
     address = result.address;
   } catch {
     throw new Error('DNS lookup failed');

--- a/packages/server/src/utils/storageJanitor.peeringExpiry.test.ts
+++ b/packages/server/src/utils/storageJanitor.peeringExpiry.test.ts
@@ -16,6 +16,14 @@ type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 let sqlite: Database.Database;
 let testDb: TestDb;
 
+// The peer-origin gate resolves an asserted origin before this instance will
+// send anything to it. These suites use non-resolving .example hosts and are
+// about peering state, not address policy (see federationFetch.test.ts for
+// that), so the resolver answers with a public address.
+vi.mock('dns', () => ({
+  default: { promises: { lookup: async () => ({ address: '93.184.216.34', family: 4 }) } },
+}));
+
 vi.mock('../db/index.js', () => ({
   getDb: () => testDb,
   getRawDb: () => sqlite,
@@ -30,6 +38,7 @@ vi.mock('../config.js', () => ({
     jwtSecret: 'test-secret-12345678901234567890123456789012',
     maxUploadSize: 100 * 1024 * 1024,
     registrationOpen: true,
+    federation: { allowPrivatePeers: false },
     uploadDir: '/tmp/backspace-test-uploads',
   },
 }));

--- a/packages/server/src/utils/storageJanitor.ts
+++ b/packages/server/src/utils/storageJanitor.ts
@@ -6,6 +6,7 @@ import { config } from '../config.js';
 import { getDb, getRawDb, schema } from '../db/index.js';
 import { deleteUploadFile, deleteAttachmentFiles } from './fileCleanup.js';
 import { generateSnowflake } from './snowflake.js';
+import { federationFetch } from './federationFetch.js';
 import type { StorageStats, StorageBreakdown, OrphanedFile, CleanupResult } from '@backspace/shared';
 
 const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.ico', '.bmp', '.avif']);
@@ -555,12 +556,14 @@ export async function cleanupExpiredApprovalRequests(): Promise<number> {
 
     let sent = false;
     try {
-      const response = await fetch(`${req.origin}/api/federation/peer/denied`, {
+      // 'asserted': the origin came from an inbound peering request that
+      // expired without ever being accepted, so nothing has approved it.
+      const response = await federationFetch(req.origin, '/api/federation/peer/denied', {
         method: 'POST',
         headers,
         body: denialBody,
         signal: AbortSignal.timeout(10_000),
-      });
+      }, 'asserted');
       sent = response.ok;
     } catch {
       // Network error — will retry next cycle

--- a/packages/server/test/helpers/twoInstanceHarness.ts
+++ b/packages/server/test/helpers/twoInstanceHarness.ts
@@ -145,6 +145,12 @@ export async function spawnInstance(opts: {
     LIVEKIT_URL: opts.livekit?.url ?? '',
     LIVEKIT_API_KEY: opts.livekit?.apiKey ?? '',
     LIVEKIT_API_SECRET: opts.livekit?.apiSecret ?? '',
+    // Every instance in this harness binds 127.0.0.1, which is exactly the
+    // LAN-only shape the flag exists for: an origin a caller asserted (a friend
+    // handle, a peering callback) is otherwise required to resolve to a public
+    // address before this instance will send anything to it. Set here and only
+    // here — the shipped default is off, and .env.example documents it that way.
+    FEDERATION_ALLOW_PRIVATE_PEERS: 'true',
   };
   // Explicit in BOTH branches: `env` starts as a copy of `process.env`, so an
   // inherited DISABLE_FEDERATION_WORKERS would otherwise silently re-disable the


### PR DESCRIPTION
Reworks how this server decides where it is willing to send an outbound request.

- Address classification moves from string prefixes to parsed range membership,
  covering IPv4, IPv6 and IPv4-mapped IPv6 in both spellings. Input the
  classifier cannot parse is treated as non-public rather than public.
- URL host handling strips the brackets around an IPv6 literal before
  resolution, which also makes IPv6-literal URLs usable for the first time.
- Replicated peer profile assets go through the re-validating fetch helper,
  which re-checks the destination of every redirect hop, and carry an 8 MiB
  size cap enforced on the bytes that actually arrive.
- The 18 outbound sites that carry a peer origin now pass a single gate that
  distinguishes an origin an admin approved (13 sites) from one a caller
  asserted (5 sites). Approved origins may be private, so admin-driven LAN
  peering keeps working. Asserted origins must resolve to a publicly routable
  address unless the operator sets FEDERATION_ALLOW_PRIVATE_PEERS, which is new,
  off by default, and exists for LAN-only deployments and the two-instance test
  harness.
- Peer requests are sent without following redirects. Every federation endpoint
  answers directly, so callers handle a 3xx through the non-2xx branch they
  already have.

Docs: `federation.md` gains section 1b (the two trust levels, which call sites
carry which, the flag, redirect behaviour, and the map of outbound paths that
are not federation endpoints); `embeds.md` describes the classifier and its
ranges instead of the old prefix table; `uploads.md` records that the
served-file policy is enforcing and owns its response.

Verification on this branch:

| Command | Result |
|---|---|
| `packages/server` `npx vitest run` | 1081 tests / 124 files, 0 failures |
| `packages/server` `npx tsc --noEmit` | exit 0 |
| `pnpm --filter @backspace/server typecheck:e2e` | exit 0 |
| `packages/web` `npx vitest run` | 493 tests / 61 files, 0 failures |
| `packages/web` `npx tsc --noEmit` | exit 0 |

The server suite was 1017 tests / 120 files before this branch. The 64 added
tests cover the classifier, URL validation, the profile-asset download and the
outbound gate.