### PR TITLE
ci(security): enforce the scanner policy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,9 +105,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Deliberately still report-only, and this is the one scanner that is.
+      # Measured 2026-09-03 against an image built from main: 20 fixable
+      # HIGH/CRITICAL, none of which the dependency pass covers, because Trivy
+      # sees the image's real node_modules while OSV reads the lockfile. Making
+      # this blocking would fail every release publish until that backlog is
+      # worked, and holding security fixes behind a scanner backlog is the exact
+      # inversion this project already decided against. It needs its own
+      # remediation pass first. See docs/systems/security-scanning.md.
       - name: Trivy image scan (report-only)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        continue-on-error: true # report-only; enforcement flipped on in Plan E
+        continue-on-error: true # report-only: see the note above, not an oversight
         with:
           scan-type: image
           image-ref: backspace:scan

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,14 @@
 name: Security
 
-# Report-only in this plan: every scanner is non-blocking and uploads SARIF to
-# the Security tab. Enforcement (fail on fixable HIGH/CRITICAL, block on secrets)
-# is flipped on in Plan E after the remediation pass.
+# Enforcing. Every scanner uploads SARIF to the Security tab AND fails the job on
+# a finding that the tiered policy says must block: a gitleaks secret hit, a
+# HIGH/CRITICAL Trivy config or license finding, and any dependency vulnerability
+# that is not listed in osv-scanner.toml.
+#
+# osv-scanner.toml is a ratchet, not a waiver. It holds the backlog that existed
+# when enforcement was turned on, each entry with a reason and an expiry date, so
+# a NEW vulnerability blocks while the documented backlog stays visible. See
+# docs/systems/security-scanning.md.
 
 on:
   pull_request:
@@ -33,7 +39,6 @@ jobs:
           fetch-depth: 0 # gitleaks scans the whole git history, not just the diff
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
-        continue-on-error: true # report-only; enforcement flipped on in Plan E
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,9 +57,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run OSV-Scanner
         uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
-        continue-on-error: true # report-only; enforcement flipped on in Plan E
         with:
+          # Exits non-zero on any vulnerability that osv-scanner.toml does not
+          # already account for. That file is the ratchet: the backlog is listed
+          # with reasons and expiry dates, so anything new fails this job.
           scan-args: |-
+            --config=osv-scanner.toml
             --lockfile=./pnpm-lock.yaml
             --format=sarif
             --output=osv-results.sarif
@@ -80,7 +88,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Trivy config scan (Dockerfile + docker-compose)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        continue-on-error: true # report-only; enforcement flipped on in Plan E
         with:
           scan-type: config
           scan-ref: .
@@ -89,6 +96,11 @@ jobs:
           trivyignores: .trivyignore
           format: sarif
           output: trivy-config.sarif
+          # In sarif mode Trivy exits 0 whatever it finds, so removing
+          # continue-on-error is not by itself enforcement. exit-code is.
+          # Scoped to HIGH/CRITICAL to match the tiered policy.
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
       - name: Upload Trivy config SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
@@ -111,13 +123,16 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Trivy license scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        continue-on-error: true # report-only; enforcement flipped on in Plan E
         with:
           scan-type: fs
           scan-ref: .
           scanners: license
           format: sarif
           output: trivy-license.sarif
+          # As above: sarif mode exits 0 on its own. HIGH/CRITICAL here means a
+          # license Trivy classifies as forbidden or restricted.
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
       - name: Upload Trivy license SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/docs/systems/security-scanning.md
+++ b/docs/systems/security-scanning.md
@@ -2,9 +2,11 @@
 
 Automated, continuous scanning wired into GitHub Actions. This document is the
 reference for what runs, where results go, and the one-time settings a maintainer
-must enable. **Current state: report-only** — scanners surface findings in the
-Security tab but do not block merges yet. Enforcement (blocking) is turned on in a
-later change once the remediation pass has cleared the backlog.
+must enable. **Current state: enforcing**, with one documented exception. The
+scanners in `security.yml` fail the job on a finding the tiered policy says must
+block. The published-image scan in `docker-publish.yml` is the exception and is
+still report-only, for the measured reason in "The image scan is the exception"
+below.
 
 ## Workflows
 
@@ -21,7 +23,7 @@ later change once the remediation pass has cleared the backlog.
 > `gitleaks` job does not upload SARIF, so secret hits do **not** appear under
 > Security → Code scanning (unlike the OSV / Trivy / CodeQL / Scorecard jobs).
 
-## Tiered policy (target, enforced in a later change)
+## Tiered policy
 
 - **Always block:** gitleaks secret hit; OSV/Trivy fixable HIGH/CRITICAL; Trivy
   disallowed license.
