### PR TITLE
chore: release 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backspace",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Open, self-hosted communication platform \u2014 text, voice, video, and federation",
   "license": "AGPL-3.0-only",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/desktop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backspace",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/server",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/shared",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/web",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/metrics",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",


### PR DESCRIPTION
Bumps all six `package.json` files to 1.0.3 in lockstep.

Contents: Tracks C, D and E of the security pass, plus the scanner enforcement flip.

- Security headers and a report-only content security policy (#71, #73)
- Outbound request validation with per-redirect re-checking (#72)
- Dependency and base image updates, including the move to Node 24 (#74)
- Dynamic scanning, runner hardening and the public evidence (#75, #76)
- Scanner enforcement with a documented dependency ratchet (#77)
- CSP observation evidence across two live deployments (#78)

The release gate for this version was that the content security policy had to be
observed on real deployments rather than merely merged. That is discharged and
recorded in `docs/systems/web-security.md`: three rounds across two instances,
covering messages, embeds, uploads, a voice join, screen sharing and the WASM
noise-suppression path, with the detector validated by injected controls on each
host and zero violations produced by the application.