### PR TITLE
fix(ci): create the release draft once before the build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,84 @@ permissions:
   contents: read
 
 jobs:
+  # Create the draft release once, before the build matrix fans out.
+  #
+  # electron-builder's GitHub publisher lists the repository's releases, looks
+  # for one carrying this tag, and creates a draft when it finds none
+  # (electron-publish, gitHubPublisher.js, getOrCreateRelease). The four matrix
+  # jobs run that lookup concurrently, so all four can see "no release for this
+  # tag" before any of them has finished creating one. On v1.0.3 two of them
+  # went on to create a draft: the tag ended up with two releases and the 22
+  # assets split 12/10 between them, which is easy to miss because a release
+  # listing shows one entry per tag. Consolidating them was manual.
+  #
+  # With the draft already in place, every matrix job takes the "found an
+  # existing draft" branch of that lookup and only uploads. That branch returns
+  # the release untouched — the publisher never rewrites the name or the body of
+  # a release it did not create — so the title set below is the one the release
+  # keeps.
+  create-release:
+    runs-on: ubuntu-latest
+    # Scoped to this job: it is the only one that needs to create a release.
+    permissions:
+      contents: write
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: audit
+
+      - name: Create the draft release for this tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        # Listing releases rather than asking for one by tag: the "get a release
+        # by tag name" endpoint does not return drafts, and the release this job
+        # creates is a draft, so a re-run would not find its own work and would
+        # try to create a second one. The list endpoint includes drafts.
+        #
+        # Deliberately not `gh release create ... || true`. That form also
+        # swallows auth and network failures, and the matrix would then race
+        # exactly as before while this job reported success. Look first, create
+        # only on a confirmed absence, and let anything else fail the job.
+        #
+        # The title matches every release shipped so far ("Backspace 1.0.3").
+        # electron-builder would name the draft after the bare version instead,
+        # because `releaseInfo.releaseName` is not set in electron-builder.yml.
+        # Notes stay empty: they are written by hand before the draft is
+        # published, as they have been for every release.
+        run: |
+          set -euo pipefail
+
+          existing="$(gh api --paginate "repos/$GH_REPO/releases" \
+            --jq '.[] | select(.tag_name == env.TAG) | .id')"
+          count="$(printf '%s' "$existing" | grep -c . || true)"
+
+          if [ "$count" -gt 1 ]; then
+            ids="$(printf '%s' "$existing" | tr '\n' ' ')"
+            echo "::error::$count releases already carry the tag $TAG (ids: $ids) — this is the duplicate-release state this job exists to prevent. Consolidate them by hand before re-running."
+            exit 1
+          fi
+
+          if [ "$count" -eq 1 ]; then
+            echo "A release already carries $TAG (id $existing) — leaving it untouched."
+            exit 0
+          fi
+
+          echo "No release carries $TAG yet — creating the draft."
+          gh release create "$TAG" \
+            --draft \
+            --title "Backspace ${TAG#v}" \
+            --notes ""
+
   build:
+    # Every matrix job publishes into the draft that `create-release` has
+    # already made. Without this dependency they race to create it themselves.
+    needs: create-release
     # `contents: write` is scoped to this job: electron-builder runs with
-    # `--publish always`, which creates the GitHub release for the tag and
-    # uploads the installers and the updater feed files to it.
+    # `--publish always`, which uploads the installers and the updater feed
+    # files to the release for the tag.
     permissions:
       contents: write
     strategy:

--- a/docs/systems/desktop.md
+++ b/docs/systems/desktop.md
@@ -259,11 +259,19 @@ are unsigned. Consequences:
   install only.
 - **Linux:** AppImage auto-update works unsigned.
 
-CI publishes via `.github/workflows/release.yml` (tag `v*` on the public repo):
-native runners for mac (arm64+x64), win (x64+arm64), linux (x64, arm64), each
-job uploading its installers, `.blockmap`s, and platform `latest*.yml` manifest
-to a single draft release. The draft must be published manually — drafts are
+CI publishes via `.github/workflows/release.yml` (tag `v*` on the public repo).
+A `create-release` job runs first and creates the draft for the tag, then four
+native build jobs fan out (mac arm64+x64, win x64+arm64, linux x64, linux
+arm64), each uploading its installers, `.blockmap`s, and platform `latest*.yml`
+manifest into that one draft. The draft must be published manually — drafts are
 invisible to electron-updater.