@@ -31,6 +33,47 @@ later change once the remediation pass has cleared the backlog.
 Code-level gates (OSV, Trivy, gitleaks) block via workflow exit codes. CodeQL
 merge-blocking, Dependabot alerts, and native secret-scanning are GitHub *settings*
 — see the checklist below.
+
+### How enforcement is actually wired
+
+Turning this on was not a matter of deleting `continue-on-error`. Two things had to
+be true first, and both were measured rather than assumed.
+
+**Trivy exits 0 in SARIF mode whatever it finds.** Removing `continue-on-error`
+alone would have looked like enforcement while enforcing nothing. The config and
+license jobs carry `exit-code: '1'` plus `severity: 'HIGH,CRITICAL'`; the exit code
+is what blocks, and the severity filter is what keeps it aligned with the tiered
+policy above.
+
+**All thirteen remaining OSV findings are fixable**, and five are HIGH, so a plain
+flip would have turned `main` red and blocked every pull request. `osv-scanner.toml`
+resolves that as a **ratchet rather than a waiver**: it lists exactly the backlog
+that existed at flip time, one entry per finding, each with the reason and the
+version that fixes it. Anything not in that file fails the job, so a newly
+introduced vulnerability blocks while the documented backlog stays visible.
+
+Every entry carries `ignoreUntil = 2026-12-01`. **A waiver with no expiry is how a
+backlog becomes permanent.** When that date passes these findings come back and
+block, which forces the upgrade decision instead of letting it rot. That is
+deliberate, and it means `main` can go red on that date if nobody has acted. The
+fix is to do the upgrades, not to push the date.
+
+### The image scan is the exception
+
+`docker-publish.yml`'s Trivy image scan stays report-only. Measured 2026-09-03
+against an image built from `main`: **20 fixable HIGH/CRITICAL**. None of them are
+covered by the dependency pass, because Trivy inspects the image's real
+`node_modules` while OSV reads the lockfile, so the two see different things. Among
+them, `pnpm` itself is present in the runtime image and contributes several, even
+though the final stage never installs it and only copies `node_modules` from the
+deps stage. That is worth its own investigation.
+
+Making this job blocking today would fail every release publish until that backlog
+is worked. Holding security fixes behind a scanner backlog is the exact inversion
+this project already decided against when the release track was changed from one
+release at the end to a patch per landed track. The image scan needs its own
+remediation pass, on the model of the dependency pass, and then it can be flipped
+the same way.
 
 ## Dynamic scanning (DAST)
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,91 @@
+# OSV-Scanner ratchet. Consumed by .github/workflows/security.yml.
+#
+# The dependency scan blocks on any vulnerability that is NOT listed here, so a
+# newly introduced one fails the build. The entries below are the backlog that
+# existed when enforcement was turned on: every one is fixable, and every one
+# needs a major upgrade that is its own compatibility decision. They are
+# deferred, not dismissed. The argument for each lives in
+# docs/systems/security-scanning.md, section "What is left open, and why".
+#
+# ignoreUntil is deliberate. A waiver with no expiry is how a backlog becomes
+# permanent. When these dates pass the findings come back and block, which
+# forces the upgrade decision to be made rather than forgotten.
+#
+# Removing an entry is the goal. Adding one needs the same written reason.
+
+# fastify 4.29.1 -> 5.x. Four findings. Major upgrade: plugin API and lifecycle
+# changes across every route file.
+[[IgnoredVulns]]
+id = "CVE-2026-25223"
+ignoreUntil = 2026-12-01
+reason = "fastify 4.29.1, fixed in 5.x. Major upgrade, tracked in security-scanning.md."
+
+[[IgnoredVulns]]
+id = "CVE-2026-18504"
+ignoreUntil = 2026-12-01
+reason = "fastify 4.29.1, fixed in 5.x. Major upgrade, tracked in security-scanning.md."
+
+[[IgnoredVulns]]
+id = "CVE-2026-3635"
+ignoreUntil = 2026-12-01
+reason = "fastify 4.29.1, fixed in 5.x. Major upgrade, tracked in security-scanning.md."
+
+[[IgnoredVulns]]
+id = "CVE-2026-25224"
+ignoreUntil = 2026-12-01
+reason = "fastify 4.29.1, fixed in 5.x. Major upgrade, tracked in security-scanning.md."
+
+# @fastify/static 7.0.4 -> 10.x. Gated behind the fastify 5 upgrade above.
+[[IgnoredVulns]]
+id = "CVE-2026-15074"
+ignoreUntil = 2026-12-01
+reason = "@fastify/static 7.0.4, fixed in 10.x. Gated behind the fastify 5 upgrade."
+
+[[IgnoredVulns]]
+id = "CVE-2026-7120"
+ignoreUntil = 2026-12-01
+reason = "@fastify/static 7.0.4, fixed in 10.x. Gated behind the fastify 5 upgrade."
+
+# find-my-way 8.2.2 -> 9.7.0. Transitive through fastify.
+[[IgnoredVulns]]
+id = "CVE-2026-47219"
+ignoreUntil = 2026-12-01
+reason = "find-my-way 8.2.2, fixed in 9.7.0. Transitive through fastify 4."
+
+# react-router 6.30.6 -> 7.18.0. Major upgrade across every route in the SPA.
+[[IgnoredVulns]]
+id = "CVE-2026-53666"
+ignoreUntil = 2026-12-01
+reason = "react-router 6.30.6, fixed in 7.18.0. Major upgrade, tracked in security-scanning.md."
+
+[[IgnoredVulns]]
+id = "CVE-2026-53669"
+ignoreUntil = 2026-12-01
+reason = "react-router 6.30.6, fixed in 7.18.0. Major upgrade, tracked in security-scanning.md."
+
+# electron 40.10.6 -> 41.10.3. No fix exists in the 40 line, so this needs a
+# major Electron upgrade and a re-run of the desktop hardening verification.
+[[IgnoredVulns]]
+id = "CVE-2026-70608"
+ignoreUntil = 2026-12-01
+reason = "electron 40.10.6, no fix in the 40 line. Needs the 41 upgrade plus fuse re-verification."
+
+# lodash 4.17.23 -> 4.18.0. Build-time only: electron-builder to
+# @malept/flatpak-bundler. Never ships in the app or the server image.
+[[IgnoredVulns]]
+id = "CVE-2021-23337"
+ignoreUntil = 2026-12-01
+reason = "lodash 4.17.23, build-time only via electron-builder. Does not ship to users."
+
+[[IgnoredVulns]]
+id = "CVE-2025-13465"
+ignoreUntil = 2026-12-01
+reason = "lodash 4.17.23, build-time only via electron-builder. Does not ship to users."
+
+# esbuild 0.18.20 -> 0.25.0. Build-time only: drizzle-kit to
+# @esbuild-kit/core-utils. Note the separate 0.28.2 copy that tsx pulls into the
+# server image is a different instance and is not affected by this advisory.
+[[IgnoredVulns]]
+id = "GHSA-67mh-4wv8-2f99"
+ignoreUntil = 2026-12-01
+reason = "esbuild 0.18.20, build-time only via drizzle-kit. The runtime copy is 0.28.2."


