### PR TITLE
fix(ci): point Linux fuse verification at the renamed executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,15 +146,16 @@ jobs:
               )
               ;;
             Linux)
-              # Not "backspace": electron-builder names the Linux executable
-              # from package.json `name` ("@backspace/desktop") via
-              # sanitizeFileName().toLowerCase(), which drops the slash but
-              # keeps the leading "@" — the "@" is only special-cased for the
-              # .deb package name, not for the binary.
+              # Was "@backspacedesktop" up to 1.0.2: electron-builder derived the
+              # Linux executable from package.json `name` ("@backspace/desktop"),
+              # dropping the slash but keeping the leading "@". electron-builder 26
+              # validates that name and rejects it outright, so the build now sets
+              # linux.executableName explicitly. Keep this path in step with
+              # packages/desktop/electron-builder.yml; nothing else couples them.
               if [ "$RUNNER_ARCH" = "ARM64" ]; then
-                artifacts=("dist-electron/linux-arm64-unpacked/@backspacedesktop")
+                artifacts=("dist-electron/linux-arm64-unpacked/Backspace")
               else
-                artifacts=("dist-electron/linux-unpacked/@backspacedesktop")
+                artifacts=("dist-electron/linux-unpacked/Backspace")
               fi
               ;;
             *)


### PR DESCRIPTION
Follow-up to #80. That change let the Linux build get further, and it now fails in
the next step instead:

```
Expected packaged artifact not found:
packages/desktop/dist-electron/linux-unpacked/@backspacedesktop
```

The fuse verification step hardcodes the Linux binary path, and #80 renamed the
binary, so the two are out of step.

**A correction to what #80 claimed.** That PR said it pinned existing behaviour and
that the executable was unchanged from 1.0.2. That was wrong. Up to 1.0.2 the Linux
executable really was named `@backspacedesktop`, which is why this workflow looked
for it. electron-builder 26 rejects that name outright, so the rename is forced, not
behaviour-preserving. The Linux binary inside the AppImage and deb changes name in
1.0.3.

This updates both Linux paths and rewrites the comment above them, which still
described the old derivation as current.

The coupling is implicit: nothing links this workflow to
`packages/desktop/electron-builder.yml`, and only a tag build exercises it. The
comment now says so.