+
+The `create-release` job exists because electron-builder creates the release
+itself when it cannot find one for the tag, and four jobs doing that lookup
+concurrently can all miss. On v1.0.3 two of them created a draft and the assets
+split across the pair, which needed manual consolidation before the release
+could be published. Creating the draft once, ahead of the matrix, leaves the
+build jobs with nothing to create.
 
 ### Check Schedule
 

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -46,11 +46,17 @@ win:
   target:
     - nsis
 linux:
-  # electron-builder 26 derives executableName from package.json `name` when it is
-  # not set, and this package is named `@backspace/desktop`. Stripping the unsafe
-  # characters leaves `@backspacedesktop`, which it then rejects, so both Linux
-  # targets fail to build. Version 25 defaulted to productName instead, so this
-  # pins the value 25 produced rather than introducing a new one.
+  # electron-builder derives the Linux executable name from package.json `name`
+  # when this key is unset (LinuxPackager: `appInfo.sanitizedName.toLowerCase()`),
+  # and this package is named `@backspace/desktop`. Sanitising drops the slash and
+  # leaves `@backspacedesktop`. Version 26 added a whitelist check on that derived
+  # value in the AppImage target (`validateCriticalPathString`, which permits only
+  # letters, digits, dots, underscores, hyphens and spaces), so the leading `@` now
+  # aborts both Linux targets. Version 25 derived exactly the same name but never
+  # validated it, which is why 1.0.2 shipped a Linux executable genuinely called
+  # `@backspacedesktop`. Setting this key is therefore a rename, not a restoration.
+  # Keep the fuse-verification paths in .github/workflows/release.yml in step with
+  # it; nothing else couples them.
   executableName: Backspace
   icon: build/icons/
   target:


### PR DESCRIPTION
## What this fixes

electron-builder's GitHub publisher lists the repository's releases, looks for one carrying the tag, and creates a draft when it finds none (`electron-publish/out/gitHubPublisher.js`, `getOrCreateRelease`). The four matrix jobs run that lookup concurrently, so all four can observe "no release for this tag" before any of them has finished creating one.

On v1.0.3 two of them went on to create a draft. The tag ended up with two releases and the 22 assets split 12/10 between them, which is easy to miss because a release listing shows one entry per tag. Consolidating them was manual, and it recurs on every tag until this is fixed.

## The change

A `create-release` job runs ahead of the matrix and creates the draft once. The four build jobs `needs:` it, so each one takes the "found an existing draft" branch of the lookup and only uploads.

Three details worth reviewing:

**The guard lists releases instead of asking for one by tag.** The get-a-release-by-tag endpoint does not return drafts, and the release this job creates is a draft, so a re-run would not find its own work and would try to create a second one. The list endpoint includes drafts.

**It is not `gh release create ... || true`.** That form swallows auth and network failures too, and the matrix would then race exactly as before while the job reported success. It looks first, creates only on a confirmed absence, and lets anything else fail the job. If it ever finds more than one release for the tag it fails loudly, since that is the state it exists to prevent.

**It sets the title.** The publisher returns an existing draft untouched, so whatever title this job sets is the one the release keeps. It uses `Backspace <version>`, matching all four releases shipped so far. electron-builder would have named the draft after the bare version instead, because `releaseInfo.releaseName` is not set in `electron-builder.yml`. Notes stay empty; they are written by hand before publishing, as they have been every time.

## Verification

`actionlint` passes on every workflow.

The step body was extracted and executed locally against a stubbed `gh`, covering all three branches: no release for the tag (creates the draft, with `Backspace 1.0.4` passed as a single argument), one release (leaves it alone, exits 0), two releases (fails with the consolidation message). The lookup itself was run against this repository for real: `v1.0.3` returns exactly one id, an absent tag returns none.

**What is not verified:** this workflow only triggers on a `v*` tag push, and I have not cut a tag to test it. The job ordering and the guard behaviour are verified; the end-to-end interaction with electron-builder's publisher is reasoned from its source, not observed. The first real proof will be the next release.

## Two corrections folded in

Both are comment and prose only, no behaviour, and both are claims this work disproved. They are here rather than in a separate PR because leaving a known-wrong comment next to the file being edited is worse than the small scope increase.

- `packages/desktop/electron-builder.yml` said version 25 derived the Linux executable name from `productName`. It did not. Both 25 and 26 derive it from the package name via `appInfo.sanitizedName.toLowerCase()`, identical code in both. What 26 added is `validateCriticalPathString` in the AppImage target, a whitelist that the leading `@` fails. So setting `linux.executableName` is a rename, and 1.0.2 really did ship an executable called `@backspacedesktop`.
- `docs/systems/desktop.md` described the matrix as uploading "to a single draft release", which was the intent rather than the behaviour. It now describes the job that makes it true.