### PR TITLE
chore: release 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backspace",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "Open, self-hosted communication platform \u2014 text, voice, video, and federation",
   "license": "AGPL-3.0-only",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/desktop",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backspace",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/shared",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/web",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/metrics",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",


### PR DESCRIPTION
Version bump only, across the six workspace packages. No other changes.

## What 1.0.4 carries

**The Content Security Policy is now enforcing** (#84). It shipped report-only from the start and was flipped after an observation phase run across two deployments. Violations are blocked rather than logged.

This is a smaller change than it sounds. `index.html` has carried an enforcing meta policy for `script-src`, `worker-src`, `object-src` and `base-uri` since 1.0.0, so the directives that stop script injection have been enforcing in every release already. What becomes enforcing here is `frame-src`, `form-action`, `frame-ancestors` and the content directives, which are deliberately permissive.

**The runtime container image no longer ships pnpm or npm** (#83). Neither was ever used at runtime: the stage installs nothing and the app starts `node` directly. Between them they accounted for 17 of the image's 20 fixable HIGH/CRITICAL scan findings, in code that never executed. The count is now 3.

**Release automation** (#82): the draft release for a tag is created once, before the build matrix, instead of four parallel jobs racing to create it. On 1.0.3 two of them won and the assets split across two drafts.

**Documentation** (#85 and #84): two wrong fix-versions corrected in the OSV ratchet, and the CSP observation evidence written up.

## Desktop

Nothing functional changed in `packages/desktop` since 1.0.3, so the installers in this release are equivalent to 1.0.2 and 1.0.3. Windows and Linux auto-update as usual. macOS users have no reason to update, and should know that updating resets the Input Monitoring and Screen Recording grants, because the ad-hoc signature has no stable identity.

## Note for the release itself

This is the first tag since #82 landed, so it is also the first test of the draft-race fix. Expect exactly one draft release. If two appear, #82 did not work and the assets need consolidating by hand before publishing.