### PR TITLE
fix(web): relax the meta policy for the dev server only

### DIFF
--- a/docs/systems/web-security.md
+++ b/docs/systems/web-security.md
@@ -324,6 +324,32 @@ must be checked against the header rather than reasoned about on its own.
 `packages/web/src/index-html.test.ts` asserts the tag's contents and asserts
 that none of the excluded directives appear in it.
 
+### The dev server needs a relaxed copy of it
+
+The tag enforces on the dev server too, and there the page is a different
+shape. `@vitejs/plugin-react` injects its React Refresh preamble as an inline
+`<script type="module">`. `script-src 'self' 'wasm-unsafe-eval'` has neither
+`'unsafe-inline'` nor a nonce, so the browser blocks it, and every module the
+plugin transforms carries a guard that throws
+`@vitejs/plugin-react can't detect preamble` when it did not run. The result is
+that `pnpm dev` serves a page that throws on first render, with the CSP
+violation in the console as the only clue.
+
+This shipped: the meta tag was verified in a headless browser against the
+**built** bundle, which has no inline script and no preamble, so the check
+passed and the dev path was never loaded.
+
+`packages/web/src/build/devCsp.ts` fixes it with a `transformIndexHtml` plugin
+that adds `'unsafe-inline'` to `script-src` for `vite dev` only. `apply: 'serve'`
+keeps it out of the build, so the shipped artifact is unchanged, and
+`order: 'pre'` puts it ahead of the plugins that inject scripts. The other three
+directives stay on in dev, so a violation of `object-src`, `base-uri` or
+`worker-src` still surfaces locally rather than in production.
+
+**Any future directive added to this tag has to be checked on both paths.**
+Building the page and loading the built page is not sufficient evidence; the dev
+server renders different HTML.
+
 ---
 
 ## Dependency note

--- a/packages/web/src/build/devCsp.test.ts
+++ b/packages/web/src/build/devCsp.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { relaxScriptSrcForDev, devCspPreamble } from './devCsp';
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(path.resolve(dir, '../../index.html'), 'utf8');
+
+// index-html.test.ts owns the assertions about the production policy itself.
+// This file covers only the dev-server transform applied on top of it.
+
+describe('relaxScriptSrcForDev', () => {
+  it('adds unsafe-inline to script-src and changes nothing else', () => {
+    const out = relaxScriptSrcForDev(html);
+    expect(out).toContain("script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'");
+    expect(out.replace(" 'unsafe-inline'", '')).toBe(html);
+  });
+
+  it('leaves the directives the dev server has no reason to relax', () => {
+    const out = relaxScriptSrcForDev(html);
+    expect(out).toContain("object-src 'none'");
+    expect(out).toContain("base-uri 'self'");
+    expect(out).toContain("worker-src 'self' blob:");
+  });
+
+  it('adds it exactly once', () => {
+    expect(relaxScriptSrcForDev(html).match(/unsafe-inline/g)).toHaveLength(1);
+  });
+
+  it('leaves HTML with no CSP tag untouched', () => {
+    const plain = '<!doctype html><html><head></head><body></body></html>';
+    expect(relaxScriptSrcForDev(plain)).toBe(plain);
+  });
+});
+
+describe('devCspPreamble', () => {
+  it('never runs during a build, so the shipped policy stays strict', () => {
+    expect(devCspPreamble().apply).toBe('serve');
+  });
+
+  it('runs before the plugins that inject the inline preamble', () => {
+    const hook = devCspPreamble().transformIndexHtml;
+    expect(typeof hook).toBe('object');
+    expect((hook as { order?: string }).order).toBe('pre');
+  });
+});

