### PR TITLE
security: dynamic scanning, runner hardening, and the public evidence

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -48,6 +48,11 @@ jobs:
     # Skip CLA enforcement on bot-authored PRs (e.g. Dependabot) and on the
     # maintainer's own PRs via the allowlist below.
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
       - name: CLA Assistant
         if: |
           (github.event.comment.body == 'recheck' ||

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -1,0 +1,126 @@
+name: DAST
+
+# Dynamic scan of a running instance, as opposed to the static analysis in
+# codeql.yml and the dependency scanning in security.yml. It stands up one
+# ephemeral container from the tree under test and runs an OWASP ZAP baseline
+# against it: spider plus passive checks, no active attack traffic.
+#
+# Scope, stated honestly and measured rather than assumed: the scan is
+# unauthenticated and the spider reaches the SPA shell and its static assets
+# only. A measured run visited 11 URLs and none of them were under /api/,
+# because the shell contains no links for a spider to follow. It does not
+# exercise the API, spaces, channels, uploads, federation or voice. Its value is
+# that it proves the image still builds and the container still becomes healthy,
+# and it passively checks response headers on what it does reach. It is not an
+# assessment of the application.
+#
+# Advisory by design. A finding never fails this workflow. A container that
+# will not become healthy does, because that is a real regression.
+#
+# Not on every pull request: the job builds the full image, which is minutes of
+# runner time, and an advisory result does not belong in the merge path. It runs
+# on every push to main, weekly, on demand, and on pull requests that touch its
+# own configuration so that it self-tests when changed.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/dast.yml'
+      - '.zap/**'
+  schedule:
+    # Wednesday 04:17 UTC. Off the hour so it does not queue behind the
+    # every-scanner-at-midnight crowd on the hosted runners.
+    - cron: '17 4 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zap-baseline:
+    name: ZAP baseline
+    runs-on: ubuntu-latest
+    # No write scope anywhere. The report leaves as an artifact rather than as
+    # SARIF: ZAP's SARIF conversion is not part of the baseline image, and a
+    # code-scanning upload would need security-events: write for results that
+    # are advisory and mostly about deployment-time headers.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # docker-compose.yml reads env_file: .env, and compose fails outright if
+      # that file is absent. DOMAIN is required even though caddy never starts:
+      # compose interpolates the whole file before it filters services, and the
+      # caddy service declares ${DOMAIN:?...}. dast.invalid is an RFC 2606
+      # reserved name that cannot resolve. The secret is a throwaway that only
+      # has to clear the 32-character floor in config.ts.
+      - name: Write the ephemeral env file
+        run: |
+          cat > .env <<'EOF'
+          DOMAIN=dast.invalid
+          JWT_SECRET=0000000000000000000000000000000000000000000000000000000000000000
+          PORT=3000
+          NODE_ENV=production
+          REGISTRATION_OPEN=true
+          EOF
+
+      # Only the backspace service. caddy sits in the default profile and would
+      # hang on ACME without public DNS; livekit is already gated behind the
+      # voice profile. --wait blocks on the healthcheck declared in the compose
+      # file, so no polling loop is needed. The -p flag fixes the project name,
+      # which is what makes the network name below deterministic.
+      - name: Start an ephemeral instance
+        run: docker compose -p backspace-dast up -d --build --wait backspace
+
+      # ZAP joins the compose network and addresses the container by service
+      # name. The compose file publishes no ports, so there is nothing to reach
+      # on the runner's localhost, and this avoids depending on how any
+      # marketplace action wires up its own container networking.
+      - name: Run the ZAP baseline
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/zap-out"
+          docker run --rm \
+            --network backspace-dast_internal \
+            -v "$GITHUB_WORKSPACE/zap-out:/zap/wrk/:rw" \
+            -v "$GITHUB_WORKSPACE/.zap:/zap/cfg/:ro" \
+            ghcr.io/zaproxy/zaproxy@sha256:781a2bdaea47324e7bab583e2263f21d257b0aee61ed51521a5be45f5f5081ef \
+            zap-baseline.py \
+              -t http://backspace:3000 \
+              -c /zap/cfg/rules.tsv \
+              -I \
+              -r report.html -w report.md -J report.json
+
+      - name: Summarise the findings
+        if: always()
+        run: |
+          if [ -f zap-out/report.md ]; then
+            {
+              echo '## ZAP baseline'
+              echo
+              cat zap-out/report.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'ZAP produced no report. The scan step failed before writing one.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zap-baseline-report
+          path: zap-out/
+          retention-days: 30
+
+      - name: Tear down
+        if: always()
+        run: docker compose -p backspace-dast down -v

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,11 @@ jobs:
       packages: write
       security-events: write
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,21 @@
+# ZAP baseline rule tuning. Consumed by .github/workflows/dast.yml.
+# Format: <rule id>\t<WARN|IGNORE|FAIL>\t<rule name>, tab separated. The third
+# column is required: zap_common.py rejects the whole file if a line carries
+# fewer than two tabs, and the scan then aborts without a report. It is only a
+# label, so it holds the alert name as ZAP prints it.
+#
+# IGNORE is only for a finding that is an artefact of scanning the app
+# container directly instead of the deployed system. Everything else stays at
+# WARN so it shows up in the report. The reasoning lives in
+# docs/systems/security-scanning.md, section "Dynamic scanning (DAST)".
+
+# The CSP ships as Content-Security-Policy-Report-Only today, and this rule
+# fires as "Report-Only Header Found". DELETE THIS LINE when the policy flips
+# to enforcing (Plan C Task 8). Leaving it after the flip would hide a real
+# regression.
+10038	IGNORE	Content Security Policy (CSP) Report-Only Header Found
+
+# Not a finding. ZAP reporting that the target is a single-page app, and that
+# its spider coverage is therefore limited, is a statement about the scanner
+# rather than about the app.
+10109	IGNORE	Modern Web Application

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ site/
 
 The metrics subsystem spans `scripts/metrics` (collector, bundler) and `site/insights` (the static dashboard the bundler feeds). See docs/systems/metrics.md.
 
-Data: `packages/server/data/` (backspace.db + uploads/)
+Data: `data/` at the repository root (backspace.db + uploads/ + backups/), mounted into the container at `/app/data`
 
 ---
 
@@ -168,7 +168,7 @@ Before modifying any subsystem, read its spec from `docs/systems/`. After making
 | [message-list.md](docs/systems/message-list.md) | Auto-scroll model, position memory (session-only), embed renderer dimension contract, known limitations | Touching MessageList.tsx, scroll behavior, embed renderers, position restore |
 | [deployment.md](docs/systems/deployment.md) | Hosting pipeline: Docker/Caddy build, admin bootstrap, DB backup/restore, image pinning, env vars | Any deploy, backup/restore, or hosting change |
 | [activity-presence.md](docs/systems/activity-presence.md) | Presence states, rich activities, activity types/priorities, broadcast pipeline, visibility control, ActivityCard/Panel | Presence, rich activities, activity display, status management |
-| [security-scanning.md](docs/systems/security-scanning.md) | CI security pipeline: Dependabot, CodeQL SAST, gitleaks, OSV-Scanner, Trivy (config/license; image scan in a later plan), OpenSSF Scorecard, SHA-pinning, harden-runner, tiered enforcement policy, maintainer settings checklist | Any CI security work, adding/changing scanners, enabling enforcement, supply-chain hardening |
+| [security-scanning.md](docs/systems/security-scanning.md) | CI security pipeline: Dependabot, CodeQL SAST, gitleaks, OSV-Scanner, Trivy (config, license, and the published image), OpenSSF Scorecard, ZAP baseline DAST, SHA-pinning, harden-runner, tiered enforcement policy, triage policy and dismissal register, maintainer settings checklist | Any CI security work, adding/changing scanners, enabling enforcement, supply-chain hardening |
 | [web-security.md](docs/systems/web-security.md) | Content Security Policy construction and rollout state, the CORS posture and why the origin is reflected, security-header ownership between Caddy and the app, the route-level policy override for served files | Any CSP, CORS or security-header work; before "tightening" CORS |
 | [metrics.md](docs/systems/metrics.md) | Traffic archive: daily collection into the `metrics-data` branch, CSV/NDJSON schemas, upsert and write-if-absent semantics, backfill, the 202 stats problem, PAT scopes, the 60-day schedule hazard; the `site/insights` dashboard: `data.json` contract, 2 MB bundle budget and weekly downsampling, uPlot vendoring, Pages deploy wiring, empty-state behaviour | Any repo-analytics or dashboard work, changing collected series, changing the bundle contract, debugging a stalled collector or a red deploy |
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@
 
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-3da639.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](https://www.typescriptlang.org/)
-[![Node.js](https://img.shields.io/badge/node-20_LTS-339933.svg)](https://nodejs.org/)
-[![Version](https://img.shields.io/badge/version-1.0.0-16a34a.svg)](#project-status)
+[![Node.js](https://img.shields.io/badge/node-24_LTS-339933.svg)](https://nodejs.org/)
+[![Release](https://img.shields.io/github/v/release/TheZwiss/backspace?color=16a34a&label=release)](https://github.com/TheZwiss/backspace/releases)
+[![CodeQL](https://github.com/TheZwiss/backspace/actions/workflows/codeql.yml/badge.svg)](https://github.com/TheZwiss/backspace/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/TheZwiss/backspace/badge)](https://scorecard.dev/viewer/?uri=github.com/TheZwiss/backspace)
+[![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](SECURITY.md)
 
 </div>
 
@@ -688,6 +691,34 @@ If you discover a security vulnerability, please **do not** open a public issue.
 Report it privately via a GitHub security advisory on this repository. See
 [`SECURITY.md`](SECURITY.md). We'll work with you on a fix and coordinated
 disclosure.
+
+### Security and supply chain
+
+Every change is scanned automatically before and after it lands. Results are
+published to this repository's Security tab.
+
+| What | Tool | When |
+|------|------|------|
+| Static analysis of the TypeScript | CodeQL | every pull request, every push to `main`, weekly |
+| Known vulnerabilities in dependencies | OSV-Scanner | every pull request, every push to `main`, weekly |
+| Secrets, across the full git history | gitleaks | every pull request, every push to `main`, weekly |
+| Infrastructure and container config | Trivy | every pull request, every push to `main`, weekly |
+| Dependency licenses | Trivy | every pull request, every push to `main`, weekly |
+| The published container image | Trivy | on every image publish |
+| Repository security posture | OpenSSF Scorecard | every push to `main`, weekly |
+| A running instance | OWASP ZAP baseline | every push to `main`, weekly |
+| Dependency and base image updates | Dependabot | weekly |
+
+Supporting practice: every GitHub Action is pinned to a full commit SHA rather
+than a tag, every job runs on a hardened runner with egress auditing, and
+workflow permissions are granted per job instead of repository-wide. Published
+images carry a software bill of materials and build provenance.
+
+Findings are triaged rather than accumulated. Anything dismissed carries a
+written reason, recorded in
+[`docs/systems/security-scanning.md`](docs/systems/security-scanning.md), which
+also documents the scan policy, the known gaps, and the deployment-time settings
+a self-hoster should check.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,41 @@ disclosure. Please include reproduction steps, affected version/commit, and your
 environment (deployment method, browser/desktop, and whether federation or voice
 is involved).
 
+## Security testing and assurance
+
+Backspace runs continuous automated security testing. None of it replaces a
+report from a human researcher, which is why the section above exists.
+
+- **Static analysis.** CodeQL analyses the TypeScript on every pull request,
+  every push to `main`, and weekly.
+- **Dependencies.** OSV-Scanner checks the lockfile against the OSV database on
+  the same schedule. GitHub Dependabot raises update pull requests weekly and
+  advisory alerts continuously.
+- **Secrets.** gitleaks scans the full git history, not just the diff.
+- **Configuration and containers.** Trivy checks infrastructure configuration
+  and dependency licenses on every change, and scans the published container
+  image on every publish.
+- **Running instance.** An OWASP ZAP baseline scan runs against a freshly built
+  ephemeral instance on every push to `main` and weekly. It is unauthenticated
+  and reaches the web shell and its static assets, so it is a regression guard
+  rather than an assessment of the application.
+- **Repository posture.** OpenSSF Scorecard evaluates the repository itself and
+  publishes the result publicly.
+- **Supply chain.** Every GitHub Action is pinned to a full commit SHA, jobs run
+  with per-job permissions on hardened runners, and published images carry a
+  software bill of materials and build provenance.
+
+Findings are triaged, not accumulated. Every dismissal carries a written reason.
+The full policy, the workflow inventory, and the register of dismissed findings
+are in
+[`docs/systems/security-scanning.md`](docs/systems/security-scanning.md).
+
+Automated scanning has known gaps, and they are worth stating plainly. The
+dynamic scan does not authenticate, and because the web shell contains no links
+for a crawler to follow it reaches the shell and its static assets rather than
+the API. It does not exercise spaces, channels, uploads, federation, or voice.
+There is no fuzzing. Reports covering those areas are especially welcome.
+
 ## Supported versions
 
 Backspace 1.x receives security fixes. Always run the latest release.

--- a/docs/systems/security-scanning.md
+++ b/docs/systems/security-scanning.md
@@ -14,6 +14,7 @@ later change once the remediation pass has cleared the backlog.
 | `.github/workflows/codeql.yml` | CodeQL SAST (`javascript-typescript`, build-mode none) | PR + push main + weekly | Security tab |
 | `.github/workflows/security.yml` | gitleaks (secrets, full history), OSV-Scanner (deps), Trivy config (IaC), Trivy license | PR + push main + weekly | Security tab |
 | `.github/workflows/scorecard.yml` | OpenSSF Scorecard (repo posture) | push main + weekly + on branch-protection change | Security tab + public badge |
+| `.github/workflows/dast.yml` | ZAP baseline against an ephemeral instance (spider + passive, unauthenticated) | push main + weekly + manual + PRs touching its own config | Job summary + artifact (advisory) |
 | `.github/workflows/docker-publish.yml` | Image scan (Trivy) + SBOM + provenance for the published container | tag push / manual | image scan (report-only) + SBOM + provenance |
 
 > **gitleaks findings** surface in the workflow's job log and PR summary — the
@@ -30,6 +31,132 @@ later change once the remediation pass has cleared the backlog.
 Code-level gates (OSV, Trivy, gitleaks) block via workflow exit codes. CodeQL
 merge-blocking, Dependabot alerts, and native secret-scanning are GitHub *settings*
 — see the checklist below.
+
+## Dynamic scanning (DAST)
+
+`dast.yml` builds the image from the tree under test, starts a single container,
+and runs an OWASP ZAP baseline against it. Baseline means spider plus passive
+checks: ZAP sends no attack traffic.
+
+**The rig is the production compose file, not a separate one.** The workflow runs
+`docker compose -p backspace-dast up -d --build --wait backspace`, naming the one
+service it wants. That single detail is what keeps the rig small:
+
+- `caddy` sits in the default profile and would hang on ACME without public DNS,
+  so it must not be started. Naming `backspace` explicitly is what excludes it.
+- `livekit` is already gated behind the `voice` profile and never starts here.
+- The compose file publishes no ports for `backspace`, so ZAP joins the compose
+  network and addresses the container as `http://backspace:3000`. Nothing is
+  reachable on the runner's localhost, and nothing needs to be. The `-p` flag
+  fixes the project name, which is what makes the network name
+  (`backspace-dast_internal`) deterministic.
+- `--wait` blocks on the healthcheck already declared in the compose file, so the
+  workflow needs no polling loop.
+- A throwaway `.env` is written first, because the service declares
+  `env_file: .env` and compose fails outright without it. `DOMAIN` has to be set
+  even though `caddy` never starts: compose interpolates the entire file before it
+  filters services, and the `caddy` service declares
+  `${DOMAIN:?Set DOMAIN in .env}`.
+
+ZAP runs as a plain `docker run` rather than through the marketplace action,
+because the target only resolves if the scanner is on the compose network, and
+`--network` is a `docker run` flag that the action does not expose.
+
+**What it covers, measured rather than assumed.** The scan is unauthenticated, and
+the spider reaches the SPA shell and its static assets only. The measured run
+visited 11 URLs: `/`, the JS bundle, three icons, `manifest.webmanifest`, and ZAP's
+own probes for `robots.txt` and `sitemap.xml`. **None were under `/api/`**, because
+the shell contains no links for the spider to follow. Adding explicit seed URLs
+would widen this. It has not been done, because the API routes carry the identical
+security header set (verified in the same run) and the passive checks would
+therefore find nothing new.
+
+Treat the job as proof that the image still builds and the container still becomes
+healthy, plus a passive header check on what it reaches. It is not an assessment of
+the application. Note also that `/robots.txt` and `/sitemap.xml` return the SPA
+shell with HTTP 200, because `setNotFoundHandler` in `packages/server/src/index.ts`
+serves `index.html` for every path that is not under `/api/` or `/ws`.
+
+**Advisory, deliberately.** ZAP runs with `-I`, so a finding never fails the job. A
+container that will not become healthy does fail it, because that is a real
+regression and the reason the job is worth running on every push to `main`.
+
+**Why not on every pull request.** It builds the whole image, which costs minutes
+of runner time, and an advisory result does not belong in the merge path. It does
+run on pull requests that touch `.github/workflows/dast.yml` or `.zap/**`, so its
+own configuration is self-testing.
+
+### Tuned rules
+
+`.zap/rules.tsv` is the only place a rule is downgraded, one line per rule with the
+reason inline. `IGNORE` is reserved for findings that are artefacts of scanning the
+app container directly instead of the deployed system. Everything else stays at
+`WARN`.
+
+| Rule | Alert | Why it is ignored |
+|---|---|---|
+| 10038 | Content Security Policy (CSP) Report-Only Header Found | The policy ships as report-only by design today (`Content-Security-Policy-Report-Only`, set by the `onSend` hook). **This line is deleted when the policy flips to enforcing.** Leaving it in place afterwards would hide a real regression. |
+| 10109 | Modern Web Application | Not a finding. ZAP is reporting that the target is a single-page app and that spider coverage is therefore limited, which is a statement about the scanner rather than about the app. |
+
+Two back-to-back runs against the same live container on 2026-09-03 give the exact
+effect of the file. Control, with no rule file:
+
+```
+FAIL-NEW: 0  WARN-NEW: 7  IGNORE: 0  PASS: 60
+```
+
+Tuned, with `-c /zap/cfg/rules.tsv`:
+
+```
+FAIL-NEW: 0  WARN-NEW: 5  IGNORE: 2  PASS: 60
+```
+
+The two moved to `IGNORE` are 10038 and 10109. The five that stay at `WARN` are
+10027, 10049, 10055, 10063 and 90004. Two of those look like candidates for
+`IGNORE` and deliberately are not:
+
+- **10055 (CSP directive warnings)** evaluates the narrow enforcing policy in the
+  `index.html` meta tag, not the report-only header, so today it is noise. It will
+  evaluate the real policy the moment the CSP flips to enforcing, and silencing it
+  now would hide a regression at exactly the point it starts to matter. `-I` means
+  a warning never fails the job, so the noise costs nothing.
+- **90004 (insufficient site isolation)** is deliberate: `crossOriginEmbedderPolicy`
+  is off because embeds pull third-party images that carry no CORP header. That is
+  a property of the deployed system, not an artefact of scanning it, so it stays
+  visible.
+
+**`Strict-Transport-Security` (rule 10035) is deliberately absent from this file.**
+It never fires. ZAP raises it only over HTTPS and this rig is plain HTTP, so the one
+header Caddy owns is also the one header ZAP never asks about. It reported `PASS`.
+An earlier draft of this document listed it as the main entry; that was a
+prediction, and the measured run disproved it. Do not add it back.
+
+**Open finding this scan surfaced, not tuned away:** the app sends no
+`Permissions-Policy` header on any route (rule 10063). helmet adds none by default,
+and unlike HSTS, Caddy does not supply it either, so a real deployment has the same
+gap. It is not fixed here because a wrong value silently breaks voice and screen
+sharing, which need `camera`, `microphone` and `display-capture` granted to self.
+It belongs with the CSP enforcement flip, which already carries the real-deployment
+observation phase a change like this needs.
+
+**The generated reports are not filtered.** The `-c` rule file changes only the
+console classification and the exit-code arithmetic. `report.md`, `report.html` and
+`report.json` still carry full entries for the ignored rules, so the job summary
+built from `report.md` shows them too. The `IGNORE:` count on the console
+classification line is the thing to read, not the body of the report.
+
+**The file needs three tab separated columns, not two.** `zap_common.py:148` splits
+each line on tabs and raises `ValueError` if it finds fewer than two, and ZAP then
+aborts the scan without writing any report at all. The third column is only a
+label, so it holds the alert name as ZAP prints it. A space separated line is the
+same trap. Check the separators after any edit:
+
+```bash
+grep -Pn '^\d+\t(WARN|IGNORE|FAIL)\t' .zap/rules.tsv
+```
+
+The trailing `\t` in that pattern is the point: it is what proves a third column
+exists. Every non-comment line in the file must match.
 
 ## Triage policy
 
@@ -288,7 +415,13 @@ settings or process. They belong to the checklist below, not to remediation.
   `metrics.yml`'s `uses: ./.github/workflows/deploy-pages.yml`. GitHub rejects
   `@ref` on a `./` path and resolves a local reusable workflow from the calling
   run's own commit, which is tighter than a SHA pin. Not a gap — do not "fix" it.
-- `step-security/harden-runner` (egress-policy `audit`) on Linux jobs.
+- `step-security/harden-runner` (egress-policy `audit`) on every workflow in
+  `.github/workflows/`. Two jobs deliberately go without it, and neither is a gap:
+  `ci.yml`'s `build-and-test-required`, which only compares a `needs` result and
+  makes no network call, and `metrics.yml`'s `deploy-dashboard`, which is a call
+  into the local reusable `deploy-pages.yml` whose own job is hardened. In
+  `release.yml` the step is gated on `runner.os == 'Linux'`, because harden-runner
+  does not support the macOS and Windows legs of the build matrix.
 - Least-privilege `permissions:` per workflow/job.
 - SBOM + SLSA provenance are attached to the published container image at push
   (`.github/workflows/docker-publish.yml`), alongside a report-only Trivy scan
@@ -344,6 +477,16 @@ rename.
       check from `security.yml`, `codeql.yml`, or `scorecard.yml` — add those
       contexts when enforcement is turned on, or the tiered policy above has no
       gate on `main`.
+- [ ] Settings → Code security: enable **Secret scanning validity checks**.
+      Currently disabled. It asks the provider whether a detected credential is
+      still live, which is the difference between an alert and an incident.
+- [ ] The five Scorecard checks that are maintainer settings or process rather than
+      code, and therefore cannot be fixed from a pull request: `Branch-Protection`,
+      `CII-Best-Practices`, `Code-Review`, `Fuzzing`, `Security-Policy`.
+      `Security-Policy` should resolve on its own now that `SECURITY.md` documents
+      the testing pipeline; re-check it after the next Scorecard run. `Code-Review`
+      reflects commits reaching `main` without a reviewed pull request, which is
+      inherent to a single-maintainer repository.
 - [ ] **Manual image bumps:** Dependabot does not track `docker-compose.yml`
       `image:` pins — update `caddy` and `livekit/livekit-server` by hand when new
       releases ship. (Renovate, which parses compose, is an optional future


### PR DESCRIPTION
Adds dynamic scanning, closes the last two runner-hardening gaps, and writes the
public description of the security pipeline.

## What this adds

**`dast.yml`, an advisory ZAP baseline.** Builds the image from the tree under
test, starts one container, and runs an OWASP ZAP baseline against it. The rig is
the existing compose file rather than a new one: `docker compose -p backspace-dast
up -d --build --wait backspace` names a single service, which is what keeps
`caddy` from starting and hanging on ACME without public DNS. `livekit` is already
profile-gated. The compose file publishes no ports for `backspace`, so ZAP joins
the compose network and addresses the container by service name. That is also why
this uses a plain `docker run` rather than the marketplace action: `--network` is
a `docker run` flag the action does not expose.

Advisory by design. A finding never fails the job. A container that will not
become healthy does, which is the main thing worth catching.

**`.zap/rules.tsv`.** Two `IGNORE` lines, 10038 and 10109. Everything else stays
visible on purpose, including the CSP directive warnings, which will evaluate the
real policy once it flips to enforcing.

**`harden-runner` on `cla.yml` and `docker-publish.yml`**, the only two workflows
that lacked it. Audit mode, matching every existing usage.

**README, SECURITY.md and `security-scanning.md`** describing what runs, when, and
where results are published, plus the known gaps.

## Verification

The rig was built and scanned locally before any of it was written, and again
afterwards to confirm the rule file behaves. Two back-to-back runs against the
same live container:

| | FAIL | WARN | IGNORE | PASS |
|---|---|---|---|---|
| control, no rule file | 0 | 7 | 0 | 60 |
| tuned | 0 | 5 | 2 | 60 |

`actionlint` passes on all three workflow files. The ZAP image is pinned by
digest and every action by full commit SHA.

This PR self-tests: the `pull_request` trigger matches `.zap/**` and
`.github/workflows/dast.yml`, both of which this branch adds, so the DAST job runs
on its own change.

## Two things the scan corrected, worth recording

**Coverage is narrower than first assumed.** The spider reached 11 URLs and none
were under `/api/`, because the web shell contains no links to follow. Earlier
drafts of the documentation claimed the scan covered several API routes. That was
wrong, and the prose in this PR says what the scan actually reaches instead.
Widening it with seed URLs would add little, since the API routes carry an
identical security header set.

**The HSTS rule never fires.** ZAP raises it only over HTTPS and this rig is plain
HTTP, so the one header Caddy owns is also the one the scanner never asks about.
It is deliberately absent from the rule file, with a note saying so, because an
earlier draft asserted the opposite.

## Known limits of this PR's own checks

The `cla-assistant` check on this PR runs `main`'s copy of `cla.yml`, not the
edited one, because a `pull_request_target` workflow always executes the
base-branch version. A green check there is not evidence about this change. It is
covered by `actionlint` here and confirmed on the first CLA event after merge.

`docker-publish.yml` triggers only on a `v*` tag or manual dispatch, so its
harden-runner step stays unexercised until the next release.

## Open finding, not fixed here

The app sends no `Permissions-Policy` header on any route, and Caddy does not
supply one either. It is documented rather than fixed because a wrong value
silently breaks voice and screen sharing, which need camera, microphone and
display-capture granted to self. That needs the same real-deployment observation
phase the CSP enforcement flip already carries, so it belongs with that change.
