### PR TITLE
fix(desktop): pin the Linux executable name for electron-builder 26

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -46,6 +46,12 @@ win:
   target:
     - nsis
 linux:
+  # electron-builder 26 derives executableName from package.json `name` when it is
+  # not set, and this package is named `@backspace/desktop`. Stripping the unsafe
+  # characters leaves `@backspacedesktop`, which it then rejects, so both Linux
+  # targets fail to build. Version 25 defaulted to productName instead, so this
+  # pins the value 25 produced rather than introducing a new one.
+  executableName: Backspace
   icon: build/icons/
   target:
     - AppImage


### PR DESCRIPTION
Both Linux legs of the v1.0.3 desktop build failed:

```
failed to build AppImage  error=executableName contains characters that cannot be
safely used in file paths: @backspacedesktop
```

**Cause.** electron-builder 26 changed where `executableName` comes from when it is
not set. Version 25 defaulted to `productName` (`Backspace`); version 26 derives it
from the package's `name`, which here is `@backspace/desktop`. Stripping the unsafe
characters leaves `@backspacedesktop`, which it then rejects, so the build stops.

The electron-builder major bump landed in #74. macOS and Windows do not use this
field the same way, which is why only Linux broke, and `release.yml` only runs on a
tag push, so nothing exercised it until the release itself.

**Fix.** Set `linux.executableName` explicitly to `Backspace`, which is the value 25
produced by default. This pins existing behaviour rather than introducing a new
name, so the executable inside the AppImage and deb is unchanged from 1.0.2.

macOS and Windows built successfully on the same run and are unaffected.