--- a/packages/web/src/build/devCsp.ts
+++ b/packages/web/src/build/devCsp.ts
@@ -1,0 +1,40 @@
+import type { Plugin } from 'vite';
+
+/**
+ * The Content-Security-Policy in `index.html` is written for the production
+ * build, where every script is an external file and `script-src 'self'` is
+ * enough.
+ *
+ * The dev server is a different shape. `@vitejs/plugin-react` injects its React
+ * Refresh preamble as an inline `<script type="module">`, and the production
+ * policy has neither `'unsafe-inline'` nor a nonce, so the browser blocks it.
+ * The preamble never runs, and every module the plugin transforms then throws
+ * "@vitejs/plugin-react can't detect preamble" on first render, so the app does
+ * not come up at all under `pnpm dev`.
+ *
+ * Relaxing script-src for the dev server keeps the rest of the policy active
+ * locally, so a violation of object-src, base-uri or worker-src still shows up
+ * before it reaches production.
+ */
+export function relaxScriptSrcForDev(html: string): string {
+  return html.replace(
+    /(<meta http-equiv="Content-Security-Policy" content="script-src 'self')/,
+    "$1 'unsafe-inline'",
+  );
+}
+
+/**
+ * Applies {@link relaxScriptSrcForDev} to the served HTML. `apply: 'serve'`
+ * keeps it out of the build entirely, so the shipped artifact carries the
+ * strict policy unchanged.
+ */
+export function devCspPreamble(): Plugin {
+  return {
+    name: 'backspace:dev-csp-preamble',
+    apply: 'serve',
+    transformIndexHtml: {
+      order: 'pre',
+      handler: relaxScriptSrcForDev,
+    },
+  };
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -3,9 +3,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
+import { devCspPreamble } from './src/build/devCsp';
 
 export default defineConfig({
   plugins: [
+    devCspPreamble(),
     react(),
     VitePWA({
       registerType: 'autoUpdate',


### PR DESCRIPTION
## What

The Content-Security-Policy meta tag in `packages/web/index.html` enforces on the dev server as well as on the built page. On the dev server `@vitejs/plugin-react` injects its React Refresh preamble as an inline `<script type="module">`, and the policy allows no inline script, so the browser blocks it. Every module the plugin transforms carries a guard that throws `@vitejs/plugin-react can't detect preamble` when it did not run, so `pnpm dev` serves a page that throws on first render.

Confirmed against a live dev server on `main`:

```
$ curl -s localhost:5173/ | grep -o "<script type=\"module\">.\{0,60\}"
<script type="module">import { injectIntoGlobalHook } from "/@react-refresh";

$ curl -s localhost:5173/src/App.tsx | grep -o "can't detect preamble[^\"]*"
can't detect preamble. Something is wrong.
```

The tag was verified in a headless browser against the **built** bundle, which has no inline script and no preamble, so that check passed and the dev path was never loaded.

## Fix

`packages/web/src/build/devCsp.ts` adds `'unsafe-inline'` to `script-src` for `vite dev` only.

- `apply: 'serve'` keeps it out of the build. The shipped `dist/index.html` is byte identical to before, still `script-src 'self' 'wasm-unsafe-eval'`.
- `order: 'pre'` puts it ahead of the plugins that inject scripts.
- `object-src`, `base-uri` and `worker-src` stay on in dev, so a violation of those still surfaces locally rather than in production.

The plugin lives in `src/` rather than beside `vite.config.ts` because `tsconfig.json` includes only `src/**/*`, so nothing in the config file is typechecked today.

## Verification

| check | result |
|---|---|
| dev server `script-src` | `'self' 'unsafe-inline' 'wasm-unsafe-eval'` |
| built `dist/index.html` `script-src` | `'self' 'wasm-unsafe-eval'`, unchanged |
| built CSP tag count / `worker-src` | 1 / `worker-src 'self' blob:` |
| `npx vite build` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npx vitest run` | 500 passed / 62 files (was 493 / 61, plus 6 new and 1 file) |

`docs/systems/web-security.md` records the two-path rule: any directive added to this tag has to be checked on the dev server as well as the built page, because they serve different HTML.