### PR DESCRIPTION
Flips the scanners in `security.yml` from report-only to blocking, and records
why the published-image scan is not flipped with them.

## Why this is not just deleting `continue-on-error`

Two things had to be true first, and both were measured.

**Trivy exits 0 in SARIF mode whatever it finds.** Removing the flag alone would
have looked like enforcement while enforcing nothing. The config and license jobs
now carry `exit-code: '1'` with a `HIGH,CRITICAL` filter, which is what actually
blocks and what keeps them aligned with the tiered policy.

**All 13 remaining dependency findings are fixable and 5 are HIGH**, so a plain
flip would have turned `main` red and blocked every pull request. Fixing them
means fastify 4 to 5, react-router 6 to 7 and electron 40 to 41: three major
upgrades with real compatibility work, which is its own piece of work.

## The ratchet

`osv-scanner.toml` lists exactly those 13, one entry each, with the reason and the
version that fixes it. Anything not in that file fails the job, so a newly
introduced vulnerability blocks while the documented backlog stays visible.

Every entry carries `ignoreUntil = 2026-12-01`. A waiver with no expiry is how a
backlog becomes permanent. When that date passes the findings come back and block,
which forces the upgrade decision rather than letting it rot. That does mean `main`
can go red on that date if nobody acts. The fix then is to do the upgrades, not to
push the date.

## The image scan stays report-only, deliberately

Measured against an image built from `main`: 20 fixable HIGH/CRITICAL. Trivy sees
the image's real `node_modules` while OSV reads the lockfile, so the two find
different things and the dependency pass does not cover these.

Making it blocking today would fail every release publish until that backlog is
worked, and holding security fixes behind a scanner backlog is the inversion this
project already decided against. It needs its own remediation pass first. The stale
comment claiming it gets flipped here has been replaced with that reasoning.

One thing that pass should start with: `pnpm` is present in the runtime image and
contributes several of the 20, even though the final stage never installs it and
only copies `node_modules` from the deps stage.

## Verification

`actionlint` passes on both workflow files. This PR is its own test: every scanner
in `security.yml` runs on `pull_request`, so if the ratchet or the exit codes are
wrong, the checks below go red rather than `main`.