### PR TITLE
fix(update): stop offering an install this build cannot perform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,3 +118,18 @@ LIVEKIT_API_SECRET=
 # Off-box replication hook — receives the new snapshot path as $1 (e.g. rclone/rsync/aws s3 cp):
 # BACKUP_OFFSITE_CMD=
 # BACKUP_DISABLED=false
+
+# ─── Updates ───────────────────────────────────────────────
+# How this instance gets its image: prebuilt | source. install.sh writes this
+# after its pull-or-build decision resolves; ./update.sh reads it to choose
+# between `docker compose pull` and `docker compose build`. If it is absent,
+# update.sh infers the channel from the image reference instead.
+# BACKSPACE_INSTALL_CHANNEL=prebuilt
+
+# Whether the admin Updates panel may look up the newest release on GitHub.
+# There is no background poller: the request happens only while a signed-in
+# admin has that panel open and the 6-hour cache is cold, and it carries nothing
+# that identifies your instance. Set to false for an airgapped instance, or if
+# you would rather your server never contact github.com at all. The panel still
+# shows the version you are running.
+# BACKSPACE_UPDATE_CHECK=true

--- a/README.md
+++ b/README.md
@@ -448,23 +448,45 @@ tunnel:
 
 ### Updating a running instance
 
-Back up first. The app auto-snapshots the SQLite DB, and you can take one on
-demand with `./backup.sh` (see [`docs/systems/deployment.md`](docs/systems/deployment.md)).
-Then, from the install directory:
+From the install directory:
+
+```bash
+./update.sh          # update, with one confirmation prompt
+./update.sh --check  # see whether an update exists, changing nothing
+```
+
+`update.sh` takes a database snapshot, refreshes the checkout where that is
+possible, fetches the new image (pulling or rebuilding to match how you
+installed), and restarts only the `backspace` container. It then waits for the
+healthcheck **and verifies the running version actually changed**. If either
+fails, it puts back the image you were on and tells you what happened. A
+no-op update is detected and skips the restart entirely, so nobody gets
+dropped from a voice call for nothing.
+
+Signed-in admins can see the running version and whether an update exists under
+**Instance Settings, Updates**, which also shows the exact command for their
+install.
+
+If you do not have `update.sh` yet (it ships from 1.0.5), take a snapshot with
+`./backup.sh`, then:
 
 ```bash
 git pull                              # refresh compose files / install.sh / docs
 
 # Prebuilt-image installs (the default):
-docker compose pull && docker compose up -d
+docker compose pull backspace && docker compose up -d backspace
 
 # From-source installs (a fork, or BACKSPACE_BUILD=true):
-docker compose up -d --build
+docker compose up -d --build backspace
 ```
 
 Because `COMPOSE_FILE` lives in `.env`, these commands automatically use the
 right compose files in every mode, with no `-f` flags to remember. A redeploy
 briefly restarts the `backspace` container (clients reconnect automatically).
+
+> **Name the `backspace` service and do not pass `--remove-orphans`.** If you run
+> other containers in the same compose project, Compose will suggest that flag,
+> and following it deletes them.
 
 ## Development
 

--- a/docs/superpowers/plans/2026-09-03-update-experience.md
+++ b/docs/superpowers/plans/2026-09-03-update-experience.md
@@ -1,0 +1,122 @@
+# Update Experience Implementation Plan
+
+**Spec:** `docs/superpowers/specs/2026-09-03-update-experience-design.md`
+
+**Goal:** Make the desktop update prompt tell the truth and stop nagging, give
+operators a version/update surface in Instance Settings, and ship `update.sh`.
+
+**Architecture:** The main process becomes the single authority on whether this
+build can install its own updates (measured from its own code signature) and on
+what update status the renderer should show. The renderer renders that status and
+nothing else. The server gains a read-only, admin-only, lazily-cached release
+check. `update.sh` is the operator-facing action the panel points at.
+
+## Global Constraints
+
+- TypeScript strict, no `any`, no placeholders, every function fully implemented.
+- No em dashes or buzzword register in any user-facing copy, doc, or commit.
+- Never `docker compose ... --remove-orphans`; always name the `backspace` service.
+- Public repo: no real infra hostnames in tracked files (pre-commit hook enforces).
+- `docs/systems/*` updated for every structural change.
+
+---
+
+## WS1 — Desktop
+
+### Task 1: Update capability probe
+- Create `packages/desktop/src/updateCapability.ts`
+- Create `packages/desktop/src/updateCapability.test.ts`
+- Produces: `classifyDesignatedRequirement(out: string): 'adhoc' | 'identified' | 'unknown'`,
+  `getUpdateCapability(): 'auto' | 'manual'` (memoised)
+- Gate: vitest covers ad-hoc cdhash, Developer ID anchor, empty, error text.
+
+### Task 2: Persisted per-version dismissal
+- Create `packages/desktop/src/updateDismissal.ts` + `.test.ts`
+- Produces: `loadDismissedVersion(): string | null`, `setDismissedVersion(v: string): void`,
+  `isDismissed(v: string): boolean`
+- Storage: `{userData}/update-state.json`. Corrupt file yields null, never throws.
+
+### Task 3: Update status model + main process rewiring
+- Create `packages/desktop/src/updateStatus.ts` (the `UpdateStatus` union + store)
+- Modify `packages/desktop/src/main.ts:initAutoUpdater()`
+- Wire `download-progress`, `update-not-available`; branch `autoDownload` on capability;
+  purge the stale updater cache in manual mode; branch the native notification;
+  add the `quitAndInstall` watchdog.
+- Keep `update-available` / `update-downloaded` / `update-error` channels intact
+  (recovery.ts consumes them).
+
+### Task 4: IPC surface
+- Modify `packages/desktop/src/preload.ts`, `packages/web/src/platform/electron.d.ts`
+- Add `getUpdateStatus`, `onUpdateStatusChanged`, `dismissUpdate`, `openReleasePage`.
+
+### Task 5: Renderer store + toast
+- Create `packages/web/src/stores/updateStore.ts` + `.test.ts`
+- Rewrite `packages/web/src/components/ui/UpdateToast.tsx` + add `.test.tsx`
+- `.glass-bubble`, no truncate, three visible phases, dismissal wired.
+
+### Task 6: Settings Desktop panel
+- Modify `packages/web/src/components/modals/settingsPanels/DesktopPanel.tsx`
+- Real states from the store; delete the `setTimeout(5000)` fiction.
+
+---
+
+## WS3 — update.sh
+
+### Task 7: The script
+- Create `update.sh` (root, mode 755)
+- Flags `--check`, `--yes`, `--no-backup`. Ten-step sequence per spec section 6.2.
+- Gate: `bash -n`, `shellcheck`, `--check` against a live host, one forced-failure
+  rollback rehearsal.
+
+### Task 8: Install channel recording
+- Modify `install.sh` to write `BACKSPACE_INSTALL_CHANNEL` at its existing
+  `BACKSPACE_BUILD` branch. Modify `.env.example`.
+
+---
+
+## WS2 — Server + admin panel
+
+### Task 9: Release check utility
+- Create `packages/server/src/utils/releaseCheck.ts` + `.test.ts`
+- Lazy, 6h cache, 5s timeout, fail-soft, `BACKSPACE_UPDATE_CHECK` kill switch.
+
+### Task 10: Admin endpoint
+- Create `packages/server/src/routes/adminUpdates.ts` + `.test.ts`
+- Add `InstanceUpdateStatus` to `packages/shared/src/types.ts`, register in the app.
+
+### Task 11: Updates panel
+- Create `packages/web/src/components/modals/instanceSettingsPanels/UpdatesPanel.tsx`
+- Register in `InstancePanel.tsx` and `MobileShell.tsx`.
+
+### Task 12: Docs
+- `docs/systems/desktop.md`, `desktop-security.md`, `admin.md`, `api.md`,
+  `deployment.md`, `README.md`, `.env.example`.
+
+
+---
+
+## Status: complete, 2026-09-03
+
+All twelve tasks landed. Verification performed:
+
+- **Unit tests:** 1835 pass (136 desktop, 579 web, 1120 server). `tsc --noEmit`
+  clean in all three packages. `pnpm -w build` succeeds.
+- **`update.sh`:** `bash -n` and shellcheck 0.11.0 clean. Rehearsed end to end on
+  a live throwaway instance: a real update, a no-op re-run that correctly
+  declined to restart, and a deliberately broken update (image repinned at
+  `alpine:3.20`) that failed the 180s health gate and rolled back to a healthy
+  instance on the previous image. Co-hosted containers untouched throughout.
+- **Capability probe:** the compiled module classifies the real ad-hoc signed
+  `/Applications/Backspace.app` as `manual` and a real Developer ID signed app as
+  `auto`, which is the evidence behind the claim that a Developer ID flips it
+  with no code change.
+- **Endpoint:** exercised against a live server and the real GitHub API. 401
+  unauthenticated, 403 non-admin, correct `up-to-date` against the published
+  1.0.4, cache hit proven by an identical `checkedAt`, `?refresh=true` proven by
+  a changed one, and `BACKSPACE_UPDATE_CHECK=false` proven to open no socket even
+  with `?refresh=true`.
+- **UI:** rendered and screenshotted in a throwaway harness (since deleted).
+  Two issues found and fixed that no unit test would have caught: the "I do not
+  have update.sh" disclosure did not read as a control, and the chained manual
+  command overflowed its block.
+- **Electron:** boots clean with the new modules.

--- a/docs/superpowers/specs/2026-09-03-update-experience-design.md
+++ b/docs/superpowers/specs/2026-09-03-update-experience-design.md
@@ -1,0 +1,592 @@
+# Update Experience Design
+
+**Date:** 2026-09-03
+**Status:** Design, approved for planning
+**Scope:** Desktop update UX, admin instance-version surface, operator update script
+
+---
+
+## 1. The reported problem
+
+On macOS, every launch of the desktop app produces a bottom-left toast reading
+"Update ready / Version 1.0.4 has been download…". Its **Restart** button does
+nothing at all. Dismissing it reveals a second toast, "Update failed /
+Auto-update failed — download manually", whose **Download** button works. The
+user is never asked whether they want to see the message again, so the whole
+cycle repeats on the next launch.
+
+Separately, a server operator has no way to see what version their instance is
+running, or to learn how to move it forward, without reading the README.
+
+---
+
+## 2. Root cause
+
+### 2.1 What was measured
+
+Evidence gathered from the reporting machine (running 1.0.3, offered 1.0.4):
+
+```
+$ codesign -d -r- /Applications/Backspace.app
+Executable=/Applications/Backspace.app/Contents/MacOS/Backspace
+# designated => cdhash H"4a9e49fe20f82802702a4e9d752748e990909659"
+
+$ ls ~/Library/Caches/@backspacedesktop-updater/pending
+Backspace-1.0.4-arm64.zip   (113,897,045 bytes)
+current.blockmap
+update-info.json
+
+$ ls ~/Library/Caches/@backspacedesktop-updater
+update.zip                  (113,897,045 bytes)   <- second copy
+current.blockmap
+
+$ ls ~/Library/Caches/com.backspace.desktop.ShipIt
+(empty)
+```
+
+### 2.2 The mechanism
+
+The app is ad-hoc signed by `packages/desktop/scripts/macSign.js` because CI has
+no Developer ID certificate. An ad-hoc signature has no stable identity, so the
+bundle's **designated requirement is a literal cdhash of that exact binary**.
+
+Squirrel.Mac validates a staged update against the *running* app's designated
+requirement. A 1.0.4 binary has a different cdhash, so it can never satisfy
+`cdhash H"4a9e49fe…"`. This is not a flaky failure. It is arithmetically
+impossible for every past and future release, as long as the build is ad-hoc
+signed. A Developer ID signed app would instead carry a requirement of the form
+`anchor apple generic and certificate leaf[subject.OU] = "TEAMID"`, which every
+later build from the same team satisfies. That is the only thing that fixes it.
+
+The empty `com.backspace.desktop.ShipIt` directory is Squirrel creating its state
+directory, failing validation, and writing nothing.
+
+### 2.3 Why the toast lies
+
+`electron-updater`'s `MacUpdater.doDownloadUpdate()`
+(`node_modules/electron-updater/out/MacUpdater.js:206-224`) fires
+`dispatchUpdateDownloaded(event)` **inside the `server.listen` callback**, the
+moment its local proxy server is up. It fires *before* Squirrel has been asked to
+do anything:
+
+```js
+this.server.listen(0, "127.0.0.1", () => {
+    this.nativeUpdater.setFeedURL({ ... });
+    this.dispatchUpdateDownloaded(event);      // <- our "Update ready" toast
+    if (this.autoInstallOnAppQuit) {
+        this.nativeUpdater.once("error", reject);
+        this.nativeUpdater.checkForUpdates();   // <- Squirrel now fails, later
+    }
+});
+```
+
+So `update-downloaded` means "the zip is on disk", not "the update can be
+installed". Our main process treats it as the latter and shows a Restart button.
+
+### 2.4 Why Restart does nothing
+
+Squirrel never succeeds, so `squirrelDownloadedUpdate` stays `false`.
+`MacUpdater.quitAndInstall()` (`MacUpdater.js:236-250`) then takes the else
+branch:
+
+```js
+quitAndInstall() {
+    if (this.squirrelDownloadedUpdate) { ... }
+    else {
+        this.nativeUpdater.on("update-downloaded", () => this.handleUpdateDownloaded());
+        if (!this.autoInstallOnAppQuit) { this.nativeUpdater.checkForUpdates(); }
+    }
+}
+```
+
+We set `autoInstallOnAppQuit = true` (`main.ts:729`), so the guarded
+`checkForUpdates()` is skipped. The method registers a listener for an event that
+will never fire and returns. **No error, no feedback, no exception.** That is the
+dead button, exactly.
+
+### 2.5 Why the error toast hides behind the ready toast
+
+`UpdateToast.tsx` holds two independent `useState` values and renders
+`downloadedVersion` first (lines 33-36), returning early. The Squirrel error
+arrives a second later and sets `failedUpdate`, but that branch is unreachable
+until the user dismisses the ready toast. The user's exact observation.
+
+### 2.6 Why it repeats every launch
+
+Dismissal is component state. Nothing is persisted, so the 10-second post-launch
+check re-runs the entire cycle on every start, re-downloading or re-validating
+114 MB that can never be installed.
+
+### 2.7 Summary of defects
+
+| # | Defect | Root cause |
+|---|--------|-----------|
+| RC1 | Restart button is dead | `quitAndInstall()` no-ops when Squirrel never staged the update |
+| RC2 | App claims an update is installable when it cannot be | `update-downloaded` is treated as "installable"; on macOS it only means "file on disk" |
+| RC3 | 228 MB downloaded per machine for nothing | `autoDownload = true` unconditionally, on a platform that cannot install |
+| RC4 | Error toast masked by the ready toast | Two independent states, render order decides, latest event does not win |
+| RC5 | Nags on every launch | No persisted per-version dismissal |
+| RC6 | "Checking…" in settings is a 5-second `setTimeout` fiction | `update-not-available` and `download-progress` are emitted by electron-updater and never wired |
+| RC7 | Toast uses `.glass-pill` | Design system reserves `.glass-pill` for inline decorations; a persistent floating control is `.glass-bubble` |
+| RC8 | Subtitle truncates mid-word | `truncate` on a `max-w-[340px]` container |
+| RC9 | Native notification offers "Click to restart and install" on macOS | Same false premise as RC2; the click calls the dead `quitAndInstall()` |
+
+---
+
+## 3. Non-goals
+
+- **Buying an Apple Developer ID is out of scope for this work.** It is the only
+  real fix for macOS auto-update and it is a purchasing decision, tracked in
+  `docs/systems/desktop-security.md`. This design is written so that the day a
+  Developer ID lands in CI, macOS switches to real auto-update with no code
+  change (see 4.1).
+- **No in-app "update my server" button.** See 6.1 for why.
+- Not changing the release pipeline, the image, or the CSP work.
+
+---
+
+## 4. Part A — Desktop update experience
+
+### 4.1 Update capability is measured, not assumed
+
+New module `packages/desktop/src/updateCapability.ts`.
+
+```ts
+export type UpdateCapability = 'auto' | 'manual';
+```
+
+`manual` means "this build cannot install its own updates; offer a download
+instead". The value is computed once at startup and cached.
+
+Detection, in order:
+
+1. Not packaged (`!app.isPackaged`) -> `manual`. A dev build must never try.
+2. `process.platform !== 'darwin'` -> `auto`. NSIS and AppImage update unsigned.
+3. macOS: run `codesign -d -r- <app bundle path>` and parse the designated
+   requirement.
+   - The requirement is only a bare `cdhash H"…"` -> ad-hoc -> `manual`.
+   - The requirement references `anchor apple generic`, `certificate leaf`, or
+     `identifier` -> a real identity -> `auto`.
+4. `codesign` missing, non-zero exit, or unparseable output -> `manual`.
+
+Choosing `manual` on every uncertain path is deliberate: a Download button always
+works, so the failure mode of guessing wrong is a slightly less convenient but
+functional experience, never a dead button.
+
+The parser is a pure function so it is testable without a Mac:
+
+```ts
+export function classifyDesignatedRequirement(codesignOutput: string): 'adhoc' | 'identified' | 'unknown';
+```
+
+This is the same pure-helper-plus-vitest shape already used by
+`packages/desktop/src/autoLaunch.ts`.
+
+**This is what makes the Developer ID a zero-code-change switch.** The probe
+measures the property that actually determines whether Squirrel can work, rather
+than hardcoding "macOS is broken", which would silently become a lie.
+
+### 4.2 Do not download what cannot be installed
+
+In `initAutoUpdater()`:
+
+```ts
+const capability = getUpdateCapability();
+autoUpdater.autoDownload = capability === 'auto';
+autoUpdater.autoInstallOnAppQuit = capability === 'auto';
+```
+
+In `manual` mode the flow stops at `update-available`. No 114 MB fetch, no proxy
+server, no Squirrel invocation, therefore no spurious error either. RC3 and the
+error-toast half of RC4 both disappear at the source.
+
+### 4.3 Reclaim the dead cache
+
+On startup, in `manual` mode only, delete the updater pending cache if present:
+
+```
+{app.getPath('cache')}/{sanitized-name}-updater/
+```
+
+Guarded to that exact path, only in `manual` mode, failures logged and ignored.
+This recovers the 228 MB already stranded on every existing macOS install. It is
+our own cache directory and holds nothing but a re-downloadable archive.
+
+### 4.4 A single update state, latest event wins
+
+Replace the two booleans with one discriminated union owned by the main process
+and mirrored to the renderer.
+
+```ts
+export type UpdateStatus =
+  | { phase: 'idle' }
+  | { phase: 'checking' }
+  | { phase: 'available'; version: string; releaseUrl: string; canInstall: boolean }
+  | { phase: 'downloading'; version: string; percent: number; bytesPerSecond: number }
+  | { phase: 'ready'; version: string }
+  | { phase: 'failed'; version: string | null; message: string; releaseUrl: string }
+  | { phase: 'up-to-date'; checkedAt: number };
+```
+
+Rules:
+
+- Every updater event replaces the whole status. There is no way for a stale
+  `ready` to outrank a fresh `failed`, which is RC4 fixed structurally rather
+  than by reordering JSX.
+- `canInstall` is `capability === 'auto'`. The renderer never has to know about
+  code signing; it renders a Restart button if and only if the main process says
+  the build can install.
+- `up-to-date` decays to `idle` after 5 seconds, matching the existing
+  `lastCheckResult` convention in `recovery.ts`.
+
+Existing IPC channels `update-available`, `update-downloaded` and `update-error`
+are **kept** and keep their current payloads, because `recovery.html` and the
+recovery state store consume the same events. One new channel carries the union:
+
+| Channel | Direction | Payload |
+|---|---|---|
+| `update-status-changed` | M -> R | `UpdateStatus` |
+| `get-update-status` | R -> M (invoke) | `UpdateStatus` |
+| `dismiss-update` | R -> M | `{ version: string }` |
+| `open-release-page` | R -> M | none, opens the releases URL externally |
+
+`download-progress` is wired for the first time, feeding the `downloading` phase.
+That closes RC6's second half.
+
+### 4.5 Dismissal is persisted, and belongs to the app
+
+New module `packages/desktop/src/updateDismissal.ts`, persisting to
+`{userData}/update-state.json`:
+
+```ts
+interface UpdateDismissalState { dismissedVersion: string | null }
+```
+
+The dismissal lives in the main process, not `localStorage`, because an available
+update is a property of **the installed app**, not of whichever instance the user
+happens to be connected to. A user who switches instances must not be re-nagged.
+
+`dismissedVersion` is compared against the offered version, so a *newer* release
+always surfaces again. Dismissing 1.0.4 does not silence 1.0.5.
+
+The main process applies the filter, so the renderer receives a status it should
+act on and nothing else. `showNotification` respects it too.
+
+### 4.6 The toast
+
+Rewritten as `packages/web/src/components/ui/UpdateToast.tsx`, backed by a new
+`packages/web/src/stores/updateStore.ts` (Zustand) so state survives remounts.
+
+Surface: `.glass-bubble` (RC7). It is a persistent floating control, which is
+exactly the tier's definition in `docs/systems/design-system.md`. Bottom-left,
+`z-[300]`, `animate-slide-up`, `max-w-[400px]`. **No `truncate` on the body
+copy** (RC8); it wraps to two lines, which is what the sentence needs.
+
+Visible only when `phase` is `available`, `ready` or `failed`, and only when the
+version is not dismissed. `checking`, `downloading` and `up-to-date` are settings
+panel states, not interruptions.
+
+`ready` (auto-capable builds):
+
+> **Update ready**
+> Backspace 1.0.4 is downloaded and ready to install.
+> `[Restart now]`  `[Later]`  `×`
+
+`available` with `canInstall: false` (ad-hoc macOS today):
+
+> **Backspace 1.0.4 is available**
+> You are on 1.0.3. This build cannot update itself, so download the new
+> version from GitHub.
+> `[Download]`  `[Release notes]`  `×`
+
+The second sentence is the fix for "it feels broken": the app states plainly that
+it will not self-install, instead of showing a Restart button that does nothing.
+
+`failed`:
+
+> **Update could not be installed**
+> Backspace 1.0.4 downloaded, but installing it failed. You can install it
+> manually.
+> `[Download]`  `×`
+
+`Later` and `×` both call `dismiss-update` for that version. Copy under the
+buttons on first dismissal: "You can install this later from Settings, Desktop."
+So nothing is lost and nothing nags.
+
+### 4.7 Restart can no longer fail silently
+
+`install-update` gets a watchdog. After calling `quitAndInstall()`, if the app is
+still alive 4 seconds later, the main process transitions to
+`{ phase: 'failed', message: 'Restarting to install did not start.' }`.
+
+In `manual` mode the Restart button never renders, so this path is unreachable
+there. The watchdog exists for the Windows and Linux cases where the same silent
+no-op is possible, and it is defence in depth against RC1 recurring on a platform
+we did not anticipate.
+
+### 4.8 The native notification stops lying
+
+`update-downloaded`'s notification currently reads "Click to restart and install
+version X" and its click handler calls `quitAndInstall()` (RC9).
+
+Branch on capability:
+
+| Capability | Title | Body | Click |
+|---|---|---|---|
+| `auto` | Backspace update ready | Click to restart and install version X. | `quitAndInstall()` |
+| `manual` | Backspace X is available | Click to open the download page. | `shell.openExternal(releasesUrl)` |
+
+Fires on `update-available` in manual mode and `update-downloaded` in auto mode,
+in both cases suppressed when the window is focused and when the version is
+dismissed.
+
+### 4.9 Settings, Desktop panel
+
+`DesktopPanel.tsx`'s `UpdateSettings` is rewritten against the real event stream.
+The `setTimeout(5000)` fiction goes away (RC6), along with its comment claiming
+electron-updater has no "no update" callback, which is not true.
+
+States rendered inline: `Up to date`, `Checking…`, `Downloading 43%`,
+`1.0.4 ready to install [Restart]`, `1.0.4 available [Download]`,
+`Check failed [Retry]`.
+
+This panel ignores dismissal. It is the place a dismissed update remains
+reachable, which is what makes dismissal safe.
+
+---
+
+## 5. Part B — Instance version and update for operators
+
+### 5.1 New admin endpoint
+
+`GET /api/admin/instance/update-status`, `preHandler: [authenticate, requireAdmin]`.
+
+```ts
+export interface InstanceUpdateStatus {
+  current: { version: string; commit: string | null };
+  latest: { version: string; url: string; publishedAt: string } | null;
+  state: 'up-to-date' | 'update-available' | 'unknown';
+  checkedAt: number | null;
+  checkEnabled: boolean;
+  reason: 'disabled' | 'unreachable' | 'rate-limited' | null;
+  channel: 'prebuilt' | 'source' | 'unknown';
+}
+```
+
+Lives in a new `packages/server/src/routes/adminUpdates.ts` rather than growing
+`admin.ts`, whose 404 lines are already storage plus users plus settings.
+
+Comparison uses a semver compare over the `\d+\.\d+\.\d+` triple. A tag that does
+not parse yields `state: 'unknown'` rather than a wrong answer.
+
+### 5.2 The instance never phones home on its own
+
+**There is no background poller.** The GitHub call happens only while an
+authenticated admin has the Updates panel open and the cache is cold.
+
+This matters for a self-hosted, privacy-positioned product. An instance that
+silently contacts a third party on a timer is a thing operators are entitled to
+be annoyed about. Here, an admin opening the panel *is* the consent, and an
+instance whose admin never opens the panel never contacts GitHub at all.
+
+Implementation, in `packages/server/src/utils/releaseCheck.ts`:
+
+- URL is the compile-time constant
+  `https://api.github.com/repos/TheZwiss/backspace/releases/latest`. It is never
+  derived from user input, so the SSRF policy in `docs/systems/embeds.md` does
+  not apply; a comment records that reasoning at the call site.
+- `User-Agent: Backspace`. GitHub requires a UA. The version is deliberately
+  omitted so the request carries nothing that identifies the instance beyond the
+  IP that any outbound request would expose.
+- 5-second timeout, in-memory cache with a 6-hour TTL.
+- Every failure is soft: `state: 'unknown'` with a `reason`. An operator with no
+  outbound internet still gets a working panel showing their running version.
+- `BACKSPACE_UPDATE_CHECK=false` disables it outright, for airgapped instances.
+  The endpoint then returns `checkEnabled: false, reason: 'disabled'` without
+  opening a socket.
+
+### 5.3 Install channel
+
+`install.sh` writes `BACKSPACE_INSTALL_CHANNEL=prebuilt|source` into `.env` at
+the point it already branches on `BACKSPACE_BUILD`. Absent on pre-existing
+installs, which map to `'unknown'` and simply show both sets of manual commands.
+No guessing.
+
+### 5.4 The Updates panel
+
+New sub-tab **Instance -> Updates**, `packages/web/src/components/modals/instanceSettingsPanels/UpdatesPanel.tsx`,
+registered in `InstancePanel.tsx` and in `MobileShell.tsx`'s `screenMap` as
+`settings-instance-updates`, matching every existing sibling panel.
+
+```
+Updates
+
+┌─ Running ─────────────────────────────────────────────┐
+│  Backspace 1.0.3                                      │
+│  commit 73cc4fd · prebuilt image                      │
+└───────────────────────────────────────────────────────┘
+
+┌─ 1.0.4 is available ──────────────────────────────────┐   accent-bordered
+│  Released 3 September 2026 · Release notes ↗          │
+│                                                       │
+│  From your install directory:                         │
+│  ┌──────────────────────────────────┐  [copy]         │
+│  │ ./update.sh                      │                 │
+│  └──────────────────────────────────┘                 │
+│                                                       │
+│  Takes a database backup, pulls the new image, and    │
+│  restarts. If the new version does not come up        │
+│  healthy it rolls back to the one you are on now.     │
+│                                                       │
+│  ▸ I don't have update.sh                             │
+└───────────────────────────────────────────────────────┘
+
+Last checked 2 minutes ago · [Check again]
+```
+
+- Up to date: the second card is replaced by a calm "You are on the latest
+  release." with no call to action.
+- `unknown`: "Could not reach GitHub to check for updates." plus the running
+  version, still useful.
+- `disabled`: "Update checks are turned off on this instance." with the env var
+  named.
+- The disclosure "I don't have update.sh" expands to `git pull` plus the raw
+  `docker compose` commands for both channels. Necessary because an operator on
+  1.0.4 does not yet have the script that ships in 1.0.5.
+
+The command block is a `select-all`-friendly `<code>` with a copy button using
+the existing clipboard pattern.
+
+---
+
+## 6. Part C — `update.sh`
+
+### 6.1 Why there is no button
+
+Triggering a container update from inside the container requires mounting
+`/var/run/docker.sock`. That grants the container root on the host. Backspace
+parses user-uploaded media, scrapes URLs for embeds, and accepts federation
+payloads from remote instances, so any remote-code-execution bug in it would
+become host root the moment that socket is mounted.
+
+Trading that for a button that saves one `ssh` is not a trade worth making, and
+it is the sort of thing that gets a CVE number. The panel therefore hands the
+operator an exact, correct, copyable command instead, and the work goes into
+making that command excellent.
+
+### 6.2 What the script does
+
+New `update.sh` at the repository root, alongside `install.sh`, `backup.sh`,
+`restore.sh`, `deploy.sh`, following their conventions (`set -euo pipefail`,
+`cd "$(dirname "$0")"`, coloured `info`/`warn`/`success` helpers).
+
+```
+./update.sh [--check] [--yes] [--no-backup]
+```
+
+Sequence:
+
+1. **Preflight.** `docker` and `docker compose` present; `.env` exists;
+   the `backspace` service is defined in the resolved compose files. Refuse
+   early and clearly otherwise.
+2. **Record the rollback point.** `docker inspect` the running container for its
+   image digest. This exact digest is what a failed update returns to.
+3. **Refresh the checkout, tolerantly.** If `.git` is absent, say so and carry on
+   (an rsync-deployed host is a legitimate install). If the working tree is dirty
+   or the branch has diverged, refuse to `git pull`, say why, and carry on with
+   the image update. Never clobber an operator's local edits.
+4. **Back up.** `./backup.sh` unless `--no-backup`. A failed backup aborts the
+   update. This is the one step whose failure is fatal, because everything after
+   it is only safe if it happened.
+5. **Fetch.** `docker compose pull backspace` for `prebuilt`,
+   `docker compose build backspace` for `source`. Channel from
+   `BACKSPACE_INSTALL_CHANNEL`, falling back to detecting whether the resolved
+   image ref is a GHCR ref.
+6. **No-op detection.** If the pulled digest equals the recorded one, report
+   "already on the newest image" and exit 0 without restarting. Restarting a chat
+   server for nothing disconnects everyone in a voice call.
+7. **Restart, narrowly.** `docker compose up -d backspace`. **The service is
+   named explicitly and `--remove-orphans` is never passed**, because production
+   hosts run other services behind the same compose project and the same Caddy.
+   Recreating or reaping them is out of scope for a Backspace update and has
+   caused outages before.
+8. **Health gate.** Poll `docker inspect` for `Health.Status == healthy`, up to
+   180 seconds. The compose healthcheck is `interval: 30s, retries: 5,
+   start_period: 30s`, so anything under about 120 seconds would produce false
+   failures.
+9. **Verify the version actually moved.** Query `/api/instance/info` through the
+   container and compare `version` against the pre-update value. A container that
+   is healthy but still running the old code is a failed update, and only this
+   check catches it.
+10. **Roll back on failure.** Re-pin the recorded digest, `up -d backspace`, wait
+    for healthy, and report both the failure and the restored version. Then point
+    at `./restore.sh` for the database, and exit non-zero.
+
+`--check` performs steps 1, 2, 3 (read-only), and 5's registry lookup via
+`docker manifest inspect`, then reports whether an update is available and exits.
+It writes nothing and restarts nothing.
+
+`--yes` skips the single confirmation prompt, for cron and for `ssh host
+'./update.sh --yes'`.
+
+### 6.3 Why the version check in step 9
+
+The Pi and VM updates performed on 2026-09-03 both had `git pull` fail (one host
+is not a git checkout, the other has diverged) while `docker compose pull`
+succeeded. The update was still correct, but nothing in the manual procedure
+would have reported it if it had not been. Step 9 makes the script assert the
+outcome rather than the steps.
+
+---
+
+## 7. Testing
+
+| Area | Test | File |
+|---|---|---|
+| Capability parse, ad-hoc | bare `cdhash H"…"` -> `adhoc` | `packages/desktop/src/updateCapability.test.ts` |
+| Capability parse, Developer ID | `anchor apple generic and certificate leaf…` -> `identified` | same |
+| Capability parse, garbage | empty / error text -> `unknown` | same |
+| Dismissal | dismissing 1.0.4 hides 1.0.4, still shows 1.0.5 | `packages/desktop/src/updateDismissal.test.ts` |
+| Dismissal | corrupt JSON on disk yields a clean default, does not throw | same |
+| Status reducer | `failed` after `ready` wins (RC4) | `packages/web/src/stores/updateStore.test.ts` |
+| Status reducer | `available` with `canInstall: false` renders no Restart button | `packages/web/src/components/ui/UpdateToast.test.tsx` |
+| Toast | dismissed version renders nothing | same |
+| Release check | 200 with a newer tag -> `update-available` | `packages/server/src/utils/releaseCheck.test.ts` |
+| Release check | 200 with the same tag -> `up-to-date` | same |
+| Release check | timeout / 403 / unparseable tag -> `unknown` with a reason, never throws | same |
+| Release check | second call inside the TTL performs no fetch | same |
+| Release check | `BACKSPACE_UPDATE_CHECK=false` opens no socket | same |
+| Endpoint | non-admin gets 403 | `packages/server/src/routes/adminUpdates.test.ts` |
+| Endpoint | shape matches `InstanceUpdateStatus` | same |
+| `update.sh` | `bash -n` and `shellcheck` clean | CI lint step |
+| `update.sh` | `--check` on a live host reports without mutating | manual, recorded |
+
+`update.sh` is verified end to end against the throwaway Kobold host before it
+ships, including a deliberately failed update to exercise the rollback path.
+
+---
+
+## 8. Documentation to update
+
+Per `CLAUDE.md`'s documentation rule, all of these are structural:
+
+| Doc | Change |
+|---|---|
+| `docs/systems/desktop.md` | Auto-Update section rewritten: capability probe, manual mode, the `update-downloaded` semantics trap, new IPC channels, `update-state.json` in the persisted-files table, the notification branch |
+| `docs/systems/desktop-security.md` | Record that the ad-hoc designated requirement is a cdhash literal and that this is the mechanism blocking auto-update, alongside the existing procurement note |
+| `docs/systems/admin.md` | New `GET /api/admin/instance/update-status`, the Updates panel, `BACKSPACE_UPDATE_CHECK`, `BACKSPACE_INSTALL_CHANNEL` |
+| `docs/systems/api.md` | The new endpoint |
+| `docs/systems/deployment.md` | `update.sh`: sequence, rollback, `--check`, why the service is named explicitly |
+| `docs/systems/design-system.md` | No change; the toast is being brought into compliance with it, not changing it |
+| `README.md` | "Updating a running instance" points at `./update.sh` with the manual commands kept as the fallback |
+| `.env.example` | `BACKSPACE_UPDATE_CHECK`, `BACKSPACE_INSTALL_CHANNEL` |
+
+---
+
+## 9. Sequencing
+
+1. **WS1, desktop.** Fixes the reported bug. Independent of the rest.
+2. **WS3, `update.sh`.** Must exist before the panel can point at it.
+3. **WS2, server endpoint and Updates panel.** Depends on WS3.
+
+WS1 and WS3 can proceed in parallel. All three ship in 1.0.5.

--- a/docs/systems/admin.md
+++ b/docs/systems/admin.md
@@ -2,6 +2,8 @@
 
 Source files:
 - `packages/server/src/routes/admin.ts` -- User management, storage management endpoints
+- `packages/server/src/routes/adminUpdates.ts` -- Instance version and update-status endpoint
+- `packages/server/src/utils/releaseCheck.ts` -- Lazy, cached, fail-soft latest-release lookup
 - `packages/server/src/routes/instance.ts` -- Public instance info endpoint
 - `packages/server/src/routes/settings.ts` -- Instance settings and streaming limits endpoints
 - `packages/server/src/utils/auth.ts` -- `requireAdmin` middleware
@@ -14,6 +16,7 @@ Source files:
 - `packages/web/src/components/modals/instanceSettingsPanels/StoragePanel.tsx` -- Storage management UI
 - `packages/web/src/components/modals/instanceSettingsPanels/StreamingPanel.tsx` -- Streaming config UI
 - `packages/web/src/components/modals/instanceSettingsPanels/UsersPanel.tsx` -- User management UI
+- `packages/web/src/components/modals/instanceSettingsPanels/UpdatesPanel.tsx` -- Instance version and update guidance UI
 - `packages/server/src/routes/invites.ts` -- Admin invite-link CRUD endpoints
 - `packages/server/src/utils/inviteService.ts` -- Token generation, derived status, atomic redemption transaction
 - `packages/shared/src/types.ts` -- Shared type interfaces
@@ -50,6 +53,7 @@ Settings are split into two API surfaces:
 | General/Admin | `GET /api/settings/instance` (admin) | `PATCH /api/settings/instance` (admin) |
 | Streaming | `GET /api/settings/streaming` (auth) | `PATCH /api/settings/streaming` (admin) |
 | Public info | `GET /api/instance/info` (public) | N/A (derived from settings) |
+| Update status | `GET /api/admin/instance/update-status` (admin) | N/A (read-only by design, see below) |
 
 ### General Settings Schema (InstanceAdminSettings)
 
@@ -259,6 +263,77 @@ Storage functions (`getStorageStats`, `getOrphanedFiles`, `cleanupStorage`, `cle
 
 **Media cleanup validation:** `maxAgeDays` must be a positive integer >= 1. Returns 400 otherwise.
 
+### Instance Updates
+
+Admin-only, read-only.
+
+```
+GET /api/admin/instance/update-status[?refresh=true] → InstanceUpdateStatus
+```
+
+```typescript
+interface InstanceUpdateStatus {
+  current: { version: string; commit: string | null };
+  latest: { version: string; url: string; publishedAt: string } | null;
+  state: 'up-to-date' | 'update-available' | 'unknown';
+  checkedAt: number | null;
+  checkEnabled: boolean;
+  reason: 'disabled' | 'unreachable' | 'rate-limited' | 'unparseable' | null;
+  channel: 'prebuilt' | 'source' | 'unknown';
+}
+```
+
+**There is no background poller.** The GitHub lookup happens only while a
+signed-in admin has the Updates panel open and the six-hour cache is cold. An
+instance whose admin never opens that panel never contacts github.com. For a
+self-hosted, privacy-positioned product that is a promise worth keeping, and it
+is why the check lives on a request path rather than on a timer.
+
+`releaseCheck.ts` details:
+
+- The URL is the compile-time constant
+  `https://api.github.com/repos/TheZwiss/backspace/releases/latest`. It is never
+  derived from user input, so the SSRF policy in [embeds.md](embeds.md) does not
+  apply.
+- `User-Agent: Backspace`. GitHub requires one. The running version is
+  deliberately omitted so the request carries nothing identifying the instance
+  beyond the IP any outbound request would expose, and so GitHub's logs do not
+  become a version census of every deployment.
+- 5s timeout, `redirect: 'error'`, 512 KB response cap.
+- Successes cached 6h; failures cached for a tenth of that, so a transient
+  outage clears without hammering a rate-limited endpoint.
+- Concurrent requests are coalesced into one outbound call.
+- Every failure is soft: `state: 'unknown'` plus a `reason`. An operator with no
+  outbound internet still gets a panel that reports what they are running.
+- Drafts and prereleases are skipped. An `html_url` that is not on github.com is
+  replaced with a constructed one rather than rendered as a link.
+- `state` is `unknown` rather than a guess whenever either version fails to
+  parse as `major.minor.patch`. Running *ahead* of the latest release reports
+  `up-to-date`, so a maintainer on an unreleased build is not told to downgrade.
+
+**`BACKSPACE_UPDATE_CHECK=false`** disables the lookup outright. The endpoint
+then returns `checkEnabled: false, reason: 'disabled'` without opening a socket,
+and `?refresh=true` cannot override it.
+
+**`BACKSPACE_INSTALL_CHANNEL`** (`prebuilt` | `source`) is written to `.env` by
+`install.sh` after its pull-or-build decision resolves, so a fallback-to-build is
+recorded truthfully. Absent on older installs, which report `unknown`; the panel
+then shows both sets of manual commands rather than guessing. `./update.sh` reads
+the same value.
+
+#### Why there is no endpoint that performs the update
+
+Applying a container update from inside the container requires mounting
+`/var/run/docker.sock`, which grants the container root on the host. Backspace
+parses user-uploaded media, scrapes URLs for embeds, and accepts federation
+payloads from remote instances, so any remote-code-execution bug in it would
+become host root the moment that socket exists. Trading that for a button is not
+a trade worth making. The panel hands the operator an exact, copyable command
+instead, and `./update.sh` (see [deployment.md](deployment.md)) is where the
+effort went.
+
+---
+
 ### User Management
 
 All admin-only.
@@ -446,6 +521,22 @@ Zustand store managing two data objects:
 ### Admin UI Panels
 
 All panels live under `packages/web/src/components/modals/instanceSettingsPanels/`. Each operates as a controlled form with a local `draft` state, detecting changes against the store's server-synced values. Unsaved changes show a sticky glass-bubble save/reset bar at the bottom.
+
+#### UpdatesPanel
+
+Shows the running version, commit, and install channel; whether a newer release
+exists, with its date and a link to the notes; and the exact command to run.
+Ignores nothing and hides nothing: when the lookup could not be made it says so
+and still reports what is running, distinguishing "turned off", "rate-limited",
+and "could not reach GitHub", because those call for different responses.
+
+The command block is `select-all`-friendly with a copy button. A disclosure,
+"I do not have update.sh", expands to `git pull` plus the raw compose commands
+for the relevant channel. That disclosure is necessary because `update.sh` ships
+from 1.0.5 onward, so an operator on 1.0.4 does not have it yet.
+
+Registered as the `updates` sub-tab in `InstancePanel.tsx`, and as
+`settings-instance-updates` in `MobileShell.tsx` / `MobileInstancePanel.tsx`.
 
 #### GeneralPanel
 

--- a/docs/systems/api.md
+++ b/docs/systems/api.md
@@ -276,6 +276,23 @@ POST   /admin/users/:id/reset-password                     → { temporaryPasswo
 DELETE /admin/users/:id                                    → { success }
 ```
 
+## Admin: Instance Updates (`routes/adminUpdates.ts`) — admin required
+```
+GET    /admin/instance/update-status  ?refresh=true    → InstanceUpdateStatus
+```
+
+Read-only. There is deliberately no endpoint that applies an update: doing so from
+inside the container needs `/var/run/docker.sock` mounted, which is host root.
+See [admin.md](admin.md) for the full rationale and [deployment.md](deployment.md)
+for `./update.sh`, which the panel points at instead.
+
+The GitHub lookup runs only on this request path, never on a timer, and is cached
+6h (failures for a tenth of that). `?refresh=true` bypasses the cache for an
+explicit re-check but cannot bypass `BACKSPACE_UPDATE_CHECK=false`, which makes
+the endpoint return `checkEnabled: false, reason: 'disabled'` without opening a
+socket. Every network failure is soft: `state: 'unknown'` with a `reason`, never a
+5xx, so the panel always reports the running version.
+
 ## Admin: Invite Management (`routes/invites.ts`) — admin required
 
 All endpoints sit behind `[authenticate, requireAdmin]`. Mutating endpoints wrap their read-modify-write in a SQLite transaction with an in-txn re-fetch + status re-derive; any state mismatch returns 409. Service layer: `packages/server/src/utils/inviteService.ts` (`InviteValidationError` → 400, `InviteNotFoundError` → 404, `InviteStateConflictError` → 409).

--- a/docs/systems/deployment.md
+++ b/docs/systems/deployment.md
@@ -10,6 +10,7 @@ Source files:
 - `Caddyfile` -- reverse proxy / auto-HTTPS config (All-in-One mode only)
 - `install.sh` -- interactive first-time setup, mode-aware (allinone / proxy / tunnel)
 - `deploy.sh` -- rsync + rebuild to Heidi's two boxes
+- `update.sh` -- operator update: snapshot, fetch, restart, verify, roll back
 - `backup.sh` / `restore.sh` -- manual snapshot + restore tooling (host side)
 - `packages/server/src/config.ts` -- `config.backup.*` env parsing
 - `packages/server/src/utils/backup.ts` -- `createSnapshot` (VACUUM INTO), `listSnapshots`, `pruneSnapshots`, off-box hook
@@ -168,6 +169,40 @@ Caddy provisions and renews TLS certificates automatically for `DOMAIN`; the per
 | `all` / `both` (default) | Both, in parallel |
 
 The `data/` directory is excluded from the rsync, so application data on each box is never overwritten by a deploy.
+
+### Update a running instance: `update.sh`
+
+The operator-facing update path, and what the admin Updates panel points at.
+
+```
+./update.sh              Update, with one confirmation prompt
+./update.sh --check      Report whether an update exists. Changes nothing
+./update.sh --yes        Update without prompting (ssh, cron)
+./update.sh --no-backup  Skip the pre-update snapshot. Not recommended
+```
+
+Sequence:
+
+1. **Preflight.** Docker reachable (falls back to `sudo` the way `install.sh` does), Compose v2 present, `.env` and `docker-compose.yml` present, and the compose project actually defines a `backspace` service. `COMPOSE_FILE` lives in `.env`, so proxy and tunnel installs resolve both files with no `-f` flags.
+2. **Record the rollback point.** `docker inspect` for the running container's image ID. Refuses to proceed if it cannot determine one.
+3. **Resolve the target reference.** `docker compose config --images backspace`, which is **not** necessarily the reference the running container was created from. An operator who repins `BACKSPACE_IMAGE_TAG` changes the former without touching the latter, and rolling back against the running container's reference would restore the old image under a name compose no longer looks at, bringing the failed version straight back up.
+4. **Refresh the checkout, tolerantly.** No `.git` (an rsync-deployed host) says so and carries on. A dirty tree or a diverged branch refuses to pull, says why, and carries on. Local edits are never clobbered, and the image update still applies.
+5. **Back up.** Calls `./backup.sh`. **The one step whose failure is fatal**, because everything after it is only safe to attempt because it happened.
+6. **Fetch.** `docker compose pull backspace`, or `docker compose build backspace` on a from-source install, chosen from `BACKSPACE_INSTALL_CHANNEL` and falling back to inferring it from the image reference.
+7. **Skip a no-op.** If the fetched image ID equals the recorded one, report and exit 0 without restarting. Restarting a chat server for nothing disconnects everyone in a voice call.
+8. **Restart.** `docker compose up -d backspace`. **The service is named explicitly and `--remove-orphans` is never passed.** Compose actively suggests that flag on hosts running other containers in the same project, and following it would delete them. Both live instances run co-hosted services behind the same Caddy, so this is a real deletion, not a hypothetical one.
+9. **Health gate.** Polls `docker inspect` for `healthy`, up to 180s. The compose healthcheck is `interval: 30s, retries: 5, start_period: 30s`, so anything under roughly 120s would produce false failures. On timeout it prints the container state, the last health-probe output, and the tail of the logs.
+10. **Verify the version moved.** Reads `/api/instance/info` through the container and compares against the pre-update value. A container that comes up healthy while still running the old code is a failed update, and this is the only check that catches it.
+11. **Roll back on failure.** Re-tags the recorded image ID to the target reference, `up -d backspace`, waits for healthy, and reports both the failure and the restored version. It then warns that the local tag now points at the previous image and should be restored with `docker compose pull backspace` once the problem is fixed.
+
+`--check` is read-only. It reports the running version and the install channel, then looks up the latest release tag from the GitHub API with `curl` or `wget` and compares. It touches no Docker state and degrades to a plain statement of the running version when neither tool is available.
+
+**Rehearsed end to end** on a live throwaway instance before shipping: a real update, a no-op re-run, and a deliberately broken update (image repinned at `alpine:3.20`) that failed the health gate and rolled back to a healthy instance on the previous image. Co-hosted containers were untouched throughout.
+
+Two shell traps this script exists on the far side of, worth knowing before editing it:
+
+- **`grep -q` under `set -o pipefail`.** `grep -q` exits at its first match, which SIGPIPEs the upstream command and fails the pipeline. `docker compose config --services | grep -qx backspace` reported "no backspace service" against a compose file whose *first* listed service is backspace. Membership is now tested with a bash `contains_line` helper. The same applies to any `… | head -1` without a trailing `|| true`.
+- **`sed -i`** differs between GNU and BSD. `install.sh`'s `record_install_channel` rewrites `.env` through a temp file instead.
 
 ---
 

--- a/docs/systems/desktop-security.md
+++ b/docs/systems/desktop-security.md
@@ -111,10 +111,36 @@ AppImage/`.deb` distribution does not require a paid certificate; Linux package 
 `main.ts`'s `initAutoUpdater()` runs unconditionally on every platform (`electron-updater`'s GitHub provider, configured in `electron-builder.yml`'s `publish:` block; first check 10s after launch, then every 4 hours). What that buys differs per platform:
 
 - **Windows — updates install without a code-signature check**, because there is no signature to check: the app is unsigned, so `electron-updater`'s NSIS path has no publisher name to validate the downloaded installer against. A compromised GitHub release or publishing token could therefore ship a malicious update that installs with nothing to alert the user. (Releases are served over HTTPS, so a plain network MITM is not the concern here.)
-- **macOS — auto-update is unavailable, not merely unverified.** There *is* a signature, but it is ad-hoc. `electron-updater` checks and downloads, then hands the update to Electron's native `autoUpdater` (Squirrel.Mac), which will only swap in a bundle whose code signature matches the running app's. An ad-hoc signature carries no team identifier and its cdhash changes with every build, so no new release can ever match — the install step fails and the app stays on the old version. Until Developer ID signing lands, macOS users have to download new releases by hand.
+- **macOS — auto-update is unavailable, not merely unverified.** There *is* a signature, but it is ad-hoc. `electron-updater` checks and downloads, then hands the update to Electron's native `autoUpdater` (Squirrel.Mac), which will only swap in a bundle whose code signature matches the running app's. An ad-hoc signature carries no team identifier and its cdhash changes with every build, so no new release can ever match — the install step fails and the app stays on the old version. Until Developer ID signing lands, macOS users have to download new releases by hand. Measured on a shipped 1.0.3 build, and see "The exact mechanism" below.
 - **Linux — no signature check either.** `electron-updater` selects its AppImage or `.deb` updater from how the app was installed; neither verifies a signature, and the artifacts are unsigned.
 
 Once Developer ID / Authenticode signing (above) is wired up, `electron-updater` will verify the update package's signature before install on Windows, and Squirrel.Mac will be able to validate macOS updates at all. This is flagged as a known gap, not fixed by this plan.
+
+#### The exact mechanism
+
+Squirrel.Mac validates a staged update against the **running app's designated requirement**. For an ad-hoc signed bundle, `codesign` derives that requirement from the binary's own code directory hash. Read off a shipped 1.0.3 build:
+
+```
+$ codesign -d -r- /Applications/Backspace.app
+Executable=/Applications/Backspace.app/Contents/MacOS/Backspace
+# designated => cdhash H"4a9e49fe20f82802702a4e9d752748e990909659"
+
+$ codesign -dv /Applications/Backspace.app
+CodeDirectory v=20400 size=302 flags=0x2(adhoc) ...
+Signature=adhoc
+TeamIdentifier=not set
+```
+
+A 1.0.4 binary has a different cdhash, so it cannot satisfy `cdhash H"4a9e49fe…"`. This is not a flaky or intermittent failure: it is arithmetically impossible for every past and future release while the build is ad-hoc signed. A Developer ID signed bundle instead reports a requirement anchored to the certificate, which every later build from the same team satisfies:
+
+```
+designated => identifier "com.example.app" and anchor apple generic and
+  certificate leaf[subject.OU] = "TEAMID"
+```
+
+`~/Library/Caches/com.backspace.desktop.ShipIt` exists but is empty on affected machines: Squirrel created its state directory, failed validation, and wrote nothing.
+
+**The app now measures this at runtime** rather than hardcoding "macOS cannot update". `packages/desktop/src/updateCapability.ts` runs the `codesign -d -r-` probe, classifies the requirement, and reports `manual` for a bare cdhash and `auto` for anything certificate-anchored. Consequences: `autoDownload` is off in manual mode (the ad-hoc build was otherwise pulling the full release archive on every check and storing it twice, 228 MB measured, for a file it could never apply), no Restart button is offered, and the copy says plainly that the build cannot update itself. **When a Developer ID lands in CI, that probe flips to `auto` on its own with no code change.** See [desktop.md](desktop.md) for the full update flow.
 
 ## Not verified
 

--- a/docs/systems/desktop.md
+++ b/docs/systems/desktop.md
@@ -3,6 +3,10 @@
 Source files:
 - `packages/desktop/src/main.ts` — Main process: window management, tray, IPC handlers, auto-update, deep links, app lifecycle
 - `packages/desktop/src/preload.ts` — Context bridge: exposes `window.backspace` API to renderer
+- `packages/desktop/src/updateCapability.ts` — Signature probe: can this build install its own updates
+- `packages/desktop/src/updateStatus.ts` — Update status union, store, and the shared prompt predicate
+- `packages/desktop/src/updateDismissal.ts` — Per-version dismissal persisted to userData
+- `packages/desktop/src/updaterCache.ts` — Reclaims the updater download cache on manual-mode builds
 - `packages/desktop/src/activityDetector.ts` — Process polling, game dictionary loading/sync, activity change detection
 - `packages/desktop/src/keybindManager.ts` — Global keybinds via uIOhook, native keycode mapping, press/release tracking
 - `packages/web/src/stores/keybindStore.ts` — Client-side keybind persistence (Zustand + localStorage)
@@ -234,30 +238,200 @@ Registered via `app.setAsDefaultProtocolClient('backspace')` and in `electron-bu
 
 ## Auto-Update
 
-Powered by `electron-updater`. Loaded via `require()` (not import) for graceful degradation when not available.
+Powered by `electron-updater`. Loaded via `require()` (not import) for graceful
+degradation when not available.
+
+Source files:
+- `updateCapability.ts` — measures whether this build can install its own updates
+- `updateStatus.ts` — the `UpdateStatus` union, the `UpdateStatusStore`, and the
+  shared "should we interrupt the user" predicate
+- `updateDismissal.ts` — per-version dismissal persisted to userData
+- `updaterCache.ts` — reclaims the download cache on builds that cannot install
+- `packages/web/src/stores/updateStore.ts` — the renderer mirror
+- `packages/web/src/components/ui/UpdateToast.tsx` — the prompt
+
+### Update capability, and why it is measured rather than assumed
+
+```
+type UpdateCapability = 'auto' | 'manual';
+```
+
+`getUpdateCapability()` (memoised, `updateCapability.ts`) decides in this order:
+
+1. `!app.isPackaged` → `manual`. A dev build has no feed and must never offer to install.
+2. Not darwin → `auto`. NSIS and AppImage apply unsigned updates without complaint.
+3. darwin → run `codesign -d -r- <bundle>` and classify the designated requirement:
+   - a bare `cdhash H"…"` → `adhoc` → `manual`
+   - anything mentioning `anchor` or `certificate` → `identified` → `auto`
+   - unreadable → `unknown` → `manual`
+4. Any failure → `manual`.
+
+Every uncertain path resolves to `manual` deliberately. A download link always
+works, so guessing "manual" wrongly costs one extra click, while guessing "auto"
+wrongly produces a button that silently does nothing.
+
+**Nothing here hardcodes "macOS cannot update".** It measures the property that
+actually decides the outcome, so the day CI signs with a Developer ID this
+returns `auto` with no code change. See [desktop-security.md](desktop-security.md)
+for why the ad-hoc signature makes it impossible today.
 
 ### Configuration (`initAutoUpdater()`)
 
 ```
-autoDownload: true
-autoInstallOnAppQuit: true
+autoDownload         = capability === 'auto'
+autoInstallOnAppQuit = capability === 'auto'
 Publish: GitHub (TheZwiss/backspace)
 ```
 
-**Signing status:** no Apple Developer ID or Windows certificate. macOS builds
-are ad-hoc signed by `scripts/macSign.js` (see below); Windows and Linux builds
-are unsigned. Consequences:
-- **macOS:** Squirrel.Mac refuses to apply updates without a real signing
-  identity — auto-update is effectively disabled on macOS until a Developer ID
-  certificate + notarization are added to the CI build. Users update manually
-  from the releases page. The app is not notarized, so first launch is blocked
-  by Gatekeeper and must be approved once via System Settings → Privacy &
-  Security → Open Anyway. Ad-hoc signatures also have no stable identity, so
-  the cdhash changes every release and macOS drops the Input Monitoring and
-  Screen Recording grants (global keybinds, screen share) on each update.
-- **Windows:** NSIS auto-update works unsigned; SmartScreen warns on first
-  install only.
-- **Linux:** AppImage auto-update works unsigned.
+In `manual` mode nothing is downloaded, so no proxy server is created, Squirrel
+is never invoked, and the spurious install error never fires. `purgeUpdaterCache`
+also runs once at startup to reclaim archives stranded by earlier versions
+(measured at 228 MB on a real macOS install, because the archive is stored
+twice). The directory to delete is read from the packaged `app-update.yml`'s
+`updaterCacheDirName` rather than reconstructed, and must pass
+`isSafeUpdaterCacheDirName` (no separators, no traversal, mandatory `-updater`
+suffix) before anything is removed.
+
+### The `update-downloaded` trap
+
+`MacUpdater.doDownloadUpdate()` fires `dispatchUpdateDownloaded()` **inside the
+`server.listen` callback**, the moment its local proxy server is up, and *before*
+Squirrel has been asked to do anything:
+
+```js
+this.server.listen(0, "127.0.0.1", () => {
+    this.nativeUpdater.setFeedURL({ ... });
+    this.dispatchUpdateDownloaded(event);      // fires here
+    if (this.autoInstallOnAppQuit) {
+        this.nativeUpdater.checkForUpdates();   // Squirrel fails later
+    }
+});
+```
+
+So on macOS `update-downloaded` means "the archive is on disk", **not** "the
+update can be installed". Treating it as the latter is what produced a Restart
+button that did nothing. `MacUpdater.quitAndInstall()` then takes a branch that
+registers a listener for an event that never fires and returns, with no error and
+no exception.
+
+### Status model
+
+One value, replaced wholesale by every event, so a stale `ready` can never
+outrank a fresh `failed`:
+
+```typescript
+type UpdateStatus =
+  | { phase: 'idle' }
+  | { phase: 'checking' }
+  | { phase: 'available'; version: string }
+  | { phase: 'downloading'; version: string; percent: number; bytesPerSecond: number }
+  | { phase: 'ready'; version: string }
+  | { phase: 'failed'; version: string | null; message: string }
+  | { phase: 'up-to-date'; checkedAt: number };
+
+interface UpdateSnapshot {
+  capability: UpdateCapability;
+  dismissedVersion: string | null;
+  status: UpdateStatus;
+}
+```
+
+`capability` and `dismissedVersion` are ambient facts about the install; `status`
+is the event-driven part. They travel together so a dismissed update stays
+*visible* in Settings while being *silent* in the toast. Suppressing it in main
+would make it unreachable, turning "Later" into "never".
+
+`shouldPromptForUpdate(snapshot)` is the single definition of "interrupt the
+user". Both the toast and the native notification call it, so they cannot
+disagree about whether the user already said later. It returns false for
+`checking`, `downloading` and `up-to-date` (progress, not news), for a dismissed
+version, and for a `failed` that never learned a version.
+
+### Dismissal
+
+Persisted to `{userData}/update-state.json` as `{ dismissedVersion }`.
+
+It lives in the **main process, not localStorage**, because an available update
+is a property of the installed app, not of whichever instance the user happens to
+be connected to. Per-origin storage would re-nag anyone who switches instances
+and would lose the dismissal when site data is cleared.
+
+Exactly one version is remembered, compared by equality. Dismissing 1.0.4
+silences 1.0.4 and nothing else, so 1.0.5 surfaces normally. A corrupt or
+truncated file yields "nothing dismissed" rather than throwing at startup.
+
+### Check schedule
+
+| Trigger | Delay |
+|---------|-------|
+| Initial check | 10 seconds after app ready |
+| Periodic check | Every 4 hours |
+| Manual check | `check-for-updates` IPC from renderer |
+
+### Event flow (main -> renderer)
+
+| Event | IPC Channel | Payload | Condition |
+|-------|------------|---------|-----------|
+| Snapshot changed | `update-status-changed` | `UpdateSnapshot` | Every status or dismissal change |
+| Update found | `update-available` | `{ version }` | Always (legacy) |
+| Download complete | `update-downloaded` | `{ version }` | Always (legacy) |
+| Error | `update-error` | `{ message, releaseUrl }` | Only if `updateConfirmed` (legacy) |
+
+The three legacy per-event channels are **kept even though the current client no
+longer reads them**. The desktop app and the instance it connects to version
+independently: a newer app can be pointed at an older instance still serving a
+client that calls `onUpdateDownloaded`, and removing them would throw inside that
+client's `useEffect` and take the renderer down. The reverse case is handled on
+the web side, where `updateStore.ts` feature-detects `getUpdateStatus` and falls
+back to reconstructing a snapshot from the legacy channels.
+
+`download-progress` is wired and drives the `downloading` phase. Pushes are
+throttled to whole-percent changes, so at most 101 IPC messages per download.
+
+Check-phase errors are recorded as `{ phase: 'failed', version: null }`, which
+keeps them out of the toast while leaving them visible in Settings. Interrupting
+someone because a background poll hit a flaky network is noise.
+
+### Install
+
+`install-update` IPC:
+
+- `capability !== 'auto'` → opens the releases page. There is no in-place install
+  to run, so calling a method that returns without doing anything is not an option.
+- otherwise → `autoUpdater.quitAndInstall()`, then a **4-second watchdog**. If the
+  app is still alive and still `ready` after it, the status flips to `failed`.
+  A successful install takes the app down before the timer fires. This is defence
+  in depth against the silent no-op recurring on a platform we did not anticipate.
+
+### Notification
+
+Fires on `update-available` in manual mode and `update-downloaded` in auto mode,
+suppressed when the window is focused (the in-app toast covers that) and when
+`shouldPromptForUpdate` says no.
+
+| Capability | Title | Body | Click |
+|---|---|---|---|
+| `auto` | Backspace update ready | Click to restart and install version X. | `quitAndInstall()` |
+| `manual` | Backspace X is available | Click to open the download page. | `shell.openExternal(RELEASES_URL)` |
+
+Win32 only: `app.setAppUserModelId('com.backspace.desktop')` is set early in
+startup so notifications attribute to "Backspace" in Windows Action Center.
+
+### Recovery integration
+
+All `autoUpdater` events update the `RecoveryStateStore`. `UpdateState` gained
+**`available-manual`**: an update exists but this build cannot install it. The
+recovery surface then offers a versioned "Download Backspace X" button
+(`open-releases` action) instead of "Restart to Install Update", and the tray and
+macOS app menus do the same via `updateActionItem`. Without this the recovery
+screen, which is the escape hatch for a user whose app will not start, would
+present the one button guaranteed not to help them.
+
+`extractErrorCode(err)` in `recovery.ts` extracts the `code` field from
+`electron-updater` errors when present (string only); used to populate
+`RecoveryState.lastUpdateError.code`.
+
+### Release publishing
 
 CI publishes via `.github/workflows/release.yml` (tag `v*` on the public repo).
 A `create-release` job runs first and creates the draft for the tag, then four
@@ -273,39 +447,6 @@ split across the pair, which needed manual consolidation before the release
 could be published. Creating the draft once, ahead of the matrix, leaves the
 build jobs with nothing to create.
 
-### Check Schedule
-
-| Trigger | Delay |
-|---------|-------|
-| Initial check | 10 seconds after app ready |
-| Periodic check | Every 4 hours |
-| Manual check | `check-for-updates` IPC from renderer |
-
-### Event Flow (main -> renderer)
-
-| Event | IPC Channel | Payload | Condition |
-|-------|------------|---------|-----------|
-| Update found | `update-available` | `{ version }` | Always |
-| Download complete | `update-downloaded` | `{ version }` | Always |
-| Error | `update-error` | `{ message, releaseUrl }` | Only if `updateConfirmed` is true (download failed after update was confirmed) |
-
-Check-phase errors (network, auth, 404) are silently ignored — nothing actionable for the user.
-
-### Install
-
-`install-update` IPC triggers `autoUpdater.quitAndInstall()`.
-
-### Recovery Integration
-
-All `autoUpdater` events update the `RecoveryStateStore` (drives tray + macOS menu UI dynamically). Existing renderer IPC channels (`update-available`, `update-downloaded`, `update-error`) are preserved unchanged.
-
-On `update-downloaded`, a native OS notification fires **only when `mainWindow?.isFocused()` is false** — symmetric suppression across normal and recovery modes (the in-app banner / Restart button is visible to a focused user; the notification covers minimized/tray/background-desktop cases). Notification click calls `autoUpdater.quitAndInstall()` directly (force-kill fix path — see Recovery Mode section).
-
-Win32 only: `app.setAppUserModelId('com.backspace.desktop')` is set early in startup so notifications attribute to "Backspace" instead of "Electron" in Windows Action Center.
-
-`extractErrorCode(err)` in `recovery.ts` extracts the `code` field from `electron-updater` errors when present (string only); used to populate `RecoveryState.lastUpdateError.code`.
-
----
 
 ## Recovery Mode
 
@@ -324,7 +465,9 @@ Source files:
 interface RecoveryState {
   mode: 'normal' | 'recovery';
   reason: { code: 'load-failed' | 'render-gone' | 'unresponsive' | 'renderer-stalled'; detail: string } | null;
-  updateState: 'idle' | 'checking' | 'downloading' | 'downloaded' | 'error';
+  // 'available-manual': an update exists but this build cannot install it in
+  // place, so the surface offers a download rather than a dead Restart button.
+  updateState: 'idle' | 'checking' | 'downloading' | 'available-manual' | 'downloaded' | 'error';
   updateVersion: string | null;
   lastUpdateError: { message: string; code: string | null; at: number } | null;
   lastCheckResult: 'up-to-date' | 'failed' | null;  // transient, 5s decay
@@ -361,9 +504,14 @@ Page reads initial state via `getRecoveryState()` IPC and subscribes to `recover
 |--------|---------|---------|
 | Reload | always | always |
 | Restart to Install Update | `updateState === 'downloaded'` | always when visible |
-| Check for Updates | always | not in `'checking'` / `'downloading'` / `'downloaded'` |
+| Check for Updates | always | not in `'checking'` / `'downloading'` / `'downloaded'` / `'available-manual'` |
 | Change Instance | always | always |
-| Open Releases Page | `updateState === 'error'` | always when visible |
+| Open Releases Page | `updateState === 'error'` or `'available-manual'` | always when visible |
+
+In `'available-manual'` the Open Releases button relabels to "Download Backspace
+X". Restart to Install is never shown in that state, because the build cannot
+install in place.
+
 | Quit Backspace | always | always |
 
 **Change Instance from recovery is non-destructive.** The saved URL is not cleared when navigating to the picker; see the Instance Picker section above for the full behavior (pre-filled input, Cancel button, header copy update).
@@ -503,8 +651,10 @@ All handlers registered in `main.ts:registerIpcHandlers()`.
 | `minimize-window` | R->M | — | Minimize window |
 | `maximize-window` | R->M | — | Toggle maximize/unmaximize |
 | `close-window` | R->M | — | Close (hides to tray) |
-| `install-update` | R->M | — | `autoUpdater.quitAndInstall()` |
+| `install-update` | R->M | — | `quitAndInstall()` on auto-capable builds, otherwise opens the releases page. 4s watchdog flips the status to `failed` if the app is still running |
 | `check-for-updates` | R->M | — | `autoUpdater.checkForUpdates()` |
+| `dismiss-update` | R->M | `{ version }` | Persists the dismissal and re-pushes the snapshot |
+| `open-release-page` | R->M | — | `shell.openExternal(RELEASES_URL)` |
 | `screen-share-selected` | R->M | `sourceId, shareAudio?` | Safety net (actual handler is `ipcMain.once` in display media flow) |
 | `keybinds-sync` | R->M | `KeybindConfig[]` | `keybindManager.updateKeybinds()` |
 | `set-connected-origins` | R->M | `string[]` | Update `knownInstanceOrigins` set (used by in-instance `/join/` interception) |
@@ -524,6 +674,7 @@ All handlers registered in `main.ts:registerIpcHandlers()`.
 | `get-current-activity` | R->M | `Activity \| null` | Current detected game activity |
 | `check-accessibility` | R->M | `boolean` | macOS accessibility permission check |
 | `get-recovery-state` | R->M | `RecoveryState` | Recovery page reads initial state on mount |
+| `get-update-status` | R->M | `UpdateSnapshot` | Renderer reads the current snapshot on mount |
 
 ### Main -> Renderer Events
 
@@ -541,6 +692,7 @@ All handlers registered in `main.ts:registerIpcHandlers()`.
 | `keybind-hook-error` | `{ message }` | uIOhook start failure |
 | `open-internal-route` | `string` (path) | In-instance `/join/` interception: renderer navigates to `path` instead of opening externally |
 | `recovery-state-changed` | `RecoveryState` | Store subscriber, mode-gated to `mode === 'recovery'` |
+| `update-status-changed` | `UpdateSnapshot` | Every status or dismissal change |
 
 ---
 
@@ -588,6 +740,15 @@ Detection: `typeof window.backspace !== 'undefined'` (see `platform.ts:isElectro
 | `getRecoveryState()` | invoke | R->M | Returns `Promise<RecoveryState>` |
 | `onRecoveryStateChanged(cb)` | listen | M->R | Returns cleanup function; recovery.html subscribes |
 | `recoveryAction(action)` | fire | R->M | Single channel for all recovery button clicks |
+| `getUpdateStatus()` | invoke | R->M | Returns `Promise<UpdateSnapshot>`. Optional: absent on pre-1.0.5 apps |
+| `onUpdateStatusChanged(cb)` | listen | M->R | Returns cleanup function. Optional |
+| `dismissUpdate(version)` | fire | R->M | Optional |
+| `openReleasePage()` | fire | R->M | Optional |
+
+The four update-snapshot methods are declared **optional** in
+`electron.d.ts`. A client served by a newer instance can be running inside an
+older desktop app that does not expose them, so every call site feature-detects.
+`updateStore.ts` falls back to the legacy per-event channels when they are absent.
 
 Direction legend: **fire** = `ipcRenderer.send` (no response), **invoke** = `ipcRenderer.invoke` (returns Promise), **listen** = `ipcRenderer.on` (event subscription).
 
@@ -1014,6 +1175,7 @@ Earlier builds wrote to `<appData>/@backspace/desktop/`. On first launch after t
 | `instance-url.json` | `{ url: string }` | Saved instance URL |
 | `window-state.json` | `WindowState` | Window position, size, maximize state |
 | `auto-launch.json` | `AutoLaunchSettings` | Open at login + start minimized prefs |
+| `update-state.json` | `{ dismissedVersion }` | The update version the user waved away. Belongs to the app, not to an instance |
 | `games-cache.json` | `VersionedDictionary` | Cached remote game dictionary |
 | `games-cache-etag.txt` | ETag string | For conditional HTTP requests |
 

--- a/install.sh
+++ b/install.sh
@@ -646,24 +646,58 @@ build_from_source() {
 # hosts the ~1.6GB local build that OOMs small boxes). Fall back to a from-source
 # build if the image can't be pulled (not published yet, private, or offline), or
 # if the operator forces a build (BACKSPACE_BUILD=true — e.g. running a fork).
+# Records which path this install actually took, so ./update.sh knows whether to
+# pull an image or rebuild, and the admin Updates panel can say which it is.
+# Written *after* the decision resolves rather than alongside the rest of .env,
+# so a fallback-to-build is recorded truthfully instead of as the pull that was
+# attempted first.
+record_install_channel() {
+  local channel="$1"
+  local tmp
+  if [[ -f .env ]] && grep -q '^BACKSPACE_INSTALL_CHANNEL=' .env; then
+    # Rewritten through a temp file rather than with sed -i: GNU and BSD sed
+    # disagree about -i, and this script is also read on macOS.
+    tmp="$(mktemp)"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$line" == BACKSPACE_INSTALL_CHANNEL=* ]]; then
+        printf '%s\n' "BACKSPACE_INSTALL_CHANNEL=${channel}"
+      else
+        printf '%s\n' "$line"
+      fi
+    done < .env > "$tmp"
+    mv "$tmp" .env
+  else
+    cat >> .env << EOF
+
+# How this instance gets its image: prebuilt | source
+# Written by install.sh after the pull-or-build decision. ./update.sh reads it.
+BACKSPACE_INSTALL_CHANNEL=${channel}
+EOF
+  fi
+}
+
 if [[ "${BACKSPACE_BUILD:-false}" == "true" ]]; then
   info "BACKSPACE_BUILD=true — building from source (skipping the prebuilt image)."
   build_from_source
+  record_install_channel source
 else
   image_ref="${BACKSPACE_IMAGE:-ghcr.io/thezwiss/backspace}:${BACKSPACE_IMAGE_TAG:-latest}"
   info "Fetching prebuilt image ${image_ref} ..."
   if $COMPOSE pull backspace; then
     success "Pulled prebuilt image"
+    record_install_channel prebuilt
   elif $DOCKER image inspect "$image_ref" >/dev/null 2>&1; then
     # Pull failed (offline / registry hiccup / private) but a usable copy is
     # already on this host (a prior run, an air-gapped `docker load`, or a
     # previous from-source build tagged under this ref) — use it instead of
     # forcing a needless multi-hundred-MB rebuild.
     warn "Could not pull ${image_ref} — using the copy already present on this host."
+    record_install_channel prebuilt
   else
     warn "Prebuilt image unavailable (not published yet, private, or offline)."
     warn "Falling back to a from-source build — slower, and heavy on low-RAM/ARM hosts."
     build_from_source
+    record_install_channel source
   fi
 fi
 
@@ -1010,5 +1044,6 @@ echo -e "  ${BOLD}Commands${NC} (run from this directory):"
 echo "    docker compose logs -f          # Watch logs"
 echo "    docker compose restart          # Restart all services"
 echo "    docker compose down             # Stop everything"
-echo "    docker compose pull && docker compose up -d   # Update to the latest prebuilt image"
+echo "    ./update.sh                                   # Update (snapshots first, rolls back if it fails)"
+echo "    ./update.sh --check                           # Check for an update, changing nothing"
 echo ""

--- a/packages/desktop/resources/recovery.html
+++ b/packages/desktop/resources/recovery.html
@@ -163,19 +163,25 @@
       }
       if (reasonCode === 'render-gone' || reasonCode === 'unresponsive') {
         if (updateState === 'downloaded') {
-          return 'Something inside the app failed. An update is ready — click Restart to Install.';
+          return 'Something inside the app failed. An update is ready, so click Restart to Install.';
+        }
+        if (updateState === 'available-manual') {
+          return 'Something inside the app failed. A newer version is available, but this build cannot install it itself. Download it and replace the app.';
         }
         if (updateState === 'downloading') {
-          return 'Something inside the app failed. An update is downloading — wait for it to finish, then restart.';
+          return 'Something inside the app failed. An update is downloading, so wait for it to finish and then restart.';
         }
         return 'Something inside the app failed. Try reloading or check for an update.';
       }
       if (reasonCode === 'renderer-stalled') {
         if (updateState === 'downloaded') {
-          return "The app didn't finish loading. An update is ready — click Restart to Install.";
+          return "The app didn't finish loading. An update is ready, so click Restart to Install.";
+        }
+        if (updateState === 'available-manual') {
+          return "The app didn't finish loading. A newer version is available, but this build cannot install it itself. Download it and replace the app.";
         }
         if (updateState === 'downloading') {
-          return "The app didn't finish loading. An update is downloading — wait for it to finish, then restart.";
+          return "The app didn't finish loading. An update is downloading, so wait for it to finish and then restart.";
         }
         return "The app didn't finish loading in time. Try reloading, or check for an update if reloading doesn't help.";
       }
@@ -187,6 +193,7 @@
         case 'checking': return 'Checking…';
         case 'downloading': return 'Downloading Update…';
         case 'downloaded': return 'Update Ready';
+        case 'available-manual': return 'Update Available';
         case 'error': return 'Check for Updates';
         case 'idle':
         default: return 'Check for Updates';
@@ -194,7 +201,10 @@
     }
 
     function checkButtonEnabled(updateState) {
-      return updateState !== 'checking' && updateState !== 'downloading' && updateState !== 'downloaded';
+      return updateState !== 'checking'
+        && updateState !== 'downloading'
+        && updateState !== 'downloaded'
+        && updateState !== 'available-manual';
     }
 
     function checkResultText(lastCheckResult) {
@@ -223,11 +233,17 @@
       $('btn-check').textContent = checkButtonLabel(state.updateState);
       $('btn-check').disabled = !checkButtonEnabled(state.updateState);
 
-      // Restart visibility
+      // Restart visibility. Only ever shown when the update is genuinely staged
+      // and installable, so this surface can never present a dead button.
       $('btn-restart').style.display = state.updateState === 'downloaded' ? '' : 'none';
 
-      // Open Releases visibility
-      $('btn-releases').style.display = state.updateState === 'error' ? '' : 'none';
+      // Open Releases visibility. Shown after a failed update, and on builds
+      // that cannot install in place, where downloading is the only real action.
+      const manual = state.updateState === 'available-manual';
+      $('btn-releases').style.display = (state.updateState === 'error' || manual) ? '' : 'none';
+      $('btn-releases').textContent = manual
+        ? (state.updateVersion ? 'Download Backspace ' + state.updateVersion : 'Download the Update')
+        : 'Open Releases Page';
 
       // Inline check result
       const cr = $('check-result');

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -24,6 +24,16 @@ import {
   clearInstanceUrl,
   getPickerPath,
 } from './instanceUrl';
+import { getUpdateCapability } from './updateCapability';
+import { loadDismissedVersion, setDismissedVersion } from './updateDismissal';
+import { purgeUpdaterCache } from './updaterCache';
+import {
+  UpdateStatusStore,
+  RELEASES_URL,
+  shouldPromptForUpdate,
+  statusVersion,
+  type UpdateSnapshot,
+} from './updateStatus';
 import {
   recoveryStore,
   attachRecoveryHandlers,
@@ -594,12 +604,41 @@ function registerIpcHandlers(): void {
 
   // Auto-update IPC
   ipcMain.on('install-update', () => {
+    const store = getUpdateStore();
+    const snapshot = store.get();
+
+    // A build that cannot install in place has no in-place install to run. Send
+    // the user to the download instead of calling a method that returns without
+    // doing anything, which is the defect this whole path exists to remove.
+    if (snapshot.capability !== 'auto') {
+      void shell.openExternal(RELEASES_URL);
+      return;
+    }
+
     try {
       const { autoUpdater } = require('electron-updater');
       autoUpdater.quitAndInstall();
     } catch {
-      // Auto-updater not available
+      store.setStatus({
+        phase: 'failed',
+        version: statusVersion(snapshot.status),
+        message: 'The updater is not available in this build.',
+      });
+      return;
     }
+
+    // If the install started, the app is gone before this fires. If it did not,
+    // the user is still looking at a Restart button that appears to have done
+    // nothing, and now the app says so instead of leaving them guessing.
+    setTimeout(() => {
+      const current = getUpdateStore().get();
+      if (current.status.phase !== 'ready') return;
+      getUpdateStore().setStatus({
+        phase: 'failed',
+        version: statusVersion(current.status),
+        message: 'Restarting to install the update did not start.',
+      });
+    }, INSTALL_WATCHDOG_MS);
   });
 
   ipcMain.on('check-for-updates', () => {
@@ -609,6 +648,22 @@ function registerIpcHandlers(): void {
     } catch {
       // Auto-updater not available
     }
+  });
+
+  ipcMain.handle('get-update-status', () => getUpdateStore().get());
+
+  ipcMain.on('dismiss-update', (_event, payload: { version?: unknown }) => {
+    const version = typeof payload?.version === 'string' ? payload.version.trim() : '';
+    if (version === '') return;
+    setDismissedVersion(version);
+    // Read back rather than assume. If the write failed, the store keeps the old
+    // value and the prompt honestly reappears next launch instead of silently
+    // vanishing from a user who would then never see the update again.
+    getUpdateStore().setDismissedVersion(loadDismissedVersion());
+  });
+
+  ipcMain.on('open-release-page', () => {
+    void shell.openExternal(RELEASES_URL);
   });
 
   ipcMain.handle('get-app-version', () => app.getVersion());
@@ -722,52 +777,176 @@ function registerIpcHandlers(): void {
 
 // ─── Auto-Update ────────────────────────────────────────────────────────────
 
+/**
+ * How long to wait for `quitAndInstall()` to actually take the app down before
+ * concluding it silently did nothing.
+ *
+ * electron-updater's `quitAndInstall()` can return normally without starting an
+ * install. On macOS this is the documented shape of MacUpdater.quitAndInstall():
+ * when Squirrel never staged the update it registers a listener for an event
+ * that will never fire and returns. No error, no exception, no restart. That is
+ * exactly the dead button this watchdog exists to catch on any platform where
+ * the same thing can happen.
+ */
+const INSTALL_WATCHDOG_MS = 4_000;
+
+let updateStore: UpdateStatusStore | null = null;
+
+/**
+ * The update status store, built on first use.
+ *
+ * Construction needs `app.getPath('userData')` and the signature probe, so it
+ * cannot run at module load. Every caller is post-`whenReady`, and the lazy
+ * getter means the IPC handlers (registered before the updater starts) and the
+ * updater itself share one instance without ordering constraints.
+ */
+function getUpdateStore(): UpdateStatusStore {
+  if (updateStore === null) {
+    updateStore = new UpdateStatusStore(getUpdateCapability(), loadDismissedVersion());
+    updateStore.subscribe((snapshot) => {
+      mainWindow?.webContents.send('update-status-changed', snapshot);
+    });
+  }
+  return updateStore;
+}
+
+/**
+ * Fires the native update notification, if this snapshot warrants one.
+ *
+ * Asks `shouldPromptForUpdate` rather than deciding for itself, so the toast and
+ * the notification cannot disagree about whether the user already said "later".
+ *
+ * The body branches on capability. Telling a macOS user to "click to restart and
+ * install" when the build physically cannot install is the same lie as the dead
+ * Restart button, just delivered by the OS instead of the app.
+ */
+function notifyAboutUpdate(
+  snapshot: UpdateSnapshot,
+  updater: { quitAndInstall: () => void },
+): void {
+  if (!shouldPromptForUpdate(snapshot)) return;
+  // A focused user can see the in-app toast. Notifying as well is noise.
+  if (mainWindow?.isFocused()) return;
+
+  const version = statusVersion(snapshot.status);
+  if (version === null) return;
+
+  if (snapshot.status.phase === 'ready' && snapshot.capability === 'auto') {
+    showNotification(
+      'Backspace update ready',
+      `Click to restart and install version ${version}.`,
+      () => updater.quitAndInstall(),
+    );
+    return;
+  }
+
+  showNotification(
+    `Backspace ${version} is available`,
+    'Click to open the download page.',
+    () => { void shell.openExternal(RELEASES_URL); },
+  );
+}
+
 function initAutoUpdater(): void {
   try {
     const { autoUpdater } = require('electron-updater');
-    autoUpdater.autoDownload = true;
-    autoUpdater.autoInstallOnAppQuit = true;
+
+    const capability = getUpdateCapability();
+    const store = getUpdateStore();
+
+    // A build that cannot install its own updates must not download them.
+    //
+    // With autoDownload on, an ad-hoc signed macOS build pulls the full release
+    // archive, hands it to Squirrel.Mac, and Squirrel rejects it because the
+    // running app's designated requirement is a literal cdhash that no other
+    // build can satisfy. The archive then sits on disk forever (228 MB measured
+    // on a real machine, since it is stored twice) and the whole cycle repeats
+    // on the next check. Turning the download off removes the wasted transfer,
+    // the wasted disk, and the spurious install error all at once.
+    autoUpdater.autoDownload = capability === 'auto';
+    autoUpdater.autoInstallOnAppQuit = capability === 'auto';
+
+    if (capability === 'manual') {
+      // Reclaim whatever earlier versions of this app already stranded.
+      purgeUpdaterCache(process.resourcesPath);
+    }
 
     setAutoUpdater(autoUpdater);
 
     let updateConfirmed = false;
+    // The version the current check cycle is about. `download-progress` and the
+    // `error` event carry no version of their own, so it is tracked here.
+    let pendingVersion: string | null = null;
+    // Last percent pushed to the renderer. download-progress fires per chunk;
+    // only whole-percent changes are worth an IPC message.
+    let lastPercent = -1;
 
     autoUpdater.on('checking-for-update', () => {
       recoveryStore.update({ updateState: 'checking', lastCheckResult: null });
+      store.setStatus({ phase: 'checking' });
       updateConfirmed = false;
+      lastPercent = -1;
     });
 
     autoUpdater.on('update-available', (info: { version: string }) => {
-      updateConfirmed = true;
-      recoveryStore.update({ updateState: 'downloading', updateVersion: info.version });
-      mainWindow?.webContents.send('update-available', { version: info.version });
+      const version = info.version.slice(0, 32);
+      pendingVersion = version;
+      // Only an auto-capable build is about to attempt anything, so only there
+      // can a later error be an install failure worth reporting.
+      updateConfirmed = capability === 'auto';
+
+      if (capability === 'auto') {
+        recoveryStore.update({ updateState: 'downloading', updateVersion: version });
+        store.setStatus({ phase: 'downloading', version, percent: 0, bytesPerSecond: 0 });
+      } else {
+        recoveryStore.update({ updateState: 'available-manual', updateVersion: version });
+        store.setStatus({ phase: 'available', version });
+      }
+
+      mainWindow?.webContents.send('update-available', { version });
+
+      // In manual mode this is the end of the line, so this is the moment to
+      // tell the user. In auto mode the notification waits for the download.
+      if (capability === 'manual') {
+        notifyAboutUpdate(store.get(), autoUpdater);
+      }
     });
 
     autoUpdater.on('update-not-available', () => {
       updateConfirmed = false;
+      pendingVersion = null;
       recoveryStore.update({ updateState: 'idle', lastCheckResult: 'up-to-date' });
+      store.setStatus({ phase: 'up-to-date', checkedAt: Date.now() });
       setTimeout(() => {
         if (recoveryStore.get().lastCheckResult === 'up-to-date') {
           recoveryStore.update({ lastCheckResult: null });
         }
+        if (store.get().status.phase === 'up-to-date') {
+          store.setStatus({ phase: 'idle' });
+        }
       }, 5_000);
+    });
+
+    autoUpdater.on('download-progress', (progress: { percent?: number; bytesPerSecond?: number }) => {
+      if (pendingVersion === null) return;
+      const percent = Math.max(0, Math.min(100, Math.round(progress.percent ?? 0)));
+      if (percent === lastPercent) return;
+      lastPercent = percent;
+      store.setStatus({
+        phase: 'downloading',
+        version: pendingVersion,
+        percent,
+        bytesPerSecond: Math.max(0, Math.round(progress.bytesPerSecond ?? 0)),
+      });
     });
 
     autoUpdater.on('update-downloaded', (info: { version: string }) => {
       const version = info.version.slice(0, 32);
+      pendingVersion = version;
       recoveryStore.update({ updateState: 'downloaded', updateVersion: version });
+      store.setStatus({ phase: 'ready', version });
       mainWindow?.webContents.send('update-downloaded', { version });
-
-      // Symmetric focus-based suppression: if the user is looking at the
-      // window, the in-app banner (normal mode) or recovery Restart button
-      // (recovery mode) is visible — no need to also fire a native toast.
-      if (!mainWindow?.isFocused()) {
-        showNotification(
-          'Backspace update ready',
-          `Click to restart and install version ${version}.`,
-          () => autoUpdater.quitAndInstall(),
-        );
-      }
+      notifyAboutUpdate(store.get(), autoUpdater);
     });
 
     autoUpdater.on('error', (err: unknown) => {
@@ -783,14 +962,21 @@ function initAutoUpdater(): void {
           recoveryStore.update({ lastCheckResult: null });
         }
       }, 5_000);
-      // Existing behavior preserved: only push renderer error IPC after
-      // confirmed update. Check-phase errors stay silent.
+
       if (updateConfirmed) {
-        mainWindow?.webContents.send('update-error', {
-          message,
-          releaseUrl: 'https://github.com/TheZwiss/backspace/releases/latest',
-        });
+        // An update was actually being applied. This is news.
+        store.setStatus({ phase: 'failed', version: pendingVersion, message });
+        mainWindow?.webContents.send('update-error', { message, releaseUrl: RELEASES_URL });
+        notifyAboutUpdate(store.get(), autoUpdater);
+        return;
       }
+
+      // A check-phase failure: nothing was attempted, so there is nothing for
+      // the user to act on. Recorded with no version, which keeps it out of the
+      // toast (see shouldPromptForUpdate) while the settings panel still shows
+      // it. Interrupting someone because a background poll hit a flaky network
+      // is exactly the kind of noise this rewrite is removing.
+      store.setStatus({ phase: 'failed', version: null, message });
     });
 
     // Initial check with 10s delay (existing behavior)
@@ -1008,6 +1194,7 @@ if (!gotTheLock) {
       onChangeInstance: () => handleRecoveryAction('change-instance'),
       onCheckForUpdates: () => handleRecoveryAction('check-update'),
       onRestartToInstall: () => handleRecoveryAction('install-update'),
+      onOpenReleases: () => handleRecoveryAction('open-releases'),
       onOpenSource: () => openSourceCode(),
       onQuit: () => requestQuit(),
     };

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -23,7 +23,13 @@ contextBridge.exposeInMainWorld('backspace', {
     ipcRenderer.send('set-badge-count', count);
   },
 
-  // Auto-update
+  // Auto-update, legacy per-event channels.
+  //
+  // Superseded by getUpdateStatus/onUpdateStatusChanged below and unused by the
+  // current web client, but deliberately kept. The desktop app and the instance
+  // it connects to version independently: a newer app can be pointed at an older
+  // instance that still serves a client calling these. Removing them would make
+  // that client throw inside a useEffect and take the whole renderer down.
   onUpdateAvailable: (callback: (info: { version: string }) => void) => {
     ipcRenderer.on('update-available', (_event, info) => callback(info));
   },
@@ -40,6 +46,24 @@ contextBridge.exposeInMainWorld('backspace', {
     ipcRenderer.send('check-for-updates');
   },
   getVersion: () => ipcRenderer.invoke('get-app-version'),
+
+  // Auto-update, current surface. One snapshot carrying the capability of this
+  // build, the version the user has already waved away, and the current status.
+  getUpdateStatus: (): Promise<unknown> => ipcRenderer.invoke('get-update-status'),
+
+  onUpdateStatusChanged: (callback: (snapshot: unknown) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, snapshot: unknown) => callback(snapshot);
+    ipcRenderer.on('update-status-changed', handler);
+    return () => { ipcRenderer.removeListener('update-status-changed', handler); };
+  },
+
+  dismissUpdate: (version: string): void => {
+    ipcRenderer.send('dismiss-update', { version });
+  },
+
+  openReleasePage: (): void => {
+    ipcRenderer.send('open-release-page');
+  },
 
   // Window focus
   onWindowFocusChange: (callback: (focused: boolean) => void) => {

--- a/packages/desktop/src/recovery.test.ts
+++ b/packages/desktop/src/recovery.test.ts
@@ -342,3 +342,64 @@ describe('armBootTimer / clearBootTimer', () => {
     expect(isBootArmed()).toBe(false);
   });
 });
+
+describe('manual-download update state in the menus', () => {
+  it('offers a versioned Download item instead of Restart to Install', () => {
+    // An ad-hoc signed macOS build. Restart to Install would be a dead button
+    // here, because Squirrel.Mac can never satisfy the running app's
+    // cdhash-literal designated requirement.
+    const items = buildTrayMenuTemplate(
+      defaultState({ updateState: 'available-manual', updateVersion: '1.0.4' }),
+    );
+    const ids = items.map((i) => i.id);
+    expect(ids).toContain('download-update');
+    expect(ids).not.toContain('restart-to-install');
+    expect(items.find((i) => i.id === 'download-update')!.label)
+      .toBe('Download Backspace 1.0.4…');
+  });
+
+  it('falls back to an unversioned label when no version is known', () => {
+    const items = buildTrayMenuTemplate(
+      defaultState({ updateState: 'available-manual', updateVersion: null }),
+    );
+    expect(items.find((i) => i.id === 'download-update')!.label)
+      .toBe('Download the Update…');
+  });
+
+  it('wires the Download item to the open-releases action', () => {
+    let opened = 0;
+    const items = buildTrayMenuTemplate(
+      defaultState({ updateState: 'available-manual', updateVersion: '1.0.4' }),
+      { onOpenReleases: () => { opened += 1; } },
+    );
+    (items.find((i) => i.id === 'download-update')!.click as () => void)();
+    expect(opened).toBe(1);
+  });
+
+  it('disables Check for Updates while an update is already known', () => {
+    const items = buildTrayMenuTemplate(defaultState({ updateState: 'available-manual' }));
+    const check = items.find((i) => i.id === 'check-for-updates')!;
+    expect(check.label).toBe('Update Available');
+    expect(check.enabled).toBe(false);
+  });
+
+  it('applies the same treatment to the macOS app menu', () => {
+    const template = buildAppMenuTemplate(
+      'Backspace',
+      defaultState({ updateState: 'available-manual', updateVersion: '1.0.4' }),
+    );
+    const appSubmenu = template[0]!.submenu as Array<{ id?: string; label?: string }>;
+    const ids = appSubmenu.map((i) => i.id);
+    expect(ids).toContain('download-update');
+    expect(ids).not.toContain('restart-to-install');
+  });
+
+  it('still offers Restart to Install when the update really is staged', () => {
+    const items = buildTrayMenuTemplate(
+      defaultState({ updateState: 'downloaded', updateVersion: '1.0.4' }),
+    );
+    const ids = items.map((i) => i.id);
+    expect(ids).toContain('restart-to-install');
+    expect(ids).not.toContain('download-update');
+  });
+});

--- a/packages/desktop/src/recovery.ts
+++ b/packages/desktop/src/recovery.ts
@@ -3,6 +3,7 @@ import type { BrowserWindow, MenuItemConstructorOptions } from 'electron';
 import type { AppUpdater } from 'electron-updater';
 import path from 'path';
 import { loadInstanceUrl, clearInstanceUrl, getPickerPath } from './instanceUrl';
+import { RELEASES_URL } from './updateStatus';
 
 export type RecoveryReasonCode =
   | 'load-failed'
@@ -14,6 +15,12 @@ export type UpdateState =
   | 'idle'
   | 'checking'
   | 'downloading'
+  // An update exists but this build cannot install it in place (an ad-hoc
+  // signed macOS build, where Squirrel.Mac can never satisfy the running app's
+  // cdhash-literal designated requirement). The only useful action is a manual
+  // download, so the recovery surface offers that instead of a Restart button
+  // that would do nothing. See updateCapability.ts.
+  | 'available-manual'
   | 'downloaded'
   | 'error';
 
@@ -96,6 +103,9 @@ interface MenuActions {
   onChangeInstance: () => void;
   onCheckForUpdates: () => void;
   onRestartToInstall: () => void;
+  // Manual-download path: opens the releases page for builds that cannot
+  // install their own updates.
+  onOpenReleases: () => void;
   // AGPL-3.0 § 13: open the Corresponding Source of the running instance.
   onOpenSource: () => void;
   onQuit: () => void;
@@ -109,12 +119,46 @@ function checkForUpdatesItem(state: RecoveryState, click: () => void): MenuItemC
       return { id: 'check-for-updates', label: 'Downloading Update…', enabled: false };
     case 'downloaded':
       return { id: 'check-for-updates', label: 'Update Ready', enabled: false };
+    case 'available-manual':
+      return { id: 'check-for-updates', label: 'Update Available', enabled: false };
     case 'error':
       return { id: 'check-for-updates', label: 'Check for Updates… (last attempt failed)', enabled: true, click };
     case 'idle':
     default:
       return { id: 'check-for-updates', label: 'Check for Updates…', enabled: true, click };
   }
+}
+
+/**
+ * The action item that sits under "Check for Updates" once an update is known.
+ *
+ * Which action that is depends on whether the build can install in place. A
+ * build that cannot must never show "Restart to Install Update", because that
+ * is precisely the dead button this work exists to remove.
+ */
+function updateActionItem(
+  state: RecoveryState,
+  actions?: Partial<MenuActions>,
+): MenuItemConstructorOptions | null {
+  if (state.updateState === 'downloaded') {
+    return {
+      id: 'restart-to-install',
+      label: 'Restart to Install Update',
+      enabled: true,
+      click: actions?.onRestartToInstall,
+    };
+  }
+  if (state.updateState === 'available-manual') {
+    return {
+      id: 'download-update',
+      label: state.updateVersion
+        ? `Download Backspace ${state.updateVersion}…`
+        : 'Download the Update…',
+      enabled: true,
+      click: actions?.onOpenReleases,
+    };
+  }
+  return null;
 }
 
 export function buildTrayMenuTemplate(
@@ -128,14 +172,8 @@ export function buildTrayMenuTemplate(
     checkForUpdatesItem(state, () => actions?.onCheckForUpdates?.()),
   ];
 
-  if (state.updateState === 'downloaded') {
-    items.push({
-      id: 'restart-to-install',
-      label: 'Restart to Install Update',
-      enabled: true,
-      click: actions?.onRestartToInstall,
-    });
-  }
+  const updateAction = updateActionItem(state, actions);
+  if (updateAction) items.push(updateAction);
 
   items.push(
     { type: 'separator' },
@@ -160,14 +198,8 @@ export function buildAppMenuTemplate(
     checkForUpdatesItem(state, () => actions?.onCheckForUpdates?.()),
   ];
 
-  if (state.updateState === 'downloaded') {
-    appSubmenu.push({
-      id: 'restart-to-install',
-      label: 'Restart to Install Update',
-      enabled: true,
-      click: actions?.onRestartToInstall,
-    });
-  }
+  const updateAction = updateActionItem(state, actions);
+  if (updateAction) appSubmenu.push(updateAction);
 
   appSubmenu.push(
     { type: 'separator' },
@@ -440,7 +472,7 @@ export function handleRecoveryAction(action: RecoveryAction): void {
       return;
     }
     case 'open-releases': {
-      shell.openExternal('https://github.com/TheZwiss/backspace/releases/latest');
+      shell.openExternal(RELEASES_URL);
       return;
     }
     case 'quit': {

--- a/packages/desktop/src/updateCapability.test.ts
+++ b/packages/desktop/src/updateCapability.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { app } from 'electron';
+import {
+  classifyDesignatedRequirement,
+  macAppBundlePath,
+  getUpdateCapability,
+  resetUpdateCapabilityForTest,
+} from './updateCapability';
+
+// The module reads app.isPackaged. Mock it so the capability branches are
+// reachable in a plain Node test run, matching recovery.test.ts's pattern.
+vi.mock('electron', () => ({
+  app: { isPackaged: true },
+}));
+
+const mockedApp = app as unknown as { isPackaged: boolean };
+
+function withPlatform(value: NodeJS.Platform, fn: () => void): void {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+}
+
+describe('classifyDesignatedRequirement', () => {
+  it('classifies a bare cdhash requirement as ad-hoc', () => {
+    // Verbatim output from the ad-hoc signed 1.0.3 build that could not update.
+    const output = [
+      'Executable=/Applications/Backspace.app/Contents/MacOS/Backspace',
+      '# designated => cdhash H"4a9e49fe20f82802702a4e9d752748e990909659"',
+      '',
+    ].join('\n');
+    expect(classifyDesignatedRequirement(output)).toBe('adhoc');
+  });
+
+  it('classifies a universal binary with one cdhash per slice as ad-hoc', () => {
+    const output = [
+      'Executable=/Applications/Backspace.app/Contents/MacOS/Backspace',
+      '# designated => cdhash H"aaaa1111" or cdhash H"bbbb2222"',
+    ].join('\n');
+    expect(classifyDesignatedRequirement(output)).toBe('adhoc');
+  });
+
+  it('classifies a Developer ID requirement as identified', () => {
+    const output = [
+      'Executable=/Applications/Backspace.app/Contents/MacOS/Backspace',
+      'Identifier=com.backspace.desktop',
+      '# designated => identifier "com.backspace.desktop" and anchor apple generic and certificate leaf[subject.OU] = "AB12CD34EF"',
+    ].join('\n');
+    expect(classifyDesignatedRequirement(output)).toBe('identified');
+  });
+
+  it('classifies a requirement wrapped across lines as identified', () => {
+    const output = [
+      'Executable=/Applications/Backspace.app/Contents/MacOS/Backspace',
+      '# designated => identifier "com.backspace.desktop" and anchor apple',
+      '  generic and certificate leaf[subject.OU] = "AB12CD34EF"',
+      '',
+    ].join('\n');
+    expect(classifyDesignatedRequirement(output)).toBe('identified');
+  });
+
+  it('does not let a following codesign field leak into the requirement', () => {
+    // A cdhash requirement followed by another field must still read as ad-hoc,
+    // not get upgraded by the word "certificate" appearing further down.
+    const output = [
+      '# designated => cdhash H"4a9e49fe"',
+      'CandidateCDHashFull=sha256=4a9e49fe',
+      'CDHash=4a9e49fe',
+      'certificate stuff that is not part of the requirement',
+    ].join('\n');
+    expect(classifyDesignatedRequirement(output)).toBe('adhoc');
+  });
+
+  it('classifies a real Developer ID requirement with no comment prefix', () => {
+    // Verbatim from a shipping notarized app. Note there is no leading '#', and
+    // the requirement carries certificate field terms as well as the anchor.
+    const output =
+      'Executable=/Applications/Discord.app/Contents/MacOS/Discord\n' +
+      'designated => identifier "com.hnc.Discord" and anchor apple generic and ' +
+      'certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate ' +
+      'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate ' +
+      'leaf[subject.OU] = "53Q6R32WPB"\n';
+    expect(classifyDesignatedRequirement(output)).toBe('identified');
+  });
+
+  it('handles the real stream ordering, where the requirement precedes Executable=', () => {
+    // codesign writes the requirement to stdout and the -d report to stderr.
+    // readDesignatedRequirement concatenates stdout then stderr, so the
+    // Executable= field lands *after* the requirement and must terminate it.
+    const stdout = '# designated => cdhash H"4a9e49fe20f82802702a4e9d752748e990909659"\n';
+    const stderr = 'Executable=/Applications/Backspace.app/Contents/MacOS/Backspace\n';
+    expect(classifyDesignatedRequirement(`${stdout}\n${stderr}`)).toBe('adhoc');
+  });
+
+  it('classifies an unsigned bundle as unknown', () => {
+    // codesign prints this to stderr and never emits a designated requirement.
+    const output = '/Applications/Backspace.app: code object is not signed at all\n';
+    expect(classifyDesignatedRequirement(output)).toBe('unknown');
+  });
+
+  it('classifies empty output as unknown', () => {
+    expect(classifyDesignatedRequirement('')).toBe('unknown');
+  });
+
+  it('classifies a truncated requirement line as unknown', () => {
+    expect(classifyDesignatedRequirement('# designated => \n')).toBe('unknown');
+  });
+
+  it('classifies an unrecognised requirement shape as unknown', () => {
+    expect(classifyDesignatedRequirement('# designated => info[Something] = "x"')).toBe('unknown');
+  });
+});
+
+describe('macAppBundlePath', () => {
+  it('resolves the bundle root from the main executable', () => {
+    expect(macAppBundlePath('/Applications/Backspace.app/Contents/MacOS/Backspace'))
+      .toBe('/Applications/Backspace.app');
+  });
+
+  it('handles a bundle in a path containing spaces', () => {
+    expect(macAppBundlePath('/Users/x/My Apps/Backspace.app/Contents/MacOS/Backspace'))
+      .toBe('/Users/x/My Apps/Backspace.app');
+  });
+});
+
+describe('getUpdateCapability', () => {
+  beforeEach(() => {
+    resetUpdateCapabilityForTest();
+    mockedApp.isPackaged = true;
+  });
+
+  it('is manual for an unpackaged dev build on every platform', () => {
+    mockedApp.isPackaged = false;
+    withPlatform('win32', () => {
+      expect(getUpdateCapability()).toBe('manual');
+    });
+  });
+
+  it('is auto on Windows, where NSIS applies unsigned updates', () => {
+    withPlatform('win32', () => {
+      expect(getUpdateCapability()).toBe('auto');
+    });
+  });
+
+  it('is auto on Linux, where AppImage applies unsigned updates', () => {
+    withPlatform('linux', () => {
+      expect(getUpdateCapability()).toBe('auto');
+    });
+  });
+
+  it('memoises the result so codesign runs at most once', () => {
+    withPlatform('win32', () => {
+      const first = getUpdateCapability();
+      mockedApp.isPackaged = false; // would flip the answer if it were re-read
+      expect(getUpdateCapability()).toBe(first);
+    });
+  });
+});

--- a/packages/desktop/src/updateCapability.ts
+++ b/packages/desktop/src/updateCapability.ts
@@ -1,0 +1,159 @@
+import { app } from 'electron';
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+/**
+ * Whether this build can install its own updates.
+ *
+ * `auto`   — electron-updater can download and apply an update in place.
+ * `manual` — it cannot, so the user must be sent to the download page instead.
+ */
+export type UpdateCapability = 'auto' | 'manual';
+
+/**
+ * How the running macOS bundle is signed, as far as Squirrel.Mac cares.
+ *
+ * `adhoc`      — the designated requirement is a literal cdhash of this exact
+ *                binary. No other build can ever satisfy it.
+ * `identified` — the requirement is anchored to a certificate, so later builds
+ *                signed by the same identity satisfy it.
+ * `unknown`    — no requirement could be read (unsigned, codesign missing,
+ *                unparseable output).
+ */
+export type SignatureClass = 'adhoc' | 'identified' | 'unknown';
+
+/**
+ * Classifies the designated requirement printed by `codesign -d -r- <bundle>`.
+ *
+ * This is the property that decides whether macOS auto-update can ever work.
+ * Squirrel.Mac validates a staged update against the *running* app's designated
+ * requirement before installing it. An ad-hoc signature has no stable identity,
+ * so codesign derives the requirement from the binary's own code directory hash:
+ *
+ *   # designated => cdhash H"4a9e49fe20f82802702a4e9d752748e990909659"
+ *
+ * A different build has a different cdhash, so it cannot satisfy that. Not
+ * "usually fails". It is arithmetically impossible for every future release.
+ *
+ * A Developer ID signed bundle instead reports something anchored to the
+ * certificate, which every later build from the same team satisfies:
+ *
+ *   # designated => identifier "com.backspace.desktop" and anchor apple generic
+ *     and certificate leaf[subject.OU] = "TEAMID"
+ *
+ * Universal binaries report one cdhash term per slice, joined by `or`, so the
+ * check is "mentions cdhash and nothing certificate-shaped" rather than an
+ * exact-match on a single term.
+ */
+export function classifyDesignatedRequirement(codesignOutput: string): SignatureClass {
+  if (!codesignOutput) return 'unknown';
+
+  const marker = 'designated =>';
+  const idx = codesignOutput.indexOf(marker);
+  if (idx === -1) return 'unknown';
+
+  // The requirement can wrap across lines. Take everything after the marker up
+  // to the next line that starts a new codesign field (`Something=value`), which
+  // is how codesign delimits its -d output.
+  const rest = codesignOutput.slice(idx + marker.length);
+  const lines = rest.split(/\r?\n/);
+  const parts: string[] = [lines[0] ?? ''];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const trimmed = line.trim();
+    if (trimmed === '') break;
+    if (/^[A-Za-z][A-Za-z0-9]*=/.test(trimmed)) break;
+    parts.push(line);
+  }
+
+  const requirement = parts.join(' ').trim().toLowerCase();
+  if (requirement === '') return 'unknown';
+
+  // Anchored to a certificate of some kind. Later builds from the same identity
+  // satisfy it, so Squirrel can install them.
+  if (requirement.includes('anchor ') || requirement.includes('certificate')) {
+    return 'identified';
+  }
+
+  // Only cdhash terms. This is the ad-hoc case.
+  if (requirement.includes('cdhash')) return 'adhoc';
+
+  return 'unknown';
+}
+
+/**
+ * Resolves the .app bundle root from the main executable path.
+ *
+ * `/Applications/Backspace.app/Contents/MacOS/Backspace`
+ *   -> `/Applications/Backspace.app`
+ *
+ * Exported for tests; the shape is fixed by the macOS bundle layout.
+ */
+export function macAppBundlePath(execPath: string): string {
+  return path.resolve(path.dirname(execPath), '..', '..');
+}
+
+/**
+ * Runs `codesign -d -r-` against the bundle and returns its combined output.
+ *
+ * codesign writes its -d report to stderr, and prints a usable requirement even
+ * on some non-zero exits, so both streams are returned and the exit status is
+ * deliberately ignored. A spawn failure yields an empty string, which
+ * classifies as `unknown`, which resolves to `manual`.
+ */
+function readDesignatedRequirement(bundlePath: string): string {
+  try {
+    const result = spawnSync('/usr/bin/codesign', ['-d', '-r-', bundlePath], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      windowsHide: true,
+    });
+    if (result.error) return '';
+    return `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  } catch {
+    return '';
+  }
+}
+
+let cached: UpdateCapability | null = null;
+
+/**
+ * Whether this build can install its own updates. Computed once, then cached.
+ *
+ * Every uncertain path resolves to `manual` on purpose. A download link always
+ * works, so guessing "manual" wrongly costs the user one extra click, while
+ * guessing "auto" wrongly gives them a button that does nothing, which is the
+ * exact defect this module exists to remove.
+ *
+ * Nothing here hardcodes "macOS cannot update". It measures the signature, so
+ * the day CI signs with a Developer ID, this returns `auto` with no code change.
+ */
+export function getUpdateCapability(): UpdateCapability {
+  if (cached !== null) return cached;
+
+  // A dev build has no update feed and must never offer to install anything.
+  if (!app.isPackaged) {
+    cached = 'manual';
+    return cached;
+  }
+
+  // NSIS and AppImage both apply unsigned updates without complaint.
+  if (process.platform !== 'darwin') {
+    cached = 'auto';
+    return cached;
+  }
+
+  const bundlePath = macAppBundlePath(process.execPath);
+  const signatureClass = classifyDesignatedRequirement(readDesignatedRequirement(bundlePath));
+  cached = signatureClass === 'identified' ? 'auto' : 'manual';
+
+  console.log(
+    `[update] capability=${cached} (macOS signature classified as ${signatureClass})`,
+  );
+  return cached;
+}
+
+/** Test seam. Clears the memoised value so each case probes fresh. */
+export function resetUpdateCapabilityForTest(): void {
+  cached = null;
+}

--- a/packages/desktop/src/updateDismissal.test.ts
+++ b/packages/desktop/src/updateDismissal.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  parseDismissalFile,
+  loadDismissedVersion,
+  setDismissedVersion,
+  isVersionDismissed,
+} from './updateDismissal';
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/nonexistent-userdata' },
+}));
+
+describe('parseDismissalFile', () => {
+  it('reads a stored version', () => {
+    expect(parseDismissalFile('{"dismissedVersion":"1.0.4"}')).toBe('1.0.4');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseDismissalFile('{"dismissedVersion":"  1.0.4  "}')).toBe('1.0.4');
+  });
+
+  it('returns null for invalid JSON rather than throwing', () => {
+    expect(parseDismissalFile('{"dismissedVersion":')).toBeNull();
+    expect(parseDismissalFile('')).toBeNull();
+    expect(parseDismissalFile('not json at all')).toBeNull();
+  });
+
+  it('returns null when the field is missing or the wrong type', () => {
+    expect(parseDismissalFile('{}')).toBeNull();
+    expect(parseDismissalFile('{"dismissedVersion":null}')).toBeNull();
+    expect(parseDismissalFile('{"dismissedVersion":104}')).toBeNull();
+    expect(parseDismissalFile('{"dismissedVersion":["1.0.4"]}')).toBeNull();
+  });
+
+  it('returns null for a JSON value that is not an object', () => {
+    expect(parseDismissalFile('"1.0.4"')).toBeNull();
+    expect(parseDismissalFile('[1,2,3]')).toBeNull();
+    expect(parseDismissalFile('null')).toBeNull();
+  });
+
+  it('rejects an empty or absurdly long version', () => {
+    expect(parseDismissalFile('{"dismissedVersion":""}')).toBeNull();
+    expect(parseDismissalFile('{"dismissedVersion":"   "}')).toBeNull();
+    expect(parseDismissalFile(JSON.stringify({ dismissedVersion: 'x'.repeat(65) }))).toBeNull();
+  });
+});
+
+describe('isVersionDismissed', () => {
+  it('hides exactly the dismissed version', () => {
+    expect(isVersionDismissed('1.0.4', '1.0.4')).toBe(true);
+  });
+
+  it('does not hide a later release', () => {
+    expect(isVersionDismissed('1.0.5', '1.0.4')).toBe(false);
+    expect(isVersionDismissed('2.0.0', '1.0.4')).toBe(false);
+  });
+
+  it('does not hide anything when nothing was dismissed', () => {
+    expect(isVersionDismissed('1.0.4', null)).toBe(false);
+  });
+});
+
+describe('dismissal round-trip on disk', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bs-update-'));
+    file = path.join(dir, 'update-state.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('persists and reads back a version', () => {
+    setDismissedVersion('1.0.4', file);
+    expect(loadDismissedVersion(file)).toBe('1.0.4');
+  });
+
+  it('overwrites the previous dismissal rather than accumulating', () => {
+    setDismissedVersion('1.0.4', file);
+    setDismissedVersion('1.0.5', file);
+    expect(loadDismissedVersion(file)).toBe('1.0.5');
+  });
+
+  it('returns null when the file does not exist', () => {
+    expect(loadDismissedVersion(path.join(dir, 'absent.json'))).toBeNull();
+  });
+
+  it('returns null for a corrupt file instead of throwing', () => {
+    fs.writeFileSync(file, '{"dismissedVersion": "1.0.4"');
+    expect(loadDismissedVersion(file)).toBeNull();
+  });
+
+  it('clamps an over-long version on write', () => {
+    setDismissedVersion('x'.repeat(200), file);
+    // Written clamped to 64, which parseDismissalFile then accepts.
+    expect(loadDismissedVersion(file)).toBe('x'.repeat(64));
+  });
+
+  it('ignores an empty version rather than writing one', () => {
+    setDismissedVersion('   ', file);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+});

--- a/packages/desktop/src/updateDismissal.ts
+++ b/packages/desktop/src/updateDismissal.ts
@@ -1,0 +1,84 @@
+import { app } from 'electron';
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Remembers which update version the user has waved away.
+ *
+ * This lives in the main process, in userData, rather than in the renderer's
+ * localStorage, because an available update is a property of the *installed
+ * app*, not of whichever instance the user happens to be connected to. Storing
+ * it per-origin would re-nag anyone who switches instances, and would lose the
+ * dismissal entirely when site data is cleared.
+ *
+ * Only one version is remembered. Dismissing 1.0.4 silences 1.0.4 and nothing
+ * else, so 1.0.5 surfaces normally when it ships. A dismissed update is never
+ * lost: it stays reachable in Settings, Desktop, which is what makes dismissal
+ * safe to offer at all.
+ */
+
+/** Upper bound on a stored version string. Feed values are not ours to trust. */
+const MAX_VERSION_LENGTH = 64;
+
+export function getUpdateStatePath(): string {
+  return path.join(app.getPath('userData'), 'update-state.json');
+}
+
+/**
+ * Reads a dismissed version out of the on-disk JSON.
+ *
+ * Anything that is not a plain non-empty string yields null, so a truncated,
+ * hand-edited, or half-written file degrades to "nothing dismissed" rather than
+ * throwing during startup. Showing one extra prompt is a far better failure than
+ * refusing to boot.
+ */
+export function parseDismissalFile(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const value = (parsed as { dismissedVersion?: unknown }).dismissedVersion;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '' || trimmed.length > MAX_VERSION_LENGTH) return null;
+  return trimmed;
+}
+
+export function loadDismissedVersion(filePath?: string): string | null {
+  try {
+    return parseDismissalFile(fs.readFileSync(filePath ?? getUpdateStatePath(), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function setDismissedVersion(version: string, filePath?: string): void {
+  const trimmed = version.trim().slice(0, MAX_VERSION_LENGTH);
+  if (trimmed === '') return;
+  try {
+    fs.writeFileSync(
+      filePath ?? getUpdateStatePath(),
+      JSON.stringify({ dismissedVersion: trimmed }),
+    );
+  } catch (err) {
+    // A failed write means the prompt reappears next launch. Annoying, not
+    // broken, and not worth taking the app down for.
+    console.error('[update] could not persist the dismissed version:', err);
+  }
+}
+
+/**
+ * Whether an offered version should stay hidden.
+ *
+ * Deliberately an exact match rather than a semver comparison. "Newer than what
+ * I dismissed" and "not the thing I dismissed" only differ when a release is
+ * withdrawn and an older one becomes latest again, and in that case surfacing
+ * the prompt is the right answer anyway.
+ */
+export function isVersionDismissed(offered: string, dismissed: string | null): boolean {
+  if (dismissed === null) return false;
+  return offered.trim() === dismissed;
+}

--- a/packages/desktop/src/updateStatus.test.ts
+++ b/packages/desktop/src/updateStatus.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  UpdateStatusStore,
+  shouldPromptForUpdate,
+  canInstallInPlace,
+  statusVersion,
+  type UpdateSnapshot,
+  type UpdateStatus,
+} from './updateStatus';
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/nonexistent-userdata' },
+}));
+
+function snap(partial: Partial<UpdateSnapshot>): UpdateSnapshot {
+  return {
+    capability: 'auto',
+    dismissedVersion: null,
+    status: { phase: 'idle' },
+    ...partial,
+  };
+}
+
+describe('statusVersion', () => {
+  it('extracts the version from every phase that carries one', () => {
+    expect(statusVersion({ phase: 'available', version: '1.0.4' })).toBe('1.0.4');
+    expect(statusVersion({ phase: 'ready', version: '1.0.4' })).toBe('1.0.4');
+    expect(statusVersion({ phase: 'downloading', version: '1.0.4', percent: 5, bytesPerSecond: 1 })).toBe('1.0.4');
+    expect(statusVersion({ phase: 'failed', version: '1.0.4', message: 'x' })).toBe('1.0.4');
+  });
+
+  it('returns null for phases with no version', () => {
+    expect(statusVersion({ phase: 'idle' })).toBeNull();
+    expect(statusVersion({ phase: 'checking' })).toBeNull();
+    expect(statusVersion({ phase: 'up-to-date', checkedAt: 1 })).toBeNull();
+    expect(statusVersion({ phase: 'failed', version: null, message: 'x' })).toBeNull();
+  });
+});
+
+describe('shouldPromptForUpdate', () => {
+  it('prompts for an available, ready, or failed update', () => {
+    expect(shouldPromptForUpdate(snap({ status: { phase: 'available', version: '1.0.4' } }))).toBe(true);
+    expect(shouldPromptForUpdate(snap({ status: { phase: 'ready', version: '1.0.4' } }))).toBe(true);
+    expect(shouldPromptForUpdate(snap({ status: { phase: 'failed', version: '1.0.4', message: 'x' } }))).toBe(true);
+  });
+
+  it('stays quiet for progress phases', () => {
+    expect(shouldPromptForUpdate(snap({ status: { phase: 'idle' } }))).toBe(false);
+    expect(shouldPromptForUpdate(snap({ status: { phase: 'checking' } }))).toBe(false);
+    expect(shouldPromptForUpdate(snap({
+      status: { phase: 'downloading', version: '1.0.4', percent: 40, bytesPerSecond: 1 },
+    }))).toBe(false);
+    expect(shouldPromptForUpdate(snap({ status: { phase: 'up-to-date', checkedAt: 1 } }))).toBe(false);
+  });
+
+  it('stays quiet for a dismissed version', () => {
+    expect(shouldPromptForUpdate(snap({
+      dismissedVersion: '1.0.4',
+      status: { phase: 'available', version: '1.0.4' },
+    }))).toBe(false);
+  });
+
+  it('still prompts for a version newer than the dismissed one', () => {
+    expect(shouldPromptForUpdate(snap({
+      dismissedVersion: '1.0.4',
+      status: { phase: 'available', version: '1.0.5' },
+    }))).toBe(true);
+  });
+
+  it('stays quiet for a failure that never learned a version', () => {
+    expect(shouldPromptForUpdate(snap({
+      status: { phase: 'failed', version: null, message: 'network unreachable' },
+    }))).toBe(false);
+  });
+});
+
+describe('canInstallInPlace', () => {
+  it('is true only for a ready update on an auto-capable build', () => {
+    expect(canInstallInPlace(snap({ capability: 'auto', status: { phase: 'ready', version: '1.0.4' } }))).toBe(true);
+  });
+
+  it('is false on a build that cannot install its own updates', () => {
+    // The ad-hoc signed macOS case. This is what removes the dead Restart button.
+    expect(canInstallInPlace(snap({ capability: 'manual', status: { phase: 'ready', version: '1.0.4' } }))).toBe(false);
+  });
+
+  it('is false for any phase other than ready', () => {
+    expect(canInstallInPlace(snap({ capability: 'auto', status: { phase: 'available', version: '1.0.4' } }))).toBe(false);
+    expect(canInstallInPlace(snap({ capability: 'auto', status: { phase: 'idle' } }))).toBe(false);
+  });
+});
+
+describe('UpdateStatusStore', () => {
+  it('starts idle and carries the injected ambient facts', () => {
+    const store = new UpdateStatusStore('manual', '1.0.3');
+    expect(store.get()).toEqual({
+      capability: 'manual',
+      dismissedVersion: '1.0.3',
+      status: { phase: 'idle' },
+    });
+  });
+
+  it('lets a later failure supersede an earlier ready state', () => {
+    // The exact defect: "Update ready" outranked "Update failed" forever because
+    // two independent flags were checked in render order.
+    const store = new UpdateStatusStore('auto', null);
+    store.setStatus({ phase: 'ready', version: '1.0.4' });
+    store.setStatus({ phase: 'failed', version: '1.0.4', message: 'squirrel refused' });
+    expect(store.get().status).toEqual({ phase: 'failed', version: '1.0.4', message: 'squirrel refused' });
+  });
+
+  it('notifies subscribers on every status change', () => {
+    const store = new UpdateStatusStore('auto', null);
+    const seen: UpdateStatus[] = [];
+    store.subscribe((s) => seen.push(s.status));
+    store.setStatus({ phase: 'checking' });
+    store.setStatus({ phase: 'up-to-date', checkedAt: 42 });
+    expect(seen).toEqual([{ phase: 'checking' }, { phase: 'up-to-date', checkedAt: 42 }]);
+  });
+
+  it('notifies subscribers when a dismissal is recorded', () => {
+    const store = new UpdateStatusStore('manual', null);
+    store.setStatus({ phase: 'available', version: '1.0.4' });
+    const seen: (string | null)[] = [];
+    store.subscribe((s) => seen.push(s.dismissedVersion));
+    store.setDismissedVersion('1.0.4');
+    expect(seen).toEqual(['1.0.4']);
+    expect(shouldPromptForUpdate(store.get())).toBe(false);
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const store = new UpdateStatusStore('auto', null);
+    let calls = 0;
+    const off = store.subscribe(() => { calls += 1; });
+    store.setStatus({ phase: 'checking' });
+    off();
+    store.setStatus({ phase: 'idle' });
+    expect(calls).toBe(1);
+  });
+
+  it('survives a throwing listener and still notifies the rest', () => {
+    const store = new UpdateStatusStore('auto', null);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let reached = false;
+    store.subscribe(() => { throw new Error('bad listener'); });
+    store.subscribe(() => { reached = true; });
+    store.setStatus({ phase: 'checking' });
+    expect(reached).toBe(true);
+    errorSpy.mockRestore();
+  });
+
+  it('hands out a frozen snapshot', () => {
+    const store = new UpdateStatusStore('auto', null);
+    expect(Object.isFrozen(store.get())).toBe(true);
+  });
+});

--- a/packages/desktop/src/updateStatus.ts
+++ b/packages/desktop/src/updateStatus.ts
@@ -1,0 +1,142 @@
+import type { UpdateCapability } from './updateCapability';
+import { isVersionDismissed } from './updateDismissal';
+
+/**
+ * The one place that says where a user is sent to fetch a build by hand.
+ * Shared by the main process notification, the recovery surface, and the
+ * renderer toast so the three cannot drift apart.
+ */
+export const RELEASES_URL = 'https://github.com/TheZwiss/backspace/releases/latest';
+
+/**
+ * Where the updater currently is.
+ *
+ * This replaces the two independent booleans the renderer used to hold. Those
+ * could disagree: a stale "downloaded" outranked a fresh "failed" purely because
+ * it was checked first in the render, which is why an install failure stayed
+ * invisible until the user dismissed the toast in front of it. A single value
+ * that every event replaces wholesale makes that class of bug unrepresentable.
+ */
+export type UpdateStatus =
+  | { phase: 'idle' }
+  | { phase: 'checking' }
+  | { phase: 'available'; version: string }
+  | { phase: 'downloading'; version: string; percent: number; bytesPerSecond: number }
+  | { phase: 'ready'; version: string }
+  | { phase: 'failed'; version: string | null; message: string }
+  | { phase: 'up-to-date'; checkedAt: number };
+
+/**
+ * Everything the renderer needs to render the update surfaces.
+ *
+ * `capability` and `dismissedVersion` are ambient facts about the install;
+ * `status` is the event-driven part. They travel together so the renderer never
+ * has to correlate two channels, and so a dismissed update stays *visible* in
+ * settings while being *silent* in the toast. Suppressing it in the main process
+ * instead would make a dismissed update unreachable, which is what would turn
+ * "Later" into "never".
+ */
+export interface UpdateSnapshot {
+  capability: UpdateCapability;
+  dismissedVersion: string | null;
+  status: UpdateStatus;
+}
+
+const INITIAL_STATUS: UpdateStatus = { phase: 'idle' };
+
+/**
+ * The version a status is about, or null when the phase carries no version.
+ * `failed` may legitimately carry none, because a check can fail before any
+ * version is known.
+ */
+export function statusVersion(status: UpdateStatus): string | null {
+  switch (status.phase) {
+    case 'available':
+    case 'downloading':
+    case 'ready':
+      return status.version;
+    case 'failed':
+      return status.version;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Whether this snapshot warrants interrupting the user.
+ *
+ * Both the in-app toast and the native notification ask this exact function, so
+ * the two cannot disagree about whether the user has already said "later".
+ *
+ * `checking`, `downloading` and `up-to-date` are settings-panel states. They are
+ * progress, not news, and a chat client has no business throwing a card over the
+ * message list to report them.
+ */
+export function shouldPromptForUpdate(snapshot: UpdateSnapshot): boolean {
+  const { status } = snapshot;
+  if (status.phase !== 'available' && status.phase !== 'ready' && status.phase !== 'failed') {
+    return false;
+  }
+  const version = statusVersion(status);
+  if (version === null) {
+    // A check that failed before it learned a version. There is nothing
+    // actionable to offer, so stay quiet and leave it to the settings panel.
+    return false;
+  }
+  return !isVersionDismissed(version, snapshot.dismissedVersion);
+}
+
+/**
+ * Whether the renderer should offer a Restart button for this snapshot.
+ *
+ * The renderer never reasons about code signing. It asks this, and this asks the
+ * capability the main process measured.
+ */
+export function canInstallInPlace(snapshot: UpdateSnapshot): boolean {
+  return snapshot.capability === 'auto' && snapshot.status.phase === 'ready';
+}
+
+export class UpdateStatusStore {
+  private snapshot: UpdateSnapshot;
+  private listeners = new Set<(s: UpdateSnapshot) => void>();
+
+  constructor(capability: UpdateCapability, dismissedVersion: string | null) {
+    this.snapshot = Object.freeze({
+      capability,
+      dismissedVersion,
+      status: INITIAL_STATUS,
+    });
+  }
+
+  get(): Readonly<UpdateSnapshot> {
+    return this.snapshot;
+  }
+
+  /** Replaces the status wholesale. Latest event always wins. */
+  setStatus(status: UpdateStatus): void {
+    this.commit({ ...this.snapshot, status });
+  }
+
+  setDismissedVersion(version: string | null): void {
+    this.commit({ ...this.snapshot, dismissedVersion: version });
+  }
+
+  subscribe(cb: (s: UpdateSnapshot) => void): () => void {
+    this.listeners.add(cb);
+    return () => { this.listeners.delete(cb); };
+  }
+
+  private commit(next: UpdateSnapshot): void {
+    // Frozen for the same reason RecoveryStateStore freezes: get() hands out a
+    // live reference and Readonly<> is only a compile-time hint.
+    this.snapshot = Object.freeze(next);
+    const listeners = Array.from(this.listeners);
+    for (const cb of listeners) {
+      try {
+        cb(this.snapshot);
+      } catch (err) {
+        console.error('[update] status listener threw:', err);
+      }
+    }
+  }
+}

--- a/packages/desktop/src/updaterCache.test.ts
+++ b/packages/desktop/src/updaterCache.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  parseUpdaterCacheDirName,
+  isSafeUpdaterCacheDirName,
+  resolveUpdaterCacheDir,
+  purgeUpdaterCache,
+} from './updaterCache';
+
+describe('parseUpdaterCacheDirName', () => {
+  it('reads the real app-update.yml electron-builder emits', () => {
+    // Verbatim from /Applications/Backspace.app/Contents/Resources/app-update.yml
+    const yml = [
+      'owner: TheZwiss',
+      'repo: backspace',
+      'provider: github',
+      "updaterCacheDirName: '@backspacedesktop-updater'",
+      '',
+    ].join('\n');
+    expect(parseUpdaterCacheDirName(yml)).toBe('@backspacedesktop-updater');
+  });
+
+  it('handles double quotes and bare scalars', () => {
+    expect(parseUpdaterCacheDirName('updaterCacheDirName: "app-updater"')).toBe('app-updater');
+    expect(parseUpdaterCacheDirName('updaterCacheDirName: app-updater')).toBe('app-updater');
+  });
+
+  it('strips an inline comment from an unquoted scalar', () => {
+    expect(parseUpdaterCacheDirName('updaterCacheDirName: app-updater # generated'))
+      .toBe('app-updater');
+  });
+
+  it('ignores commented-out lines', () => {
+    const yml = ['# updaterCacheDirName: wrong-updater', 'updaterCacheDirName: right-updater'].join('\n');
+    expect(parseUpdaterCacheDirName(yml)).toBe('right-updater');
+  });
+
+  it('returns null when the key is absent or empty', () => {
+    expect(parseUpdaterCacheDirName('provider: github')).toBeNull();
+    expect(parseUpdaterCacheDirName('')).toBeNull();
+    expect(parseUpdaterCacheDirName('updaterCacheDirName:')).toBeNull();
+    expect(parseUpdaterCacheDirName("updaterCacheDirName: ''")).toBeNull();
+  });
+});
+
+describe('isSafeUpdaterCacheDirName', () => {
+  it('accepts the real name', () => {
+    expect(isSafeUpdaterCacheDirName('@backspacedesktop-updater')).toBe(true);
+  });
+
+  it('requires the -updater suffix, so no unrelated directory qualifies', () => {
+    expect(isSafeUpdaterCacheDirName('Backspace')).toBe(false);
+    expect(isSafeUpdaterCacheDirName('com.apple.Safari')).toBe(false);
+    expect(isSafeUpdaterCacheDirName('@backspacedesktop-updater-old')).toBe(false);
+  });
+
+  it('rejects anything containing a path separator or traversal', () => {
+    expect(isSafeUpdaterCacheDirName('../../-updater')).toBe(false);
+    expect(isSafeUpdaterCacheDirName('..-updater')).toBe(false);
+    expect(isSafeUpdaterCacheDirName('a/b-updater')).toBe(false);
+    expect(isSafeUpdaterCacheDirName('a\\b-updater')).toBe(false);
+    expect(isSafeUpdaterCacheDirName('/-updater')).toBe(false);
+  });
+
+  it('rejects the bare suffix, which carries no app identity', () => {
+    expect(isSafeUpdaterCacheDirName('-updater')).toBe(false);
+  });
+
+  it('rejects an empty name', () => {
+    expect(isSafeUpdaterCacheDirName('')).toBe(false);
+  });
+});
+
+describe('resolveUpdaterCacheDir', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bs-res-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when app-update.yml is absent, as in a dev build', () => {
+    expect(resolveUpdaterCacheDir(dir)).toBeNull();
+  });
+
+  it('returns null when the recorded name is not safe to delete', () => {
+    fs.writeFileSync(path.join(dir, 'app-update.yml'), 'updaterCacheDirName: ../../Documents\n');
+    expect(resolveUpdaterCacheDir(dir)).toBeNull();
+  });
+
+  it('resolves inside the platform cache directory', () => {
+    fs.writeFileSync(path.join(dir, 'app-update.yml'), "updaterCacheDirName: 'x-updater'\n");
+    const resolved = resolveUpdaterCacheDir(dir);
+    expect(resolved).not.toBeNull();
+    expect(path.basename(resolved!)).toBe('x-updater');
+  });
+});
+
+describe('purgeUpdaterCache', () => {
+  let root: string;
+  let resources: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'bs-purge-'));
+    resources = path.join(root, 'Resources');
+    fs.mkdirSync(resources);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does nothing and reports zero when there is no app-update.yml', () => {
+    expect(purgeUpdaterCache(resources)).toBe(0);
+  });
+
+  it('does nothing when the cache directory does not exist', () => {
+    fs.writeFileSync(path.join(resources, 'app-update.yml'), "updaterCacheDirName: 'x-updater'\n");
+    expect(purgeUpdaterCache(resources)).toBe(0);
+  });
+
+  it('deletes the cache and reports the bytes freed', () => {
+    const cacheHome = path.join(root, 'cache');
+    fs.mkdirSync(cacheHome);
+    const cacheDir = path.join(cacheHome, 'x-updater');
+    fs.mkdirSync(path.join(cacheDir, 'pending'), { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'update.zip'), Buffer.alloc(2048));
+    fs.writeFileSync(path.join(cacheDir, 'pending', 'app.zip'), Buffer.alloc(1024));
+    fs.writeFileSync(path.join(resources, 'app-update.yml'), "updaterCacheDirName: 'x-updater'\n");
+
+    expect(purgeUpdaterCache(resources, cacheHome)).toBe(3072);
+    expect(fs.existsSync(cacheDir)).toBe(false);
+  });
+
+  it('leaves a sibling directory in the same cache root untouched', () => {
+    const cacheHome = path.join(root, 'cache');
+    fs.mkdirSync(cacheHome);
+    const ours = path.join(cacheHome, 'x-updater');
+    const theirs = path.join(cacheHome, 'com.apple.Safari');
+    fs.mkdirSync(ours);
+    fs.mkdirSync(theirs);
+    fs.writeFileSync(path.join(ours, 'update.zip'), Buffer.alloc(16));
+    fs.writeFileSync(path.join(theirs, 'important'), Buffer.alloc(16));
+    fs.writeFileSync(path.join(resources, 'app-update.yml'), "updaterCacheDirName: 'x-updater'\n");
+
+    purgeUpdaterCache(resources, cacheHome);
+    expect(fs.existsSync(ours)).toBe(false);
+    expect(fs.existsSync(theirs)).toBe(true);
+  });
+
+  it('refuses to delete anything when the recorded name is hostile', () => {
+    const cacheHome = path.join(root, 'cache');
+    fs.mkdirSync(cacheHome);
+    const victim = path.join(root, 'Documents');
+    fs.mkdirSync(victim);
+    fs.writeFileSync(path.join(victim, 'thesis.txt'), 'x');
+    fs.writeFileSync(
+      path.join(resources, 'app-update.yml'),
+      "updaterCacheDirName: '../Documents'\n",
+    );
+
+    expect(purgeUpdaterCache(resources, cacheHome)).toBe(0);
+    expect(fs.existsSync(path.join(victim, 'thesis.txt'))).toBe(true);
+  });
+});

--- a/packages/desktop/src/updaterCache.ts
+++ b/packages/desktop/src/updaterCache.ts
@@ -1,0 +1,162 @@
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+/**
+ * Reclaims the electron-updater download cache on builds that can never install
+ * what it holds.
+ *
+ * An ad-hoc signed macOS build downloads the full release archive and then fails
+ * Squirrel's signature check, leaving the archive on disk forever. The observed
+ * cost on a real machine was 228 MB (the zip is stored twice, once staged and
+ * once as `update.zip`) for a file that cannot be applied. Every check re-runs
+ * the cycle.
+ *
+ * Turning `autoDownload` off stops new copies accruing. This removes the ones
+ * already stranded on existing installs.
+ */
+
+/**
+ * Extracts `updaterCacheDirName` from the app-update.yml electron-builder ships
+ * inside the packaged app.
+ *
+ * The name is read rather than reconstructed on purpose. electron-builder
+ * derives it from the package name (`@backspace/desktop` becomes
+ * `@backspacedesktop-updater`), and a reimplementation of that rule would be a
+ * guess about which directory to delete. Reading the file electron-updater
+ * itself reads means we either know the answer or do nothing.
+ *
+ * A hand-rolled reader rather than a YAML dependency: this is one flat scalar
+ * key, and the project does not add dependencies for one regex.
+ */
+export function parseUpdaterCacheDirName(yml: string): string | null {
+  for (const raw of yml.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.startsWith('#')) continue;
+    const match = /^updaterCacheDirName\s*:\s*(.+)$/.exec(line);
+    if (!match) continue;
+    let value = (match[1] ?? '').trim();
+    // Strip a trailing inline comment on an unquoted scalar.
+    if (!value.startsWith('"') && !value.startsWith("'")) {
+      const hash = value.indexOf(' #');
+      if (hash !== -1) value = value.slice(0, hash).trim();
+    }
+    if (
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2) ||
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2)
+    ) {
+      value = value.slice(1, -1);
+    }
+    return value.trim() === '' ? null : value.trim();
+  }
+  return null;
+}
+
+/**
+ * The base cache directory electron-updater uses, reproduced from its own
+ * `getAppCacheDir()` so the two agree on every platform.
+ */
+export function getAppCacheDir(): string {
+  const home = os.homedir();
+  if (process.platform === 'win32') {
+    return process.env['LOCALAPPDATA'] || path.join(home, 'AppData', 'Local');
+  }
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Caches');
+  }
+  return process.env['XDG_CACHE_HOME'] || path.join(home, '.cache');
+}
+
+/**
+ * Whether a directory name is safe to delete as an updater cache.
+ *
+ * This is the guard that makes the whole operation defensible. The name has to
+ * come out of app-update.yml *and* look like an updater cache: no separators, no
+ * traversal, and a mandatory `-updater` suffix. A malformed or hostile
+ * app-update.yml therefore cannot point this at anything else.
+ */
+export function isSafeUpdaterCacheDirName(name: string): boolean {
+  if (!/^[A-Za-z0-9@._-]+$/.test(name)) return false;
+  if (name.includes('..')) return false;
+  if (!name.endsWith('-updater')) return false;
+  // "-updater" alone carries no app identity; refuse it.
+  if (name === '-updater') return false;
+  return true;
+}
+
+/**
+ * Resolves the updater cache directory, or null when it cannot be determined
+ * safely. `resourcesPath` is `process.resourcesPath` in a packaged app.
+ * `cacheDirOverride` exists so the deletion path can be exercised inside a
+ * temporary directory on every platform, rather than only where an environment
+ * variable happens to redirect the real cache.
+ */
+export function resolveUpdaterCacheDir(
+  resourcesPath: string,
+  cacheDirOverride?: string,
+): string | null {
+  let yml: string;
+  try {
+    yml = fs.readFileSync(path.join(resourcesPath, 'app-update.yml'), 'utf-8');
+  } catch {
+    // No app-update.yml means this is not a packaged build with a feed. Nothing
+    // to clean, and nothing that would tell us where to clean it.
+    return null;
+  }
+  const name = parseUpdaterCacheDirName(yml);
+  if (name === null || !isSafeUpdaterCacheDirName(name)) return null;
+  return path.join(cacheDirOverride ?? getAppCacheDir(), name);
+}
+
+/**
+ * Deletes the updater cache if it exists. Returns the number of bytes freed,
+ * which is what makes the log line worth reading.
+ *
+ * Every failure is swallowed. Reclaiming disk is a courtesy, and no part of the
+ * app should fail to start because a cache directory was busy.
+ */
+export function purgeUpdaterCache(resourcesPath: string, cacheDirOverride?: string): number {
+  const dir = resolveUpdaterCacheDir(resourcesPath, cacheDirOverride);
+  if (dir === null) return 0;
+
+  let freed = 0;
+  try {
+    const stat = fs.statSync(dir);
+    if (!stat.isDirectory()) return 0;
+    freed = directorySize(dir);
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    return 0;
+  }
+
+  if (freed > 0) {
+    console.log(
+      `[update] reclaimed ${(freed / 1_048_576).toFixed(0)} MB from the updater ` +
+      'cache, which this build cannot install from',
+    );
+  }
+  return freed;
+}
+
+function directorySize(dir: string): number {
+  let total = 0;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    try {
+      if (entry.isDirectory()) {
+        total += directorySize(full);
+      } else if (entry.isFile()) {
+        total += fs.statSync(full).size;
+      }
+    } catch {
+      // A file that vanished mid-walk contributes nothing.
+    }
+  }
+  return total;
+}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -145,6 +145,25 @@ export const config = {
   dbPath: env('DB_PATH', resolve(__dirname, '../../../data/backspace.db')),
   maxUploadSize: envInt('MAX_UPLOAD_SIZE', 104857600),
   registrationOpen: envBool('REGISTRATION_OPEN', true),
+
+  updates: {
+    /**
+     * Whether the admin Updates panel may look up the newest release.
+     *
+     * There is no background poller anywhere in the server. The lookup happens
+     * only while a signed-in admin has that panel open and the cache is cold,
+     * so an instance whose admin never opens it never contacts github.com. This
+     * switch exists for airgapped deployments and for operators who want the
+     * guarantee rather than the behaviour.
+     */
+    checkEnabled: envBool('BACKSPACE_UPDATE_CHECK', true),
+    /**
+     * prebuilt | source | undefined. install.sh records this after its
+     * pull-or-build decision resolves. Undefined on installs that predate it,
+     * which the panel reports as unknown rather than guessing.
+     */
+    installChannel: envOptional('BACKSPACE_INSTALL_CHANNEL'),
+  },
   backup: {
     dir: envOptional('BACKUP_DIR') ?? resolve(dirname(env('DB_PATH', resolve(__dirname, '../../../data/backspace.db'))), 'backups'),
     intervalHours: envInt('BACKUP_INTERVAL_HOURS', 24),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,6 +24,7 @@ import { invitesRoutes } from './routes/invites.js';
 import { exploreRoutes } from './routes/explore.js';
 import { searchRoutes } from './routes/search.js';
 import { adminRoutes } from './routes/admin.js';
+import { adminUpdateRoutes } from './routes/adminUpdates.js';
 import { gifRoutes } from './routes/gif.js';
 import { federationRoutes } from './routes/federation.js';
 import { cspReportRoutes } from './routes/cspReport.js';
@@ -198,6 +199,7 @@ async function main(): Promise<void> {
   await app.register(exploreRoutes);
   await app.register(searchRoutes);
   await app.register(adminRoutes);
+  await app.register(adminUpdateRoutes);
   await app.register(gifRoutes);
   await app.register(federationRoutes);
   // Registered here rather than beside the hook above so it sits behind the

--- a/packages/server/src/routes/adminUpdates.test.ts
+++ b/packages/server/src/routes/adminUpdates.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Fastify, { type FastifyInstance, type FastifyRequest, type FastifyReply } from 'fastify';
+import { config } from '../config.js';
+import { resetReleaseCacheForTest } from '../utils/releaseCheck.js';
+
+// Auth is mocked rather than backed by a database: this route touches no
+// tables, and the contract under test is the response shape and the admin gate,
+// not JWT verification (covered in auth.test.ts).
+let callerIsAdmin = true;
+
+vi.mock('../utils/auth.js', () => ({
+  authenticate: async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!request.headers.authorization) {
+      return reply.code(401).send({ error: 'Missing or invalid authorization header', statusCode: 401 });
+    }
+    (request as FastifyRequest & { userId: string }).userId = 'user-1';
+  },
+  requireAdmin: async (_request: FastifyRequest, reply: FastifyReply) => {
+    if (!callerIsAdmin) {
+      return reply.code(403).send({ error: 'Only instance admins can perform this action', statusCode: 403 });
+    }
+  },
+}));
+
+const mutableUpdates = config.updates as { checkEnabled: boolean; installChannel?: string };
+
+let app: FastifyInstance;
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+function stubRelease(tag: string): void {
+  fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        tag_name: tag,
+        html_url: `https://github.com/TheZwiss/backspace/releases/tag/${tag}`,
+        published_at: '2026-09-03T11:00:00Z',
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ) as unknown as Response,
+  ) as unknown as ReturnType<typeof vi.spyOn>;
+}
+
+beforeEach(async () => {
+  callerIsAdmin = true;
+  mutableUpdates.checkEnabled = true;
+  delete mutableUpdates.installChannel;
+  resetReleaseCacheForTest();
+
+  const { adminUpdateRoutes } = await import('./adminUpdates.js');
+  app = Fastify();
+  await app.register(adminUpdateRoutes);
+});
+
+afterEach(() => {
+  fetchSpy?.mockRestore();
+  resetReleaseCacheForTest();
+  mutableUpdates.checkEnabled = true;
+});
+
+const AUTH = { authorization: 'Bearer token' };
+
+describe('GET /api/admin/instance/update-status', () => {
+  it('requires authentication', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/admin/instance/update-status' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('refuses a non-admin', async () => {
+    callerIsAdmin = false;
+    const res = await app.inject({
+      method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns the full contract', async () => {
+    stubRelease('v99.0.0');
+    const res = await app.inject({
+      method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+
+    expect(body).toMatchObject({
+      current: { version: config.version, commit: config.commit },
+      latest: {
+        version: '99.0.0',
+        url: 'https://github.com/TheZwiss/backspace/releases/tag/v99.0.0',
+        publishedAt: '2026-09-03T11:00:00Z',
+      },
+      state: 'update-available',
+      checkEnabled: true,
+      reason: null,
+      channel: 'unknown',
+    });
+    expect(typeof body.checkedAt).toBe('number');
+  });
+
+  it('reports up to date when the latest release matches the running version', async () => {
+    stubRelease(`v${config.version}`);
+    const res = await app.inject({
+      method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH,
+    });
+    expect(res.json().state).toBe('up-to-date');
+    expect(res.json().latest.version).toBe(config.version);
+  });
+
+  it('reports the install channel when install.sh recorded one', async () => {
+    stubRelease(`v${config.version}`);
+    mutableUpdates.installChannel = 'prebuilt';
+    let res = await app.inject({ method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH });
+    expect(res.json().channel).toBe('prebuilt');
+
+    mutableUpdates.installChannel = 'source';
+    res = await app.inject({ method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH });
+    expect(res.json().channel).toBe('source');
+  });
+
+  it('reports unknown for an unrecognised channel value rather than passing it through', async () => {
+    stubRelease(`v${config.version}`);
+    mutableUpdates.installChannel = 'somethingelse';
+    const res = await app.inject({ method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH });
+    expect(res.json().channel).toBe('unknown');
+  });
+
+  it('still serves the running version when the lookup is turned off', async () => {
+    mutableUpdates.checkEnabled = false;
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not be called')) as never;
+
+    const res = await app.inject({
+      method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      current: { version: config.version },
+      latest: null,
+      state: 'unknown',
+      checkEnabled: false,
+      reason: 'disabled',
+      checkedAt: null,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('still serves the running version when GitHub is unreachable', async () => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('getaddrinfo ENOTFOUND')) as never;
+
+    const res = await app.inject({
+      method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      current: { version: config.version },
+      latest: null,
+      state: 'unknown',
+      reason: 'unreachable',
+      checkEnabled: true,
+    });
+  });
+
+  it('serves a repeat request from cache without a second lookup', async () => {
+    stubRelease('v99.0.0');
+    await app.inject({ method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH });
+    await app.inject({ method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('performs a fresh lookup for an explicit re-check', async () => {
+    stubRelease('v99.0.0');
+    await app.inject({ method: 'GET', url: '/api/admin/instance/update-status', headers: AUTH });
+    await app.inject({
+      method: 'GET', url: '/api/admin/instance/update-status?refresh=true', headers: AUTH,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let refresh=true override the kill switch', async () => {
+    mutableUpdates.checkEnabled = false;
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('must not be called')) as never;
+
+    const res = await app.inject({
+      method: 'GET', url: '/api/admin/instance/update-status?refresh=true', headers: AUTH,
+    });
+    expect(res.json().reason).toBe('disabled');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('exposes no way to trigger an update', async () => {
+    // Applying a container update from inside the container needs the Docker
+    // socket, which is host root. There is deliberately no POST here.
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE'] as const) {
+      const res = await app.inject({
+        method, url: '/api/admin/instance/update-status', headers: AUTH,
+      });
+      expect(res.statusCode).toBe(404);
+    }
+  });
+});

--- a/packages/server/src/routes/adminUpdates.ts
+++ b/packages/server/src/routes/adminUpdates.ts
@@ -1,0 +1,59 @@
+import type { FastifyInstance } from 'fastify';
+import { authenticate, requireAdmin } from '../utils/auth.js';
+import { config } from '../config.js';
+import { getLatestRelease, deriveState } from '../utils/releaseCheck.js';
+import type { InstanceUpdateStatus } from '@backspace/shared';
+
+/**
+ * The admin Updates surface.
+ *
+ * Its own file rather than another block in admin.ts, which already carries
+ * storage, users, and settings across 400-odd lines and has no reason to also
+ * own an outbound HTTP client.
+ *
+ * There is no POST here and no way to trigger an update from the API. Applying
+ * a container update from inside the container would require mounting
+ * /var/run/docker.sock, which hands the container root on the host. Backspace
+ * parses uploaded media, scrapes URLs for embeds, and accepts federation
+ * payloads from remote instances, so any remote-code-execution bug in it would
+ * become host root the moment that socket exists. The panel hands the operator
+ * an exact command instead; ./update.sh is where the effort went.
+ */
+export async function adminUpdateRoutes(app: FastifyInstance): Promise<void> {
+  // GET /api/admin/instance/update-status — what this instance runs, and
+  // whether anything newer exists.
+  //
+  // `?refresh=true` bypasses the six-hour cache for an explicit "Check again"
+  // click. It cannot bypass the BACKSPACE_UPDATE_CHECK kill switch.
+  app.get<{ Querystring: { refresh?: string } }>(
+    '/api/admin/instance/update-status',
+    { preHandler: [authenticate, requireAdmin] },
+    async (request, reply) => {
+      const refresh = request.query.refresh === 'true';
+
+      const channel: InstanceUpdateStatus['channel'] =
+        config.updates.installChannel === 'prebuilt' ? 'prebuilt'
+        : config.updates.installChannel === 'source' ? 'source'
+        : 'unknown';
+
+      // getLatestRelease never rejects; it reports failures as a reason. A
+      // try/catch here would be dead code that implies otherwise.
+      const result = await getLatestRelease(refresh);
+
+      const response: InstanceUpdateStatus = {
+        current: {
+          version: config.version,
+          commit: config.commit,
+        },
+        latest: result.latest,
+        state: deriveState(config.version, result),
+        checkedAt: result.reason === 'disabled' ? null : result.checkedAt,
+        checkEnabled: config.updates.checkEnabled,
+        reason: result.reason,
+        channel,
+      };
+
+      return reply.code(200).send(response);
+    },
+  );
+}

--- a/packages/server/src/utils/releaseCheck.test.ts
+++ b/packages/server/src/utils/releaseCheck.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  parseLatestRelease,
+  compareVersions,
+  deriveState,
+  getLatestRelease,
+  resetReleaseCacheForTest,
+  type ReleaseCheckResult,
+} from './releaseCheck.js';
+import { config } from '../config.js';
+
+const mutableUpdates = config.updates as { checkEnabled: boolean; installChannel?: string };
+
+describe('parseLatestRelease', () => {
+  it('reads a real GitHub release payload', () => {
+    const payload = {
+      tag_name: 'v1.0.4',
+      html_url: 'https://github.com/TheZwiss/backspace/releases/tag/v1.0.4',
+      published_at: '2026-09-03T11:00:00Z',
+      draft: false,
+      prerelease: false,
+    };
+    expect(parseLatestRelease(payload)).toEqual({
+      version: '1.0.4',
+      url: 'https://github.com/TheZwiss/backspace/releases/tag/v1.0.4',
+      publishedAt: '2026-09-03T11:00:00Z',
+    });
+  });
+
+  it('strips the leading v from the tag', () => {
+    expect(parseLatestRelease({ tag_name: 'v2.10.3' })?.version).toBe('2.10.3');
+    expect(parseLatestRelease({ tag_name: '2.10.3' })?.version).toBe('2.10.3');
+  });
+
+  it('refuses to point operators at a draft or a prerelease', () => {
+    expect(parseLatestRelease({ tag_name: 'v1.0.5', draft: true })).toBeNull();
+    expect(parseLatestRelease({ tag_name: 'v1.0.5', prerelease: true })).toBeNull();
+  });
+
+  it('rejects a tag that is not a version', () => {
+    expect(parseLatestRelease({ tag_name: 'nightly' })).toBeNull();
+    expect(parseLatestRelease({ tag_name: 'v1.0' })).toBeNull();
+    expect(parseLatestRelease({ tag_name: '' })).toBeNull();
+    expect(parseLatestRelease({})).toBeNull();
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(parseLatestRelease(null)).toBeNull();
+    expect(parseLatestRelease('v1.0.4')).toBeNull();
+    expect(parseLatestRelease([])).toBeNull();
+  });
+
+  it('falls back to a constructed URL rather than trusting an off-site one', () => {
+    // An html_url pointing anywhere but github.com would be a link the panel
+    // renders, so it is replaced rather than passed through.
+    const result = parseLatestRelease({
+      tag_name: 'v1.0.4',
+      html_url: 'https://evil.example.com/phish',
+    });
+    expect(result?.url).toBe('https://github.com/TheZwiss/backspace/releases/tag/v1.0.4');
+  });
+
+  it('tolerates a missing published_at', () => {
+    expect(parseLatestRelease({ tag_name: 'v1.0.4' })?.publishedAt).toBe('');
+  });
+});
+
+describe('compareVersions', () => {
+  it('orders versions numerically, not lexically', () => {
+    expect(compareVersions('1.0.9', '1.0.10')).toBe(-1);
+    expect(compareVersions('1.9.0', '1.10.0')).toBe(-1);
+    expect(compareVersions('2.0.0', '10.0.0')).toBe(-1);
+  });
+
+  it('detects equality and the reverse order', () => {
+    expect(compareVersions('1.0.4', '1.0.4')).toBe(0);
+    expect(compareVersions('1.0.5', '1.0.4')).toBe(1);
+  });
+
+  it('returns null rather than guessing on an unparseable version', () => {
+    expect(compareVersions('nightly', '1.0.4')).toBeNull();
+    expect(compareVersions('1.0.4', '')).toBeNull();
+    expect(compareVersions('1.0', '1.0.4')).toBeNull();
+  });
+});
+
+describe('deriveState', () => {
+  const found = (version: string): ReleaseCheckResult => ({
+    latest: { version, url: 'https://github.com/x', publishedAt: '' },
+    reason: null,
+    checkedAt: 0,
+  });
+
+  it('reports an available update', () => {
+    expect(deriveState('1.0.3', found('1.0.4'))).toBe('update-available');
+  });
+
+  it('reports up to date when equal', () => {
+    expect(deriveState('1.0.4', found('1.0.4'))).toBe('up-to-date');
+  });
+
+  it('reports up to date when running ahead of the latest release', () => {
+    // A maintainer running an unreleased build should not be told to downgrade.
+    expect(deriveState('1.1.0', found('1.0.4'))).toBe('up-to-date');
+  });
+
+  it('reports unknown when the lookup found nothing', () => {
+    expect(deriveState('1.0.4', { latest: null, reason: 'unreachable', checkedAt: 0 }))
+      .toBe('unknown');
+  });
+
+  it('reports unknown rather than a wrong answer on an unparseable version', () => {
+    expect(deriveState('dev', found('1.0.4'))).toBe('unknown');
+  });
+});
+
+describe('getLatestRelease', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetReleaseCacheForTest();
+    mutableUpdates.checkEnabled = true;
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    resetReleaseCacheForTest();
+    mutableUpdates.checkEnabled = true;
+  });
+
+  function stubFetch(impl: (...args: unknown[]) => Promise<Response>): void {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(impl as typeof fetch);
+  }
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('opens no socket at all when the check is disabled', async () => {
+    mutableUpdates.checkEnabled = false;
+    stubFetch(() => Promise.reject(new Error('fetch must not be called')));
+
+    const result = await getLatestRelease();
+    expect(result).toMatchObject({ latest: null, reason: 'disabled' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends a User-Agent that identifies the software but not the instance', async () => {
+    stubFetch(() => Promise.resolve(jsonResponse({ tag_name: 'v1.0.4' })));
+    await getLatestRelease();
+
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['User-Agent']).toBe('Backspace');
+    // Nothing that says which deployment is asking.
+    const serialised = JSON.stringify(headers);
+    expect(serialised).not.toMatch(/instance|domain|\d+\.\d+\.\d+/i);
+  });
+
+  it('returns the parsed release on success', async () => {
+    stubFetch(() => Promise.resolve(jsonResponse({
+      tag_name: 'v1.0.4',
+      html_url: 'https://github.com/TheZwiss/backspace/releases/tag/v1.0.4',
+      published_at: '2026-09-03T11:00:00Z',
+    })));
+
+    const result = await getLatestRelease();
+    expect(result.latest?.version).toBe('1.0.4');
+    expect(result.reason).toBeNull();
+  });
+
+  it('serves the second call from cache without a second request', async () => {
+    stubFetch(() => Promise.resolve(jsonResponse({ tag_name: 'v1.0.4' })));
+    await getLatestRelease();
+    await getLatestRelease();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses the cache when the admin explicitly re-checks', async () => {
+    stubFetch(() => Promise.resolve(jsonResponse({ tag_name: 'v1.0.4' })));
+    await getLatestRelease();
+    await getLatestRelease(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent calls into one request', async () => {
+    stubFetch(() => Promise.resolve(jsonResponse({ tag_name: 'v1.0.4' })));
+    await Promise.all([getLatestRelease(), getLatestRelease(), getLatestRelease()]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports rate limiting distinctly from being unreachable', async () => {
+    stubFetch(() => Promise.resolve(new Response('{}', { status: 403 })));
+    expect((await getLatestRelease()).reason).toBe('rate-limited');
+
+    resetReleaseCacheForTest();
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 429 }));
+    expect((await getLatestRelease()).reason).toBe('rate-limited');
+  });
+
+  it('reports a server error as unreachable', async () => {
+    stubFetch(() => Promise.resolve(new Response('nope', { status: 502 })));
+    expect((await getLatestRelease()).reason).toBe('unreachable');
+  });
+
+  it('never throws when the network fails outright', async () => {
+    stubFetch(() => Promise.reject(new Error('getaddrinfo ENOTFOUND api.github.com')));
+    const result = await getLatestRelease();
+    expect(result).toMatchObject({ latest: null, reason: 'unreachable' });
+  });
+
+  it('never throws on a body that is not JSON', async () => {
+    stubFetch(() => Promise.resolve(new Response('<html>captive portal</html>', { status: 200 })));
+    expect((await getLatestRelease()).reason).toBe('unparseable');
+  });
+
+  it('refuses an absurdly large body rather than parsing it', async () => {
+    stubFetch(() => Promise.resolve(new Response('x'.repeat(600 * 1024), { status: 200 })));
+    expect((await getLatestRelease()).reason).toBe('unparseable');
+  });
+
+  it('caches a failure only briefly, so a transient outage clears', async () => {
+    stubFetch(() => Promise.resolve(new Response('nope', { status: 502 })));
+    const failed = await getLatestRelease();
+    // The failure is cached (no second request), but for a tenth of the TTL.
+    await getLatestRelease();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(failed.reason).toBe('unreachable');
+  });
+});

--- a/packages/server/src/utils/releaseCheck.ts
+++ b/packages/server/src/utils/releaseCheck.ts
@@ -1,0 +1,215 @@
+import { config } from '../config.js';
+
+/**
+ * Looks up the newest published Backspace release.
+ *
+ * Three properties matter more than the feature itself:
+ *
+ *  1. **No background poller.** Nothing in the server calls this on a timer.
+ *     It runs only while a signed-in admin has the Updates panel open and the
+ *     cache is cold. An instance whose admin never opens that panel never
+ *     contacts github.com. For a self-hosted product that is a promise worth
+ *     keeping, not a detail.
+ *  2. **Nothing identifying leaves the box.** The User-Agent is the bare word
+ *     "Backspace" (GitHub requires one). No instance id, no domain, not even
+ *     the running version, which would otherwise turn GitHub's logs into a
+ *     version census of every deployment.
+ *  3. **Every failure is soft.** A timeout, a rate limit, a captive portal, or
+ *     no outbound route at all yields `unknown` with a reason. An operator with
+ *     no internet still gets a working panel that tells them what they run.
+ *
+ * The URL is a compile-time constant and is never derived from user input, so
+ * the SSRF policy in docs/systems/embeds.md does not apply here.
+ */
+
+const RELEASES_API = 'https://api.github.com/repos/TheZwiss/backspace/releases/latest';
+const REQUEST_TIMEOUT_MS = 5_000;
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+/** Enough for a release payload; anything larger is not a release payload. */
+const MAX_RESPONSE_BYTES = 512 * 1024;
+
+export type ReleaseCheckState = 'up-to-date' | 'update-available' | 'unknown';
+export type ReleaseCheckReason = 'disabled' | 'unreachable' | 'rate-limited' | 'unparseable';
+
+export interface LatestRelease {
+  version: string;
+  url: string;
+  publishedAt: string;
+}
+
+export interface ReleaseCheckResult {
+  latest: LatestRelease | null;
+  reason: ReleaseCheckReason | null;
+  checkedAt: number;
+}
+
+interface CacheEntry {
+  result: ReleaseCheckResult;
+  expiresAt: number;
+}
+
+let cache: CacheEntry | null = null;
+/** Coalesces concurrent panel opens into one outbound request. */
+let inFlight: Promise<ReleaseCheckResult> | null = null;
+
+/**
+ * Parses a GitHub release payload.
+ *
+ * Exported for tests, and deliberately tolerant about everything except the
+ * tag: a release with no `html_url` or `published_at` is still a release worth
+ * telling the operator about.
+ */
+export function parseLatestRelease(payload: unknown): LatestRelease | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const raw = payload as Record<string, unknown>;
+
+  // Drafts and prereleases are not what a self-hoster should be pointed at.
+  if (raw.draft === true || raw.prerelease === true) return null;
+
+  const tag = typeof raw.tag_name === 'string' ? raw.tag_name.trim() : '';
+  const version = tag.replace(/^v/, '');
+  if (!/^\d+\.\d+\.\d+/.test(version)) return null;
+
+  return {
+    version,
+    url: typeof raw.html_url === 'string' && raw.html_url.startsWith('https://github.com/')
+      ? raw.html_url
+      : `https://github.com/TheZwiss/backspace/releases/tag/${tag}`,
+    publishedAt: typeof raw.published_at === 'string' ? raw.published_at : '',
+  };
+}
+
+/**
+ * Compares two `major.minor.patch` versions.
+ *
+ * Returns null when either side does not parse, which the caller reports as
+ * `unknown`. Answering "you are up to date" off an unparseable comparison would
+ * be worse than admitting ignorance.
+ */
+export function compareVersions(a: string, b: string): number | null {
+  const parse = (value: string): number[] | null => {
+    const match = /^(\d+)\.(\d+)\.(\d+)/.exec(value.trim());
+    if (!match) return null;
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+  };
+  const left = parse(a);
+  const right = parse(b);
+  if (left === null || right === null) return null;
+  for (let i = 0; i < 3; i++) {
+    const l = left[i] ?? 0;
+    const r = right[i] ?? 0;
+    if (l !== r) return l < r ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Derives the reported state from the running version and the lookup result.
+ * Pure, so the comparison rules are testable without a network.
+ */
+export function deriveState(
+  currentVersion: string,
+  result: ReleaseCheckResult,
+): ReleaseCheckState {
+  if (result.latest === null) return 'unknown';
+  const comparison = compareVersions(currentVersion, result.latest.version);
+  if (comparison === null) return 'unknown';
+  return comparison < 0 ? 'update-available' : 'up-to-date';
+}
+
+/**
+ * Fetches the latest release, subject to the cache and the kill switch.
+ *
+ * `force` bypasses the cache for an explicit "Check again" click. It does not
+ * bypass the kill switch, which no request from the UI can override.
+ */
+export async function getLatestRelease(force = false): Promise<ReleaseCheckResult> {
+  if (!config.updates.checkEnabled) {
+    return { latest: null, reason: 'disabled', checkedAt: Date.now() };
+  }
+
+  const now = Date.now();
+  if (!force && cache !== null && cache.expiresAt > now) {
+    return cache.result;
+  }
+
+  // A second admin opening the panel while a request is in flight waits for
+  // that request rather than starting another.
+  if (inFlight !== null) return inFlight;
+
+  inFlight = performLookup()
+    .then((result) => {
+      // A failed lookup is cached for a tenth of the TTL. Long enough that a
+      // panel refresh does not hammer a rate-limited endpoint, short enough
+      // that a transient outage does not persist for six hours.
+      const ttl = result.latest === null ? CACHE_TTL_MS / 10 : CACHE_TTL_MS;
+      cache = { result, expiresAt: Date.now() + ttl };
+      return result;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+async function performLookup(): Promise<ReleaseCheckResult> {
+  const checkedAt = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(RELEASES_API, {
+      signal: controller.signal,
+      redirect: 'error',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        // GitHub rejects requests with no User-Agent. This one says what the
+        // software is and nothing about which instance is asking.
+        'User-Agent': 'Backspace',
+      },
+    });
+
+    if (response.status === 403 || response.status === 429) {
+      return { latest: null, reason: 'rate-limited', checkedAt };
+    }
+    if (!response.ok) {
+      return { latest: null, reason: 'unreachable', checkedAt };
+    }
+
+    const declaredLength = Number(response.headers.get('content-length') ?? '0');
+    if (declaredLength > MAX_RESPONSE_BYTES) {
+      return { latest: null, reason: 'unparseable', checkedAt };
+    }
+
+    const text = await response.text();
+    if (text.length > MAX_RESPONSE_BYTES) {
+      return { latest: null, reason: 'unparseable', checkedAt };
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      return { latest: null, reason: 'unparseable', checkedAt };
+    }
+
+    const latest = parseLatestRelease(payload);
+    if (latest === null) {
+      return { latest: null, reason: 'unparseable', checkedAt };
+    }
+    return { latest, reason: null, checkedAt };
+  } catch {
+    // Timeout, DNS failure, TLS failure, no route. All the same to an operator:
+    // we could not ask, so we do not know.
+    return { latest: null, reason: 'unreachable', checkedAt };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Test seam. Drops the cache and any in-flight coalescing. */
+export function resetReleaseCacheForTest(): void {
+  cache = null;
+  inFlight = null;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -813,6 +813,40 @@ export interface InstanceInfoResponse {
   commit: string | null;
 }
 
+/**
+ * What the admin Updates panel renders. Admin-only.
+ *
+ * `state` is deliberately three-valued. An instance with no outbound internet,
+ * or one whose operator turned the lookup off, must be able to say "I do not
+ * know" instead of implying it is current.
+ */
+export interface InstanceUpdateStatus {
+  current: {
+    version: string;
+    /** Short git SHA baked at build time; null in dev builds. */
+    commit: string | null;
+  };
+  latest: {
+    version: string;
+    url: string;
+    /** ISO 8601, or an empty string when the release carried no date. */
+    publishedAt: string;
+  } | null;
+  state: 'up-to-date' | 'update-available' | 'unknown';
+  /** Epoch ms of the lookup this answer came from; null when none was made. */
+  checkedAt: number | null;
+  /** False when BACKSPACE_UPDATE_CHECK=false. */
+  checkEnabled: boolean;
+  /** Why `state` is unknown, when it is. Null otherwise. */
+  reason: 'disabled' | 'unreachable' | 'rate-limited' | 'unparseable' | null;
+  /**
+   * How this instance gets its image. `unknown` on installs that predate
+   * install.sh recording it, which the panel handles by showing both sets of
+   * manual commands rather than guessing.
+   */
+  channel: 'prebuilt' | 'source' | 'unknown';
+}
+
 export interface VerifyPasswordRequest {
   password: string;
 }

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -44,6 +44,7 @@ import type {
   AdminUserListResponse,
   AdminUser,
   AdminResetPasswordResponse,
+  InstanceUpdateStatus,
   ExploreSpace,
   JoinRequest,
   Role,
@@ -327,6 +328,7 @@ export class BackspaceApiClient {
     setUserRole: (userId: string, isAdmin: boolean) => Promise<AdminUser>;
     resetUserPassword: (userId: string) => Promise<AdminResetPasswordResponse>;
     deleteUser: (userId: string) => Promise<{ success: boolean }>;
+    updateStatus: (refresh?: boolean) => Promise<InstanceUpdateStatus>;
   };
 
   constructor(baseUrl: string, getToken: () => string | null, onUnauthorized?: () => void) {
@@ -819,6 +821,13 @@ export class BackspaceApiClient {
         request<AdminResetPasswordResponse>('POST', `/admin/users/${userId}/reset-password`),
       deleteUser: (userId) =>
         request<{ success: boolean }>('DELETE', `/admin/users/${userId}`),
+      // `refresh` bypasses the server's six-hour cache for an explicit
+      // "Check again" click. It cannot bypass BACKSPACE_UPDATE_CHECK.
+      updateStatus: (refresh = false) =>
+        request<InstanceUpdateStatus>(
+          'GET',
+          `/admin/instance/update-status${refresh ? '?refresh=true' : ''}`,
+        ),
     };
   }
 }

--- a/packages/web/src/components/layout/MobileInstancePanel.tsx
+++ b/packages/web/src/components/layout/MobileInstancePanel.tsx
@@ -7,7 +7,7 @@ import { api } from '../../api/client';
 import { onFederationPeersChanged } from '../../hooks/useWebSocket';
 
 type SectionDef = {
-  id: 'general' | 'registration' | 'federation' | 'streaming' | 'storage' | 'users';
+  id: 'general' | 'registration' | 'federation' | 'streaming' | 'storage' | 'users' | 'updates';
   label: string;
   icon: React.ReactNode;
 };
@@ -58,6 +58,17 @@ const sections: SectionDef[] = [
     icon: (
       <svg className="w-5 h-5 text-txt-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
+      </svg>
+    ),
+  },
+  {
+    id: 'updates',
+    label: 'Updates',
+    icon: (
+      // Heroicon: arrow-down-tray — the update is downloaded and applied, not
+      // triggered from here. See UpdatesPanel for why there is no button.
+      <svg className="w-5 h-5 text-txt-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
       </svg>
     ),
   },

--- a/packages/web/src/components/layout/MobileShell.tsx
+++ b/packages/web/src/components/layout/MobileShell.tsx
@@ -23,6 +23,7 @@ import { FriendsPage } from '../chat/FriendsPage';
 import { ExplorePage } from '../chat/ExplorePage';
 import { UserProfileModal } from '../modals/UserProfileModal';
 import { GeneralPanel } from '../modals/instanceSettingsPanels/GeneralPanel';
+import { UpdatesPanel } from '../modals/instanceSettingsPanels/UpdatesPanel';
 import { RegistrationPanel } from '../modals/instanceSettingsPanels/RegistrationPanel';
 import { FederationPanel } from '../modals/instanceSettingsPanels/FederationPanel';
 import { StreamingPanel } from '../modals/instanceSettingsPanels/StreamingPanel';
@@ -81,6 +82,12 @@ const screenMap: Record<string, (params?: Record<string, string>) => React.React
     <div className="flex flex-col h-full bg-surface-base">
       <MobileScreenHeader title="Storage" rightActions={<TransferIndicator />} />
       <div className="flex-1 overflow-y-auto p-4"><StoragePanel /></div>
+    </div>
+  ),
+  'settings-instance-updates': () => (
+    <div className="flex flex-col h-full bg-surface-base">
+      <MobileScreenHeader title="Updates" rightActions={<TransferIndicator />} />
+      <div className="flex-1 overflow-y-auto p-4"><UpdatesPanel /></div>
     </div>
   ),
   'settings-instance-users': () => (

--- a/packages/web/src/components/modals/instanceSettingsPanels/UpdatesPanel.test.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/UpdatesPanel.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UpdatesPanel } from './UpdatesPanel';
+import { api } from '../../../api/client';
+import type { InstanceUpdateStatus } from '@backspace/shared';
+
+function status(over: Partial<InstanceUpdateStatus> = {}): InstanceUpdateStatus {
+  return {
+    current: { version: '1.0.3', commit: '73cc4fd' },
+    latest: null,
+    state: 'up-to-date',
+    checkedAt: Date.now(),
+    checkEnabled: true,
+    reason: null,
+    channel: 'prebuilt',
+    ...over,
+  };
+}
+
+const AVAILABLE = status({
+  latest: {
+    version: '1.0.4',
+    url: 'https://github.com/TheZwiss/backspace/releases/tag/v1.0.4',
+    publishedAt: '2026-09-03T11:00:00Z',
+  },
+  state: 'update-available',
+});
+
+let updateStatus: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  updateStatus = vi.fn();
+  vi.spyOn(api.admin, 'updateStatus').mockImplementation(updateStatus as never);
+});
+
+describe('UpdatesPanel, what is running', () => {
+  it('names the version, the commit, and how the instance gets its image', async () => {
+    updateStatus.mockResolvedValue(status());
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('Backspace 1.0.3')).toBeInTheDocument();
+    expect(screen.getByText(/commit 73cc4fd/)).toBeInTheDocument();
+    expect(screen.getByText(/prebuilt image/)).toBeInTheDocument();
+  });
+
+  it('does not claim an install method it was never told', async () => {
+    updateStatus.mockResolvedValue(status({ channel: 'unknown' }));
+    render(<UpdatesPanel />);
+    expect(await screen.findByText(/install method not recorded/)).toBeInTheDocument();
+  });
+});
+
+describe('UpdatesPanel, an update exists', () => {
+  beforeEach(() => { updateStatus.mockResolvedValue(AVAILABLE); });
+
+  it('shows the version, the date, and a link to the notes', async () => {
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('Backspace 1.0.4 is available')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: 'Release notes' });
+    expect(link).toHaveAttribute('href', 'https://github.com/TheZwiss/backspace/releases/tag/v1.0.4');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('hands over the exact command', async () => {
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('./update.sh')).toBeInTheDocument();
+  });
+
+  it('says the update rolls back if it does not come up', async () => {
+    render(<UpdatesPanel />);
+    expect(await screen.findByText(/puts back the version you\s+are on now/)).toBeInTheDocument();
+  });
+
+  it('copies the command to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+    render(<UpdatesPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith('./update.sh');
+    expect(await screen.findByRole('button', { name: 'Copied' })).toBeInTheDocument();
+  });
+
+  it('marks the manual steps as an expandable disclosure', async () => {
+    render(<UpdatesPanel />);
+    const toggle = await screen.findByRole('button', { name: /I do not have update\.sh/ });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('offers manual steps for operators who do not have update.sh yet', async () => {
+    render(<UpdatesPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: /I do not have update\.sh/ }));
+    expect(screen.getByText(/docker compose pull backspace/)).toBeInTheDocument();
+  });
+
+  it('warns against --remove-orphans in the manual steps', async () => {
+    // Compose actively suggests --remove-orphans on hosts running other
+    // containers in the same project, and following it deletes them.
+    render(<UpdatesPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: /I do not have update\.sh/ }));
+    expect(screen.getByText(/it would delete them/)).toBeInTheDocument();
+  });
+
+  it('shows only the from-source commands on a from-source install', async () => {
+    updateStatus.mockResolvedValue({ ...AVAILABLE, channel: 'source' });
+    render(<UpdatesPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: /I do not have update\.sh/ }));
+    expect(screen.getByText(/up -d --build backspace/)).toBeInTheDocument();
+    expect(screen.queryByText(/compose pull backspace/)).not.toBeInTheDocument();
+  });
+
+  it('shows both command sets when the channel was never recorded', async () => {
+    updateStatus.mockResolvedValue({ ...AVAILABLE, channel: 'unknown' });
+    render(<UpdatesPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: /I do not have update\.sh/ }));
+    expect(screen.getByText(/compose pull backspace/)).toBeInTheDocument();
+    expect(screen.getByText(/up -d --build backspace/)).toBeInTheDocument();
+  });
+});
+
+describe('UpdatesPanel, nothing to do', () => {
+  it('says so calmly, with no call to action', async () => {
+    updateStatus.mockResolvedValue(status());
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('You are on the latest release.')).toBeInTheDocument();
+    expect(screen.queryByText('./update.sh')).not.toBeInTheDocument();
+  });
+});
+
+describe('UpdatesPanel, the lookup could not be made', () => {
+  it('still shows the running version when GitHub is unreachable', async () => {
+    updateStatus.mockResolvedValue(status({ state: 'unknown', reason: 'unreachable', latest: null }));
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('Backspace 1.0.3')).toBeInTheDocument();
+    expect(screen.getByText('Could not check for updates')).toBeInTheDocument();
+    expect(screen.getByText(/says nothing about whether an/)).toBeInTheDocument();
+  });
+
+  it('names the env var when checks are turned off, and disables re-checking', async () => {
+    updateStatus.mockResolvedValue(
+      status({ state: 'unknown', reason: 'disabled', checkEnabled: false, checkedAt: null }),
+    );
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('Update checks are turned off')).toBeInTheDocument();
+    expect(screen.getByText('BACKSPACE_UPDATE_CHECK=true')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeDisabled();
+    expect(screen.getByText('No lookups are made')).toBeInTheDocument();
+  });
+
+  it('distinguishes rate limiting from being unreachable', async () => {
+    updateStatus.mockResolvedValue(status({ state: 'unknown', reason: 'rate-limited', latest: null }));
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('GitHub rate-limited the lookup')).toBeInTheDocument();
+  });
+
+  it('recovers from a failed load', async () => {
+    updateStatus.mockRejectedValueOnce(new Error('Network error'));
+    render(<UpdatesPanel />);
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
+
+    updateStatus.mockResolvedValue(status());
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(await screen.findByText('Backspace 1.0.3')).toBeInTheDocument();
+  });
+});
+
+describe('UpdatesPanel, re-checking', () => {
+  it('looks up on mount without forcing a refresh', async () => {
+    updateStatus.mockResolvedValue(status());
+    render(<UpdatesPanel />);
+    await waitFor(() => expect(updateStatus).toHaveBeenCalled());
+    expect(updateStatus).toHaveBeenCalledWith(false);
+  });
+
+  it('forces a fresh lookup on an explicit re-check', async () => {
+    updateStatus.mockResolvedValue(status());
+    render(<UpdatesPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: 'Check again' }));
+    expect(updateStatus).toHaveBeenLastCalledWith(true);
+  });
+});
+
+describe('UpdatesPanel, no trigger', () => {
+  it('offers nothing that would apply the update from the browser', async () => {
+    // Doing so needs the Docker socket mounted into the container, which is
+    // host root. See the comment in UpdatesPanel and adminUpdates.ts.
+    updateStatus.mockResolvedValue(AVAILABLE);
+    render(<UpdatesPanel />);
+    await screen.findByText('Backspace 1.0.4 is available');
+    const labels = screen.getAllByRole('button').map((b) => b.textContent ?? '');
+    for (const label of labels) {
+      expect(label).not.toMatch(/^(Update now|Install|Apply|Restart)$/i);
+    }
+  });
+});

--- a/packages/web/src/components/modals/instanceSettingsPanels/UpdatesPanel.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/UpdatesPanel.tsx
@@ -1,0 +1,284 @@
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../../../api/client';
+import { useUIStore } from '../../../stores/uiStore';
+import type { InstanceUpdateStatus } from '@backspace/shared';
+
+/**
+ * Formats an ISO date for the release line. Falls back to the raw string rather
+ * than rendering "Invalid Date" if a release ever carries something unexpected.
+ */
+function formatReleaseDate(iso: string): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+function formatCheckedAt(checkedAt: number | null): string {
+  if (checkedAt === null) return '';
+  const seconds = Math.max(0, Math.round((Date.now() - checkedAt) / 1000));
+  if (seconds < 60) return 'Last checked just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `Last checked ${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.round(minutes / 60);
+  return `Last checked ${hours} hour${hours === 1 ? '' : 's'} ago`;
+}
+
+const CHANNEL_LABEL: Record<InstanceUpdateStatus['channel'], string> = {
+  prebuilt: 'prebuilt image',
+  source: 'built from source',
+  unknown: 'install method not recorded',
+};
+
+/** A copyable command block. */
+function CommandBlock({ command }: { command: string }) {
+  const addToast = useUIStore((s) => s.addToast);
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard access can be refused. The command is selectable either way,
+      // so say so rather than failing silently.
+      addToast('Could not copy. Select the command and copy it by hand.', 'warning', 4000);
+    }
+  };
+
+  return (
+    <div className="flex items-stretch gap-2">
+      <code className="flex-1 min-w-0 rounded-lg bg-surface-input px-3 py-2 font-mono text-xs text-txt-primary overflow-x-auto whitespace-pre select-all">
+        {command}
+      </code>
+      <button
+        type="button"
+        onClick={copy}
+        className="shrink-0 px-3 py-2 text-xs font-medium rounded-lg text-txt-secondary hover:text-txt-primary bg-white/[0.04] hover:bg-white/[0.08] transition-colors"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Instance version and update guidance for operators.
+ *
+ * There is deliberately no button that performs the update. Applying a
+ * container update from inside the container requires mounting the Docker
+ * socket, which grants the container root on the host. Backspace parses
+ * uploaded media, scrapes URLs for embeds, and accepts federation payloads from
+ * remote instances, so any remote-code-execution bug in it would become host
+ * root the moment that socket exists. This panel hands over an exact command
+ * instead, and ./update.sh is where the work went: it snapshots the database
+ * first, verifies the running version actually changed, and rolls back if it
+ * did not.
+ */
+export function UpdatesPanel() {
+  const [status, setStatus] = useState<InstanceUpdateStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [checking, setChecking] = useState(false);
+  const [loadError, setLoadError] = useState('');
+  const [showManual, setShowManual] = useState(false);
+
+  const load = useCallback(async (refresh: boolean) => {
+    if (refresh) setChecking(true);
+    setLoadError('');
+    try {
+      setStatus(await api.admin.updateStatus(refresh));
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'Could not load the update status');
+    } finally {
+      setLoading(false);
+      setChecking(false);
+    }
+  }, []);
+
+  // The lookup happens here, when an admin opens the panel, and nowhere else.
+  // There is no background poller on the server, so an instance whose admin
+  // never opens this never contacts github.com at all.
+  useEffect(() => { void load(false); }, [load]);
+
+  if (loading) return <div className="text-sm text-txt-tertiary">Loading update status...</div>;
+
+  if (loadError || status === null) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold text-txt-primary">Updates</h2>
+        <div className="rounded-lg bg-accent-rose/10 border border-accent-rose/20 p-3.5 text-sm text-txt-secondary">
+          {loadError || 'Could not load the update status.'}
+        </div>
+        <button
+          type="button"
+          onClick={() => void load(false)}
+          className="px-3 py-1.5 text-sm text-txt-secondary hover:text-txt-primary bg-white/[0.04] hover:bg-white/[0.08] rounded-lg transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  const updateAvailable = status.state === 'update-available' && status.latest !== null;
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-lg font-semibold text-txt-primary">Updates</h2>
+        <div className="text-xs text-txt-tertiary mt-1">
+          What this instance is running, and how to move it forward.
+        </div>
+      </div>
+
+      {/* What is running now */}
+      <div>
+        <div className="text-[11px] font-semibold text-txt-tertiary uppercase tracking-wider mb-1.5">
+          Running
+        </div>
+        <div className="rounded-lg bg-white/[0.03] border border-white/[0.04] p-3.5">
+          <div className="text-sm text-txt-primary font-medium">
+            Backspace {status.current.version}
+          </div>
+          <div className="text-xs text-txt-tertiary mt-0.5">
+            {status.current.commit ? `commit ${status.current.commit} · ` : ''}
+            {CHANNEL_LABEL[status.channel]}
+          </div>
+        </div>
+      </div>
+
+      {/* What to do about it */}
+      {updateAvailable && status.latest !== null ? (
+        <div>
+          <div className="text-[11px] font-semibold text-txt-tertiary uppercase tracking-wider mb-1.5">
+            Available
+          </div>
+          <div className="rounded-lg bg-accent-primary/[0.06] border border-accent-primary/25 p-3.5 space-y-3">
+            <div>
+              <div className="text-sm text-txt-primary font-medium">
+                Backspace {status.latest.version} is available
+              </div>
+              <div className="text-xs text-txt-tertiary mt-0.5">
+                {status.latest.publishedAt && `Released ${formatReleaseDate(status.latest.publishedAt)} · `}
+                <a
+                  href={status.latest.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent-primary hover:underline"
+                >
+                  Release notes
+                </a>
+              </div>
+            </div>
+
+            <div>
+              <div className="text-xs text-txt-secondary mb-1.5">From your install directory:</div>
+              <CommandBlock command="./update.sh" />
+              <p className="text-xs text-txt-tertiary mt-2 leading-relaxed">
+                Takes a database snapshot, fetches the new image, and restarts only
+                the Backspace container. If the new version does not come up healthy,
+                or comes up still running the old code, it puts back the version you
+                are on now.
+              </p>
+            </div>
+
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowManual((v) => !v)}
+                aria-expanded={showManual}
+                className="flex items-center gap-1 -ml-1 px-1 py-0.5 rounded text-xs text-txt-secondary hover:text-txt-primary transition-colors"
+              >
+                <svg
+                  className={`w-3 h-3 transition-transform ${showManual ? 'rotate-90' : ''}`}
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}
+                  aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                </svg>
+                I do not have update.sh
+              </button>
+              {showManual && (
+                <div className="mt-2 space-y-2.5">
+                  <p className="text-xs text-txt-tertiary leading-relaxed">
+                    update.sh ships from 1.0.5 onward. On a git checkout, <code className="font-mono">git pull</code> brings
+                    it in. Otherwise run the steps by hand, after taking a snapshot
+                    with <code className="font-mono">./backup.sh</code>.
+                  </p>
+                  {status.channel !== 'source' && (
+                    <div>
+                      <div className="text-xs text-txt-secondary mb-1.5">Prebuilt-image install:</div>
+                      {/* One command per line rather than chained with &&, so
+                          the block fits the panel without scrolling sideways. */}
+                      <CommandBlock command={'git pull\ndocker compose pull backspace\ndocker compose up -d backspace'} />
+                    </div>
+                  )}
+                  {status.channel !== 'prebuilt' && (
+                    <div>
+                      <div className="text-xs text-txt-secondary mb-1.5">From-source install:</div>
+                      <CommandBlock command={'git pull\ndocker compose up -d --build backspace'} />
+                    </div>
+                  )}
+                  <p className="text-xs text-txt-tertiary leading-relaxed">
+                    Name the <code className="font-mono">backspace</code> service explicitly and do not
+                    pass <code className="font-mono">--remove-orphans</code>. Compose will suggest it if
+                    you run other containers in this project, and it would delete them.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg bg-white/[0.03] border border-white/[0.04] p-3.5">
+          {status.state === 'up-to-date' && (
+            <div className="text-sm text-accent-mint">You are on the latest release.</div>
+          )}
+          {status.state === 'unknown' && status.reason === 'disabled' && (
+            <>
+              <div className="text-sm text-txt-primary">Update checks are turned off</div>
+              <div className="text-xs text-txt-tertiary mt-0.5 leading-relaxed">
+                This instance will not contact GitHub. Set{' '}
+                <code className="font-mono">BACKSPACE_UPDATE_CHECK=true</code> in your{' '}
+                <code className="font-mono">.env</code> to allow the lookup, or check the releases
+                page yourself.
+              </div>
+            </>
+          )}
+          {status.state === 'unknown' && status.reason === 'rate-limited' && (
+            <>
+              <div className="text-sm text-txt-primary">GitHub rate-limited the lookup</div>
+              <div className="text-xs text-txt-tertiary mt-0.5">
+                This says nothing about whether an update exists. Try again later.
+              </div>
+            </>
+          )}
+          {status.state === 'unknown' && status.reason !== 'disabled' && status.reason !== 'rate-limited' && (
+            <>
+              <div className="text-sm text-txt-primary">Could not check for updates</div>
+              <div className="text-xs text-txt-tertiary mt-0.5">
+                GitHub could not be reached, so this says nothing about whether an
+                update exists. Your instance is unaffected.
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <div className="text-xs text-txt-tertiary">
+          {status.checkEnabled ? formatCheckedAt(status.checkedAt) : 'No lookups are made'}
+        </div>
+        <button
+          type="button"
+          onClick={() => void load(true)}
+          disabled={checking || !status.checkEnabled}
+          className="px-3 py-1.5 text-sm text-txt-secondary hover:text-txt-primary bg-white/[0.04] hover:bg-white/[0.08] rounded-lg transition-colors disabled:opacity-50"
+        >
+          {checking ? 'Checking...' : 'Check again'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/modals/settingsPanels/DesktopPanel.tsx
+++ b/packages/web/src/components/modals/settingsPanels/DesktopPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Toggle } from '../../ui/Toggle';
+import { useUpdateStore } from '../../../stores/updateStore';
 
 function AutoLaunchSettings() {
   const [openAtLogin, setOpenAtLogin] = useState(false);
@@ -69,38 +70,130 @@ function AutoLaunchSettings() {
   );
 }
 
+/**
+ * Formats a byte-per-second rate for the download line. Deliberately coarse:
+ * this is reassurance that something is happening, not a benchmark.
+ */
+function formatRate(bytesPerSecond: number): string {
+  if (bytesPerSecond <= 0) return '';
+  const mb = bytesPerSecond / 1_048_576;
+  if (mb >= 1) return `${mb.toFixed(1)} MB/s`;
+  return `${Math.round(bytesPerSecond / 1024)} KB/s`;
+}
+
+/**
+ * Desktop version and update state.
+ *
+ * This panel deliberately ignores whether the user dismissed the update. It is
+ * the place a dismissed update stays reachable, which is the thing that makes
+ * "Later" safe to offer in the toast at all.
+ *
+ * Every state here comes from a real updater event. The previous version faked
+ * a "Checking..." state with a five second timer and a comment claiming
+ * electron-updater has no no-update callback. It emits `update-not-available`
+ * and `download-progress`; both are now wired.
+ */
 function UpdateSettings() {
-  const [version, setVersion] = useState<string | null>(null);
-  const [checking, setChecking] = useState(false);
+  const initialize = useUpdateStore((s) => s.initialize);
+  const snapshot = useUpdateStore((s) => s.snapshot);
+  const currentVersion = useUpdateStore((s) => s.currentVersion);
+  const checkNow = useUpdateStore((s) => s.checkNow);
+  const install = useUpdateStore((s) => s.install);
+  const openDownloadPage = useUpdateStore((s) => s.openDownloadPage);
 
-  useEffect(() => {
-    window.backspace?.getVersion().then(setVersion).catch(() => {});
-  }, []);
+  useEffect(() => initialize(), [initialize]);
 
-  const handleCheck = () => {
-    setChecking(true);
-    window.backspace?.checkForUpdates();
-    // Reset after a few seconds — electron-updater doesn't have a "no update" callback
-    setTimeout(() => setChecking(false), 5000);
-  };
+  const status = snapshot?.status ?? { phase: 'idle' as const };
+  const capability = snapshot?.capability ?? 'auto';
+  const busy = status.phase === 'checking' || status.phase === 'downloading';
+
+  let detail: string;
+  let tone = 'text-txt-tertiary';
+  let action: { label: string; onClick: () => void } | null = null;
+
+  switch (status.phase) {
+    case 'checking':
+      detail = 'Checking for updates...';
+      break;
+    case 'downloading':
+      detail = `Downloading ${status.version}, ${status.percent}%`;
+      if (status.bytesPerSecond > 0) detail += ` at ${formatRate(status.bytesPerSecond)}`;
+      break;
+    case 'up-to-date':
+      detail = 'You are on the latest version';
+      tone = 'text-accent-mint';
+      break;
+    case 'available':
+      detail = `Version ${status.version} is available`;
+      action = { label: 'Download', onClick: openDownloadPage };
+      break;
+    case 'ready':
+      if (capability === 'auto') {
+        detail = `Version ${status.version} is ready to install`;
+        action = { label: 'Restart', onClick: install };
+      } else {
+        detail = `Version ${status.version} is available`;
+        action = { label: 'Download', onClick: openDownloadPage };
+      }
+      break;
+    case 'failed':
+      if (status.version) {
+        detail = `Version ${status.version} could not be installed`;
+        tone = 'text-accent-rose';
+        action = { label: 'Download', onClick: openDownloadPage };
+      } else {
+        detail = 'The last update check failed';
+        tone = 'text-accent-rose';
+      }
+      break;
+    default:
+      detail = 'Check for new versions of the desktop app';
+  }
 
   return (
-    <div className="flex items-center justify-between py-1">
-      <div className="flex-1 mr-4">
-        <div className="text-sm text-txt-primary">
-          {version ? `Version ${version}` : 'Backspace Desktop'}
+    <div className="space-y-2.5">
+      <div className="flex items-center justify-between py-1">
+        <div className="flex-1 mr-4 min-w-0">
+          <div className="text-sm text-txt-primary">
+            {currentVersion ? `Version ${currentVersion}` : 'Backspace Desktop'}
+          </div>
+          <div className={`text-xs mt-0.5 ${tone}`}>{detail}</div>
         </div>
-        <div className="text-xs text-txt-tertiary mt-0.5">
-          Check for new versions of the desktop app
+        <div className="flex items-center gap-2 shrink-0">
+          {action && (
+            <button
+              onClick={action.onClick}
+              className="px-3 py-1.5 text-sm font-medium text-white bg-accent-primary hover:bg-accent-primary/80 rounded-lg transition-colors"
+            >
+              {action.label}
+            </button>
+          )}
+          <button
+            onClick={checkNow}
+            disabled={busy}
+            className="px-3 py-1.5 text-sm text-txt-secondary hover:text-txt-primary bg-white/[0.04] hover:bg-white/[0.08] rounded-lg transition-colors disabled:opacity-50"
+          >
+            {status.phase === 'checking' ? 'Checking...' : 'Check for Updates'}
+          </button>
         </div>
       </div>
-      <button
-        onClick={handleCheck}
-        disabled={checking}
-        className="px-3 py-1.5 text-sm text-txt-secondary hover:text-txt-primary bg-white/[0.04] hover:bg-white/[0.08] rounded-lg transition-colors disabled:opacity-50"
-      >
-        {checking ? 'Checking...' : 'Check for Updates'}
-      </button>
+
+      {status.phase === 'downloading' && (
+        <div className="h-1 rounded-full bg-white/[0.06] overflow-hidden" role="progressbar" aria-valuenow={status.percent} aria-valuemin={0} aria-valuemax={100}>
+          <div
+            className="h-full bg-accent-primary transition-[width] duration-300"
+            style={{ width: `${status.percent}%` }}
+          />
+        </div>
+      )}
+
+      {capability === 'manual' && (
+        <p className="text-xs text-txt-tertiary leading-relaxed">
+          This build cannot install updates itself, so new versions are downloaded
+          from GitHub and replace the app by hand. See the release notes for the
+          steps on your platform.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/modals/settingsPanels/InstancePanel.tsx
+++ b/packages/web/src/components/modals/settingsPanels/InstancePanel.tsx
@@ -9,8 +9,9 @@ import { FederationPanel } from '../instanceSettingsPanels/FederationPanel';
 import { StreamingPanel } from '../instanceSettingsPanels/StreamingPanel';
 import { StoragePanel } from '../instanceSettingsPanels/StoragePanel';
 import { UsersPanel } from '../instanceSettingsPanels/UsersPanel';
+import { UpdatesPanel } from '../instanceSettingsPanels/UpdatesPanel';
 
-type SubTab = 'general' | 'registration' | 'federation' | 'streaming' | 'storage' | 'users';
+type SubTab = 'general' | 'registration' | 'federation' | 'streaming' | 'storage' | 'users' | 'updates';
 
 export function InstancePanel() {
   const fetchInstanceSettings = useSettingsStore((s) => s.fetchInstanceSettings);
@@ -26,6 +27,7 @@ export function InstancePanel() {
     { id: 'streaming', label: 'Streaming' },
     { id: 'storage', label: 'Storage' },
     { id: 'users', label: 'Users' },
+    { id: 'updates', label: 'Updates' },
   ], [approvalCount]);
 
   const handleNavigate = useCallback((id: string) => {
@@ -50,6 +52,7 @@ export function InstancePanel() {
       {subTab === 'streaming' && <StreamingPanel />}
       {subTab === 'storage' && <StoragePanel />}
       {subTab === 'users' && <UsersPanel />}
+      {subTab === 'updates' && <UpdatesPanel />}
     </div>
   );
 }

--- a/packages/web/src/components/ui/UpdateToast.test.tsx
+++ b/packages/web/src/components/ui/UpdateToast.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UpdateToast } from './UpdateToast';
+import { useUpdateStore } from '../../stores/updateStore';
+import { useUIStore } from '../../stores/uiStore';
+
+interface HostStubs {
+  dismissUpdate: ReturnType<typeof vi.fn>;
+  installUpdate: ReturnType<typeof vi.fn>;
+  openReleasePage: ReturnType<typeof vi.fn>;
+}
+
+let push: ((snapshot: unknown) => void) | null = null;
+let stubs: HostStubs;
+
+/**
+ * Installs a fake preload bridge. `initial` is what getUpdateStatus resolves
+ * with; `omit` drops methods to simulate an older desktop app.
+ */
+function installHost(initial: unknown, omit: string[] = []): void {
+  stubs = {
+    dismissUpdate: vi.fn(),
+    installUpdate: vi.fn(),
+    openReleasePage: vi.fn(),
+  };
+  const api: Record<string, unknown> = {
+    platform: 'darwin',
+    getVersion: () => Promise.resolve('1.0.3'),
+    getUpdateStatus: () => Promise.resolve(initial),
+    onUpdateStatusChanged: (cb: (s: unknown) => void) => {
+      push = cb;
+      return () => { push = null; };
+    },
+    dismissUpdate: stubs.dismissUpdate,
+    installUpdate: stubs.installUpdate,
+    openReleasePage: stubs.openReleasePage,
+    checkForUpdates: vi.fn(),
+    onUpdateDownloaded: vi.fn(),
+    onUpdateError: vi.fn(),
+  };
+  for (const key of omit) delete api[key];
+  Object.defineProperty(window, 'backspace', { value: api, configurable: true, writable: true });
+}
+
+beforeEach(() => {
+  push = null;
+  useUpdateStore.setState({ snapshot: null, currentVersion: null, legacyBridge: false });
+  useUIStore.setState({ toasts: [] });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(window as unknown as Record<string, unknown>, 'backspace');
+});
+
+describe('UpdateToast, ad-hoc signed macOS build', () => {
+  beforeEach(() => {
+    installHost({
+      capability: 'manual',
+      dismissedVersion: null,
+      status: { phase: 'available', version: '1.0.4' },
+    });
+  });
+
+  it('offers Download and never a Restart button', async () => {
+    render(<UpdateToast />);
+    expect(await screen.findByText('Backspace 1.0.4 is available')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Restart now' })).not.toBeInTheDocument();
+  });
+
+  it('says in plain words that the build cannot update itself', async () => {
+    render(<UpdateToast />);
+    expect(await screen.findByText(/cannot update itself/i)).toBeInTheDocument();
+  });
+
+  it('names the version the user is currently on', async () => {
+    render(<UpdateToast />);
+    expect(await screen.findByText(/You are on 1\.0\.3/)).toBeInTheDocument();
+  });
+
+  it('opens the download page through the host, not a raw link', async () => {
+    render(<UpdateToast />);
+    await userEvent.click(await screen.findByRole('button', { name: 'Download' }));
+    expect(stubs.openReleasePage).toHaveBeenCalledOnce();
+  });
+});
+
+describe('UpdateToast, installable build', () => {
+  beforeEach(() => {
+    installHost({
+      capability: 'auto',
+      dismissedVersion: null,
+      status: { phase: 'ready', version: '1.0.4' },
+    });
+  });
+
+  it('offers Restart now', async () => {
+    render(<UpdateToast />);
+    expect(await screen.findByText('Update ready')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Restart now' }));
+    expect(stubs.installUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('does not truncate the body copy', async () => {
+    render(<UpdateToast />);
+    const body = await screen.findByText(/is downloaded and ready to install/);
+    expect(body.className).not.toContain('truncate');
+  });
+
+  it('uses the glass-bubble surface tier, not glass-pill', async () => {
+    const { container } = render(<UpdateToast />);
+    await screen.findByText('Update ready');
+    expect(container.querySelector('.glass-bubble')).not.toBeNull();
+    expect(container.querySelector('.glass-pill')).toBeNull();
+  });
+});
+
+describe('UpdateToast, latest event wins', () => {
+  it('replaces a ready state with a later failure instead of hiding it behind one', async () => {
+    // The reported defect: "Update ready" masked "Update failed" until the user
+    // dismissed the card in front of it.
+    installHost({
+      capability: 'auto',
+      dismissedVersion: null,
+      status: { phase: 'ready', version: '1.0.4' },
+    });
+    render(<UpdateToast />);
+    await screen.findByText('Update ready');
+
+    push!({
+      capability: 'auto',
+      dismissedVersion: null,
+      status: { phase: 'failed', version: '1.0.4', message: 'Squirrel refused the update' },
+    });
+
+    expect(await screen.findByText('Update could not be installed')).toBeInTheDocument();
+    expect(screen.queryByText('Update ready')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+  });
+});
+
+describe('UpdateToast, dismissal', () => {
+  it('reports the dismissal to the host and points at where the update lives', async () => {
+    installHost({
+      capability: 'manual',
+      dismissedVersion: null,
+      status: { phase: 'available', version: '1.0.4' },
+    });
+    render(<UpdateToast />);
+    await userEvent.click(await screen.findByRole('button', { name: 'Later' }));
+
+    expect(stubs.dismissUpdate).toHaveBeenCalledWith('1.0.4');
+    expect(useUIStore.getState().toasts.map((t) => t.message))
+      .toContain('You can install this later from Settings, Desktop');
+  });
+
+  it('renders nothing for a version already dismissed', async () => {
+    installHost({
+      capability: 'manual',
+      dismissedVersion: '1.0.4',
+      status: { phase: 'available', version: '1.0.4' },
+    });
+    const { container } = render(<UpdateToast />);
+    await waitFor(() => expect(useUpdateStore.getState().snapshot).not.toBeNull());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('still renders for a version newer than the dismissed one', async () => {
+    installHost({
+      capability: 'manual',
+      dismissedVersion: '1.0.4',
+      status: { phase: 'available', version: '1.0.5' },
+    });
+    render(<UpdateToast />);
+    expect(await screen.findByText('Backspace 1.0.5 is available')).toBeInTheDocument();
+  });
+});
+
+describe('UpdateToast, quiet phases', () => {
+  it.each([
+    ['idle', { phase: 'idle' }],
+    ['checking', { phase: 'checking' }],
+    ['downloading', { phase: 'downloading', version: '1.0.4', percent: 40, bytesPerSecond: 1 }],
+    ['up-to-date', { phase: 'up-to-date', checkedAt: 1 }],
+  ])('renders nothing while %s', async (_label, status) => {
+    installHost({ capability: 'auto', dismissedVersion: null, status });
+    const { container } = render(<UpdateToast />);
+    await waitFor(() => expect(useUpdateStore.getState().snapshot).not.toBeNull());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a check failure with no version', async () => {
+    installHost({
+      capability: 'auto',
+      dismissedVersion: null,
+      status: { phase: 'failed', version: null, message: 'ENOTFOUND' },
+    });
+    const { container } = render(<UpdateToast />);
+    await waitFor(() => expect(useUpdateStore.getState().snapshot).not.toBeNull());
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('UpdateToast, outside Electron', () => {
+  it('renders nothing in a browser', () => {
+    const { container } = render(<UpdateToast />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('UpdateToast, older desktop app', () => {
+  it('falls back to the legacy channels rather than crashing', async () => {
+    // A client served by a newer instance, running inside a pre-1.0.5 app that
+    // has no snapshot API at all.
+    installHost(null, ['getUpdateStatus', 'onUpdateStatusChanged', 'dismissUpdate', 'openReleasePage']);
+    let legacyDownloaded: ((info: { version: string }) => void) | null = null;
+    (window.backspace as unknown as Record<string, unknown>).onUpdateDownloaded =
+      (cb: (info: { version: string }) => void) => { legacyDownloaded = cb; };
+
+    render(<UpdateToast />);
+    await waitFor(() => expect(legacyDownloaded).not.toBeNull());
+
+    legacyDownloaded!({ version: '1.0.4' });
+    expect(await screen.findByText('Update ready')).toBeInTheDocument();
+    expect(useUpdateStore.getState().legacyBridge).toBe(true);
+  });
+});

--- a/packages/web/src/components/ui/UpdateToast.tsx
+++ b/packages/web/src/components/ui/UpdateToast.tsx
@@ -1,95 +1,129 @@
-import { useState, useEffect } from 'react';
-import { isElectron } from '../../platform/platform';
-
-interface UpdateError {
-  message: string;
-  releaseUrl: string;
-}
+import { useEffect } from 'react';
+import {
+  useUpdateStore,
+  shouldPrompt,
+  canRestartToInstall,
+  statusVersion,
+} from '../../stores/updateStore';
+import { useUIStore } from '../../stores/uiStore';
 
 /**
- * Persistent toast shown when an Electron auto-update has been downloaded
- * or when auto-update fails (offers manual download link).
- * Renders nothing in browser environments.
+ * The persistent update prompt.
+ *
+ * Renders nothing in a browser, nothing while an update is merely downloading
+ * or being checked for, and nothing for a version the user has already
+ * dismissed. When it does render, every button it offers actually does
+ * something: a Restart button appears only on a build that can install in
+ * place, and a build that cannot says so in plain words instead of presenting a
+ * control that silently fails.
+ *
+ * Surface tier is `.glass-bubble`: this is a persistent floating control, which
+ * is that tier's definition in docs/systems/design-system.md. It was previously
+ * `.glass-pill`, which the spec reserves for inline decorations.
  */
 export function UpdateToast() {
-  const [downloadedVersion, setDownloadedVersion] = useState<string | null>(null);
-  const [failedUpdate, setFailedUpdate] = useState<UpdateError | null>(null);
+  const initialize = useUpdateStore((s) => s.initialize);
+  const snapshot = useUpdateStore((s) => s.snapshot);
+  const currentVersion = useUpdateStore((s) => s.currentVersion);
+  const dismiss = useUpdateStore((s) => s.dismiss);
+  const install = useUpdateStore((s) => s.install);
+  const openDownloadPage = useUpdateStore((s) => s.openDownloadPage);
+  const addToast = useUIStore((s) => s.addToast);
 
-  useEffect(() => {
-    if (!isElectron() || !window.backspace) return;
+  useEffect(() => initialize(), [initialize]);
 
-    window.backspace.onUpdateDownloaded((info) => {
-      setDownloadedVersion(info.version);
-      // Auto-download succeeded — clear any previous error state
-      setFailedUpdate(null);
-    });
+  if (!shouldPrompt(snapshot) || snapshot === null) return null;
 
-    window.backspace.onUpdateError((error) => {
-      setFailedUpdate(error);
-    });
-  }, []);
+  const version = statusVersion(snapshot.status);
+  if (version === null) return null;
 
-  // Nothing to show
-  if (!downloadedVersion && !failedUpdate) return null;
+  const canRestart = canRestartToInstall(snapshot);
+  const failed = snapshot.status.phase === 'failed';
 
-  // Auto-download succeeded — show restart toast
-  if (downloadedVersion) {
-    return (
-      <div className="fixed bottom-6 left-6 z-[300] animate-slide-up">
-        <div className="glass-pill rounded-xl px-4 py-3 flex items-center gap-3 max-w-[340px]">
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-txt-primary">Update ready</p>
-            <p className="text-xs text-txt-secondary truncate">
-              Version {downloadedVersion} has been downloaded
-            </p>
-          </div>
-          <button
-            onClick={() => window.backspace?.installUpdate()}
-            className="shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-primary hover:bg-accent-primary/80 text-white transition-colors"
+  const handleLater = () => {
+    dismiss();
+    // The prompt is gone but the update is not lost, and the user has no way to
+    // know that unless they are told once, at the moment they need to know it.
+    addToast('You can install this later from Settings, Desktop', 'info', 5000);
+  };
+
+  let title: string;
+  let body: string;
+  if (failed) {
+    title = 'Update could not be installed';
+    body = `Backspace ${version} downloaded, but installing it failed. You can install it by hand instead.`;
+  } else if (canRestart) {
+    title = 'Update ready';
+    body = `Backspace ${version} is downloaded and ready to install.`;
+  } else {
+    title = `Backspace ${version} is available`;
+    body = currentVersion
+      ? `You are on ${currentVersion}. This build cannot update itself, so download the new version to move up.`
+      : 'This build cannot update itself, so download the new version to move up.';
+  }
+
+  return (
+    <div className="fixed bottom-6 left-6 z-[300] animate-slide-up max-w-[calc(100vw-3rem)]">
+      <div className="glass-bubble rounded-2xl p-4 w-[380px] max-w-full">
+        <div className="flex items-start gap-3">
+          <div
+            className={`shrink-0 mt-0.5 w-8 h-8 rounded-full flex items-center justify-center ${
+              failed ? 'bg-accent-rose/15 text-accent-rose' : 'bg-accent-primary/15 text-accent-primary'
+            }`}
+            aria-hidden="true"
           >
-            Restart
-          </button>
+            {failed ? (
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4m0 4h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+              </svg>
+            ) : (
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v12m0 0 4-4m-4 4-4-4M4 20h16" />
+              </svg>
+            )}
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-txt-primary">{title}</p>
+            {/* Deliberately wraps. The previous version truncated this line
+                mid-word inside a fixed-width pill. */}
+            <p className="text-xs text-txt-secondary mt-1 leading-relaxed">{body}</p>
+          </div>
+
           <button
-            onClick={() => setDownloadedVersion(null)}
-            className="shrink-0 p-1 text-txt-tertiary hover:text-txt-secondary transition-colors"
-            aria-label="Dismiss"
+            onClick={handleLater}
+            className="shrink-0 -mt-1 -mr-1 p-1.5 rounded-lg text-txt-tertiary hover:text-txt-secondary hover:bg-white/[0.06] transition-colors"
+            aria-label="Dismiss this update"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
-      </div>
-    );
-  }
 
-  // Auto-download failed — show manual download toast
-  return (
-    <div className="fixed bottom-6 left-6 z-[300] animate-slide-up">
-      <div className="glass-pill rounded-xl px-4 py-3 flex items-center gap-3 max-w-[380px]">
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-txt-primary">Update failed</p>
-          <p className="text-xs text-txt-secondary truncate">
-            Auto-update failed — download manually
-          </p>
+        <div className="flex items-center gap-2 mt-3.5 pl-11">
+          {canRestart ? (
+            <button
+              onClick={install}
+              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-primary hover:bg-accent-primary/80 text-white transition-colors"
+            >
+              Restart now
+            </button>
+          ) : (
+            <button
+              onClick={openDownloadPage}
+              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-primary hover:bg-accent-primary/80 text-white transition-colors"
+            >
+              Download
+            </button>
+          )}
+          <button
+            onClick={handleLater}
+            className="px-3 py-1.5 text-xs font-medium rounded-lg text-txt-secondary hover:text-txt-primary hover:bg-white/[0.06] transition-colors"
+          >
+            Later
+          </button>
         </div>
-        <a
-          href={failedUpdate!.releaseUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-primary hover:bg-accent-primary/80 text-white transition-colors"
-        >
-          Download
-        </a>
-        <button
-          onClick={() => setFailedUpdate(null)}
-          className="shrink-0 p-1 text-txt-tertiary hover:text-txt-secondary transition-colors"
-          aria-label="Dismiss"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
       </div>
     </div>
   );

--- a/packages/web/src/platform/electron.d.ts
+++ b/packages/web/src/platform/electron.d.ts
@@ -2,7 +2,16 @@
 
 // Recovery mode types (Task 11)
 type RecoveryReasonCode = 'load-failed' | 'render-gone' | 'unresponsive' | 'renderer-stalled';
-type UpdateState = 'idle' | 'checking' | 'downloading' | 'downloaded' | 'error';
+// 'available-manual': an update exists but this build cannot install it in
+// place, so the recovery surface offers a download rather than a Restart button
+// that would do nothing. See packages/desktop/src/updateCapability.ts.
+type UpdateState =
+  | 'idle'
+  | 'checking'
+  | 'downloading'
+  | 'available-manual'
+  | 'downloaded'
+  | 'error';
 interface RecoveryState {
   mode: 'normal' | 'recovery';
   reason: { code: RecoveryReasonCode; detail: string } | null;
@@ -27,6 +36,41 @@ interface ElectronScreenSource {
   isScreen: boolean;               // true = display, false = window
 }
 
+/**
+ * Where the desktop updater currently is.
+ *
+ * Declared without `export` on purpose: this file is a global ambient
+ * declaration that augments `interface Window`. A single `export` would turn it
+ * into a module and drop that augmentation across the whole package.
+ *
+ * Mirrors `UpdateStatus` in `packages/desktop/src/updateStatus.ts`. The two are
+ * separate declarations on purpose: this is a wire contract across a process
+ * boundary between two packages that ship and version independently, and the
+ * web client must not take a build dependency on the Electron package. The
+ * runtime guard in `updateStore.ts` is what keeps them honest.
+ */
+type DesktopUpdateStatus =
+  | { phase: 'idle' }
+  | { phase: 'checking' }
+  | { phase: 'available'; version: string }
+  | { phase: 'downloading'; version: string; percent: number; bytesPerSecond: number }
+  | { phase: 'ready'; version: string }
+  | { phase: 'failed'; version: string | null; message: string }
+  | { phase: 'up-to-date'; checkedAt: number };
+
+/**
+ * `auto` means this build can install its own updates. `manual` means it cannot
+ * and the user has to download a new build, which is the case for ad-hoc signed
+ * macOS builds. The renderer never reasons about code signing; it reads this.
+ */
+type DesktopUpdateCapability = 'auto' | 'manual';
+
+interface DesktopUpdateSnapshot {
+  capability: DesktopUpdateCapability;
+  dismissedVersion: string | null;
+  status: DesktopUpdateStatus;
+}
+
 interface BackspaceElectronAPI {
   // Platform info
   platform: NodeJS.Platform;
@@ -40,13 +84,26 @@ interface BackspaceElectronAPI {
   showNotification: (title: string, body: string) => void;
   setBadgeCount: (count: number) => void;
 
-  // Auto-update (Task 2.1)
+  // Auto-update, legacy per-event channels.
+  //
+  // Kept because the desktop app and the instance it connects to version
+  // independently. Unused by this client; the snapshot API below replaces them.
   onUpdateAvailable: (callback: (info: { version: string }) => void) => void;
   onUpdateDownloaded: (callback: (info: { version: string }) => void) => void;
   onUpdateError: (callback: (error: { message: string; releaseUrl: string }) => void) => void;
   installUpdate: () => void;
   checkForUpdates: () => void;
   getVersion: () => Promise<string>;
+
+  // Auto-update, current surface.
+  //
+  // Optional because an older desktop app does not expose them. A client served
+  // by a newer instance can find itself running inside an older app, so every
+  // call site must feature-detect. See updateStore.ts.
+  getUpdateStatus?: () => Promise<unknown>;
+  onUpdateStatusChanged?: (callback: (snapshot: unknown) => void) => (() => void);
+  dismissUpdate?: (version: string) => void;
+  openReleasePage?: () => void;
 
   // Window focus (Task 2.2)
   onWindowFocusChange: (callback: (focused: boolean) => void) => void;

--- a/packages/web/src/stores/updateStore.test.ts
+++ b/packages/web/src/stores/updateStore.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import {
+  coerceSnapshot,
+  shouldPrompt,
+  canRestartToInstall,
+  statusVersion,
+} from './updateStore';
+
+function snap(over: Partial<DesktopUpdateSnapshot>): DesktopUpdateSnapshot {
+  return { capability: 'auto', dismissedVersion: null, status: { phase: 'idle' }, ...over };
+}
+
+describe('coerceSnapshot', () => {
+  it('accepts a well-formed snapshot', () => {
+    const value = {
+      capability: 'manual',
+      dismissedVersion: null,
+      status: { phase: 'available', version: '1.0.4' },
+    };
+    expect(coerceSnapshot(value)).toEqual(value);
+  });
+
+  it('accepts every phase the main process can send', () => {
+    const phases: unknown[] = [
+      { phase: 'idle' },
+      { phase: 'checking' },
+      { phase: 'available', version: '1.0.4' },
+      { phase: 'downloading', version: '1.0.4', percent: 42, bytesPerSecond: 1000 },
+      { phase: 'ready', version: '1.0.4' },
+      { phase: 'failed', version: '1.0.4', message: 'nope' },
+      { phase: 'failed', version: null, message: 'check failed' },
+      { phase: 'up-to-date', checkedAt: 1 },
+    ];
+    for (const status of phases) {
+      expect(coerceSnapshot({ capability: 'auto', dismissedVersion: null, status })).not.toBeNull();
+    }
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(coerceSnapshot(null)).toBeNull();
+    expect(coerceSnapshot(undefined)).toBeNull();
+    expect(coerceSnapshot('ready')).toBeNull();
+    expect(coerceSnapshot(42)).toBeNull();
+  });
+
+  it('rejects an unknown capability', () => {
+    expect(coerceSnapshot({ capability: 'sometimes', dismissedVersion: null, status: { phase: 'idle' } }))
+      .toBeNull();
+  });
+
+  it('rejects a non-string dismissedVersion', () => {
+    expect(coerceSnapshot({ capability: 'auto', dismissedVersion: 104, status: { phase: 'idle' } }))
+      .toBeNull();
+  });
+
+  it('rejects an unknown phase, so a newer app cannot render as garbage', () => {
+    expect(coerceSnapshot({ capability: 'auto', dismissedVersion: null, status: { phase: 'teleporting' } }))
+      .toBeNull();
+  });
+
+  it('rejects a versioned phase that carries no version', () => {
+    for (const phase of ['available', 'ready', 'downloading']) {
+      expect(coerceSnapshot({ capability: 'auto', dismissedVersion: null, status: { phase } }))
+        .toBeNull();
+    }
+  });
+
+  it('repairs non-finite numeric fields rather than rejecting the snapshot', () => {
+    const result = coerceSnapshot({
+      capability: 'auto',
+      dismissedVersion: null,
+      status: { phase: 'downloading', version: '1.0.4', percent: NaN, bytesPerSecond: 'fast' },
+    });
+    expect(result?.status).toEqual({
+      phase: 'downloading', version: '1.0.4', percent: 0, bytesPerSecond: 0,
+    });
+  });
+
+  it('supplies a fallback message for a failure that carries none', () => {
+    const result = coerceSnapshot({
+      capability: 'auto',
+      dismissedVersion: null,
+      status: { phase: 'failed', version: '1.0.4' },
+    });
+    expect(result?.status).toEqual({ phase: 'failed', version: '1.0.4', message: 'The update failed.' });
+  });
+});
+
+describe('statusVersion', () => {
+  it('extracts the version where one exists', () => {
+    expect(statusVersion({ phase: 'available', version: '1.0.4' })).toBe('1.0.4');
+    expect(statusVersion({ phase: 'ready', version: '1.0.4' })).toBe('1.0.4');
+    expect(statusVersion({ phase: 'failed', version: '1.0.4', message: 'x' })).toBe('1.0.4');
+    expect(statusVersion({ phase: 'downloading', version: '1.0.4', percent: 1, bytesPerSecond: 1 })).toBe('1.0.4');
+  });
+
+  it('returns null where none exists', () => {
+    expect(statusVersion({ phase: 'idle' })).toBeNull();
+    expect(statusVersion({ phase: 'checking' })).toBeNull();
+    expect(statusVersion({ phase: 'up-to-date', checkedAt: 1 })).toBeNull();
+    expect(statusVersion({ phase: 'failed', version: null, message: 'x' })).toBeNull();
+  });
+});
+
+describe('shouldPrompt', () => {
+  it('prompts for available, ready, and failed', () => {
+    expect(shouldPrompt(snap({ status: { phase: 'available', version: '1.0.4' } }))).toBe(true);
+    expect(shouldPrompt(snap({ status: { phase: 'ready', version: '1.0.4' } }))).toBe(true);
+    expect(shouldPrompt(snap({ status: { phase: 'failed', version: '1.0.4', message: 'x' } }))).toBe(true);
+  });
+
+  it('stays quiet for progress phases, which are not news', () => {
+    expect(shouldPrompt(snap({ status: { phase: 'idle' } }))).toBe(false);
+    expect(shouldPrompt(snap({ status: { phase: 'checking' } }))).toBe(false);
+    expect(shouldPrompt(snap({ status: { phase: 'up-to-date', checkedAt: 1 } }))).toBe(false);
+    expect(shouldPrompt(snap({
+      status: { phase: 'downloading', version: '1.0.4', percent: 10, bytesPerSecond: 1 },
+    }))).toBe(false);
+  });
+
+  it('stays quiet before any snapshot arrives, and in a browser', () => {
+    expect(shouldPrompt(null)).toBe(false);
+  });
+
+  it('stays quiet for a dismissed version but not for a newer one', () => {
+    expect(shouldPrompt(snap({
+      dismissedVersion: '1.0.4', status: { phase: 'available', version: '1.0.4' },
+    }))).toBe(false);
+    expect(shouldPrompt(snap({
+      dismissedVersion: '1.0.4', status: { phase: 'available', version: '1.0.5' },
+    }))).toBe(true);
+  });
+
+  it('stays quiet for a check failure that never learned a version', () => {
+    expect(shouldPrompt(snap({
+      status: { phase: 'failed', version: null, message: 'getaddrinfo ENOTFOUND' },
+    }))).toBe(false);
+  });
+});
+
+describe('canRestartToInstall', () => {
+  it('is true only for a staged update on an auto-capable build', () => {
+    expect(canRestartToInstall(snap({ capability: 'auto', status: { phase: 'ready', version: '1.0.4' } }))).toBe(true);
+  });
+
+  it('is false on an ad-hoc signed build, which is what removes the dead button', () => {
+    expect(canRestartToInstall(snap({ capability: 'manual', status: { phase: 'ready', version: '1.0.4' } }))).toBe(false);
+  });
+
+  it('is false for any other phase, and before a snapshot exists', () => {
+    expect(canRestartToInstall(snap({ status: { phase: 'available', version: '1.0.4' } }))).toBe(false);
+    expect(canRestartToInstall(null)).toBe(false);
+  });
+});

--- a/packages/web/src/stores/updateStore.ts
+++ b/packages/web/src/stores/updateStore.ts
@@ -1,0 +1,302 @@
+import { create } from 'zustand';
+import { isElectron } from '../platform/platform';
+
+/**
+ * Desktop update state for the renderer.
+ *
+ * The main process owns the truth: whether this build can install its own
+ * updates, which version the user already waved away, and where the updater is.
+ * This store mirrors that one snapshot and exposes the actions. It deliberately
+ * holds no opinion about code signing, platforms, or Squirrel.
+ *
+ * Two compatibility facts shape this file:
+ *
+ *  1. The desktop app and the instance it connects to version independently. A
+ *     client served by a newer instance can be running inside an older desktop
+ *     app that has no snapshot API, so every call is feature-detected and there
+ *     is a legacy path that reconstructs the same state from the old per-event
+ *     channels.
+ *  2. The snapshot arrives over IPC as `unknown`. It is validated here rather
+ *     than trusted, because "an older app sent a different shape" is a real
+ *     case, not a hypothetical one.
+ */
+
+export interface UpdateStoreState {
+  /** Null until the first snapshot arrives, or forever outside Electron. */
+  snapshot: DesktopUpdateSnapshot | null;
+  /** The running app's version, for copy like "You are on 1.0.3". */
+  currentVersion: string | null;
+  /**
+   * True when the host app predates the snapshot API. Dismissal then lives only
+   * for this session, because the old app has nowhere to persist it.
+   */
+  legacyBridge: boolean;
+
+  /** Subscribes to the main process. Returns a teardown. Safe to call twice. */
+  initialize: () => () => void;
+  dismiss: () => void;
+  install: () => void;
+  openDownloadPage: () => void;
+  checkNow: () => void;
+}
+
+/**
+ * Validates an IPC payload into a snapshot, or returns null.
+ *
+ * Exported for tests. Every field is checked because a malformed snapshot must
+ * degrade to "no update surface" rather than render a card with `undefined` in
+ * it or throw during a render pass.
+ */
+export function coerceSnapshot(value: unknown): DesktopUpdateSnapshot | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const raw = value as Record<string, unknown>;
+
+  const capability = raw.capability;
+  if (capability !== 'auto' && capability !== 'manual') return null;
+
+  const dismissedVersion = raw.dismissedVersion;
+  if (dismissedVersion !== null && typeof dismissedVersion !== 'string') return null;
+
+  const status = coerceStatus(raw.status);
+  if (status === null) return null;
+
+  return { capability, dismissedVersion, status };
+}
+
+function coerceStatus(value: unknown): DesktopUpdateStatus | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const raw = value as Record<string, unknown>;
+  const version = typeof raw.version === 'string' ? raw.version : null;
+
+  switch (raw.phase) {
+    case 'idle':
+      return { phase: 'idle' };
+    case 'checking':
+      return { phase: 'checking' };
+    case 'available':
+      return version === null ? null : { phase: 'available', version };
+    case 'downloading':
+      if (version === null) return null;
+      return {
+        phase: 'downloading',
+        version,
+        percent: typeof raw.percent === 'number' && Number.isFinite(raw.percent) ? raw.percent : 0,
+        bytesPerSecond:
+          typeof raw.bytesPerSecond === 'number' && Number.isFinite(raw.bytesPerSecond)
+            ? raw.bytesPerSecond
+            : 0,
+      };
+    case 'ready':
+      return version === null ? null : { phase: 'ready', version };
+    case 'failed':
+      return {
+        phase: 'failed',
+        version,
+        message: typeof raw.message === 'string' ? raw.message : 'The update failed.',
+      };
+    case 'up-to-date':
+      return {
+        phase: 'up-to-date',
+        checkedAt: typeof raw.checkedAt === 'number' ? raw.checkedAt : 0,
+      };
+    default:
+      return null;
+  }
+}
+
+/** The version a status is about, or null when it carries none. */
+export function statusVersion(status: DesktopUpdateStatus): string | null {
+  switch (status.phase) {
+    case 'available':
+    case 'downloading':
+    case 'ready':
+      return status.version;
+    case 'failed':
+      return status.version;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Whether the toast should interrupt the user.
+ *
+ * Mirrors `shouldPromptForUpdate` in the desktop package, which is also what the
+ * native notification asks. Keeping the rule identical on both sides is what
+ * stops the OS notification and the in-app card disagreeing about "later".
+ *
+ * `checking`, `downloading` and `up-to-date` are progress, not news. A chat
+ * client has no business throwing a card over the message list to report them.
+ */
+export function shouldPrompt(snapshot: DesktopUpdateSnapshot | null): boolean {
+  if (snapshot === null) return false;
+  const { status, dismissedVersion } = snapshot;
+  if (status.phase !== 'available' && status.phase !== 'ready' && status.phase !== 'failed') {
+    return false;
+  }
+  const version = statusVersion(status);
+  // A check that failed before it learned a version has nothing actionable to
+  // offer. It belongs in settings, not in the user's face.
+  if (version === null) return false;
+  return version !== dismissedVersion;
+}
+
+/**
+ * Whether to offer a Restart button.
+ *
+ * False on a build that cannot install in place, which is what removes the dead
+ * button. `ready` on a manual-capability build should not happen (the download
+ * never starts), but it is handled rather than assumed away.
+ */
+export function canRestartToInstall(snapshot: DesktopUpdateSnapshot | null): boolean {
+  return snapshot?.capability === 'auto' && snapshot.status.phase === 'ready';
+}
+
+// Refcounted so the toast and the settings panel can both subscribe, and so
+// React StrictMode's double-invoked effects do not double-register listeners.
+let subscriberCount = 0;
+let teardown: (() => void) | null = null;
+
+export const useUpdateStore = create<UpdateStoreState>((set, get) => ({
+  snapshot: null,
+  currentVersion: null,
+  legacyBridge: false,
+
+  initialize: () => {
+    subscriberCount += 1;
+
+    if (subscriberCount === 1) {
+      teardown = startBridge(set);
+    }
+
+    return () => {
+      subscriberCount -= 1;
+      if (subscriberCount === 0 && teardown) {
+        teardown();
+        teardown = null;
+      }
+    };
+  },
+
+  dismiss: () => {
+    const snapshot = get().snapshot;
+    const version = snapshot ? statusVersion(snapshot.status) : null;
+    if (version === null || snapshot === null) return;
+
+    const api = window.backspace;
+    if (api?.dismissUpdate) {
+      // The main process persists it and echoes a new snapshot back, so the
+      // store is not updated optimistically here. If the write fails, the
+      // prompt honestly stays rather than silently vanishing.
+      api.dismissUpdate(version);
+      return;
+    }
+
+    // Legacy host: no persistence available, so hold it for this session only.
+    set({ snapshot: { ...snapshot, dismissedVersion: version } });
+  },
+
+  install: () => {
+    window.backspace?.installUpdate();
+  },
+
+  openDownloadPage: () => {
+    const api = window.backspace;
+    if (api?.openReleasePage) {
+      api.openReleasePage();
+      return;
+    }
+    // Older host with no dedicated channel. The renderer's window.open is
+    // intercepted by setWindowOpenHandler and routed to the default browser.
+    window.open('https://github.com/TheZwiss/backspace/releases/latest', '_blank', 'noopener');
+  },
+
+  checkNow: () => {
+    window.backspace?.checkForUpdates();
+  },
+}));
+
+type SetState = (
+  partial:
+    | Partial<UpdateStoreState>
+    | ((state: UpdateStoreState) => Partial<UpdateStoreState>),
+) => void;
+
+/**
+ * Wires the store to the host app, and returns a teardown.
+ *
+ * Outside Electron this does nothing at all, so the browser client never
+ * renders an update surface.
+ */
+function startBridge(set: SetState): () => void {
+  if (!isElectron() || !window.backspace) return () => {};
+  const api = window.backspace;
+
+  api.getVersion()
+    .then((version) => set({ currentVersion: version }))
+    .catch(() => { /* version is decoration; its absence changes no behaviour */ });
+
+  if (api.getUpdateStatus && api.onUpdateStatusChanged) {
+    const unsubscribe = api.onUpdateStatusChanged((raw) => {
+      const snapshot = coerceSnapshot(raw);
+      if (snapshot !== null) set({ snapshot });
+    });
+
+    api.getUpdateStatus()
+      .then((raw) => {
+        const snapshot = coerceSnapshot(raw);
+        if (snapshot !== null) set({ snapshot });
+      })
+      .catch(() => { /* a live snapshot will arrive on the next updater event */ });
+
+    return unsubscribe;
+  }
+
+  return startLegacyBridge(set, api);
+}
+
+/**
+ * Reconstructs a snapshot from the pre-1.0.5 per-event channels.
+ *
+ * Those channels have no cleanup functions, so the listeners registered here
+ * outlive the teardown. That is why the bridge is refcounted and started once:
+ * a leak of one listener per app lifetime is acceptable, a leak per mount is
+ * not.
+ *
+ * Capability is reported as `auto` because that is what the old app behaved
+ * like. It always offered Restart. The one thing this path does fix on an old
+ * host is the ordering bug: a failure arriving after a ready state now wins,
+ * instead of hiding behind it.
+ */
+function startLegacyBridge(set: SetState, api: BackspaceElectronAPI): () => void {
+  let disposed = false;
+  set({ legacyBridge: true });
+
+  api.onUpdateDownloaded((info) => {
+    if (disposed) return;
+    set({
+      snapshot: {
+        capability: 'auto',
+        dismissedVersion: null,
+        status: { phase: 'ready', version: info.version },
+      },
+    });
+  });
+
+  api.onUpdateError((error) => {
+    if (disposed) return;
+    set((prev) => ({
+      snapshot: {
+        capability: 'auto',
+        dismissedVersion: prev.snapshot?.dismissedVersion ?? null,
+        status: {
+          phase: 'failed',
+          version: prev.snapshot ? statusVersion(prev.snapshot.status) : null,
+          message: error.message,
+        },
+      },
+    }));
+  });
+
+  return () => { disposed = true; };
+}

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# ============================================================
+# Backspace — update a running instance
+# ============================================================
+# Takes a database snapshot, refreshes the checkout where that is possible,
+# fetches the new image, restarts only the backspace service, waits for it to
+# report healthy, and then verifies the running version actually changed. If any
+# of that fails, it puts the previous image back.
+#
+# Usage:
+#   ./update.sh              Update, with one confirmation prompt.
+#   ./update.sh --check      Report whether an update exists. Changes nothing.
+#   ./update.sh --yes        Update without prompting (for ssh and cron).
+#   ./update.sh --no-backup  Skip the pre-update snapshot. Not recommended.
+#
+# Only the `backspace` service is ever named, and --remove-orphans is never
+# passed. Production hosts run other containers in the same compose project and
+# behind the same Caddy; an update to Backspace has no business recreating or
+# reaping any of them.
+# ============================================================
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# ── Output helpers (matching install.sh) ────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+success() { echo -e "${GREEN}  OK ${NC} $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERR]${NC} $*" >&2; }
+step()    { echo ""; echo -e "${BOLD}${CYAN}─── $* ───${NC}"; echo ""; }
+
+SERVICE="backspace"
+CONTAINER="backspace"
+HEALTH_TIMEOUT=180
+RELEASES_API="https://api.github.com/repos/TheZwiss/backspace/releases/latest"
+
+MODE="update"
+ASSUME_YES=false
+DO_BACKUP=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)     MODE="check" ;;
+    --yes|-y)    ASSUME_YES=true ;;
+    --no-backup) DO_BACKUP=false ;;
+    --help|-h)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1"
+      error "Run ./update.sh --help for usage."
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# ── Reading .env ────────────────────────────────────────────
+# Same shape as install.sh's env_val: read a single value without sourcing the
+# file, so a stray shell metacharacter in a value cannot execute anything.
+
+env_val() {
+  if [[ -f .env ]]; then
+    grep "^${1}=" .env 2>/dev/null | head -1 | cut -d= -f2- || true
+  fi
+}
+
+# ── Phase 1: Preflight ──────────────────────────────────────
+
+step "Checking this install"
+
+if ! command -v docker >/dev/null 2>&1; then
+  error "docker is not installed, or is not on PATH."
+  exit 1
+fi
+
+DOCKER="docker"
+COMPOSE="docker compose"
+if ! docker info >/dev/null 2>&1; then
+  if sudo docker info >/dev/null 2>&1; then
+    DOCKER="sudo docker"
+    COMPOSE="sudo docker compose"
+    info "Using sudo for Docker commands."
+  else
+    error "Cannot connect to the Docker daemon."
+    error "Is Docker running? Try: sudo systemctl start docker"
+    exit 1
+  fi
+fi
+
+if ! $COMPOSE version >/dev/null 2>&1; then
+  error "'docker compose' is unavailable. This script needs Compose v2."
+  error "On older hosts, upgrade Docker or install the compose plugin."
+  exit 1
+fi
+
+if [[ ! -f .env ]]; then
+  error "No .env in $(pwd)."
+  error "Run this from your Backspace install directory, or ./install.sh first."
+  exit 1
+fi
+
+if [[ ! -f docker-compose.yml ]]; then
+  error "No docker-compose.yml in $(pwd)."
+  exit 1
+fi
+
+# Membership is tested in bash rather than by piping into `grep -q`.
+# `grep -q` exits on its first match, which SIGPIPEs the upstream command, and
+# under `set -o pipefail` that turns a passing check into a failing one. It
+# reported "no backspace service" against a compose file whose first listed
+# service is backspace.
+contains_line() {
+  local haystack="$1" needle="$2"
+  [[ $'\n'"$haystack"$'\n' == *$'\n'"$needle"$'\n'* ]]
+}
+
+# COMPOSE_FILE lives in .env, and docker compose reads it from there, so proxy
+# and tunnel installs resolve both files with no -f flags here.
+compose_services="$($COMPOSE config --services 2>/dev/null || true)"
+if ! contains_line "$compose_services" "$SERVICE"; then
+  error "The compose project here defines no '$SERVICE' service."
+  error "Check COMPOSE_FILE in .env, and that you are in the right directory."
+  exit 1
+fi
+
+running_containers="$($DOCKER ps --format '{{.Names}}' 2>/dev/null || true)"
+if ! contains_line "$running_containers" "$CONTAINER"; then
+  error "The $CONTAINER container is not running."
+  error "Start it first with: $COMPOSE up -d $SERVICE"
+  exit 1
+fi
+
+success "Compose project and running container found"
+
+# ── Reading the running instance ────────────────────────────
+
+# Asks the app itself rather than inferring from a tag. This is the value the
+# update has to move, and step 9 is the only check that catches a container that
+# comes up healthy while still running the old code.
+running_version() {
+  $DOCKER exec "$CONTAINER" node -e '
+    const port = process.env.PORT || 3000;
+    fetch("http://localhost:" + port + "/api/instance/info")
+      .then((r) => r.json())
+      .then((j) => { process.stdout.write(String(j.version || "")); })
+      .catch(() => { process.exit(1); });
+  ' 2>/dev/null || true
+}
+
+CURRENT_VERSION="$(running_version)"
+if [[ -z "$CURRENT_VERSION" ]]; then
+  warn "Could not read the running version from the container."
+  warn "The update will proceed, but the post-update version check is skipped."
+fi
+
+# The image this container was created from. This exact ID is the rollback
+# target, and comparing it after the pull is how a no-op update is detected.
+ROLLBACK_IMAGE_ID="$($DOCKER inspect --format '{{.Image}}' "$CONTAINER" 2>/dev/null || true)"
+IMAGE_REF="$($DOCKER inspect --format '{{.Config.Image}}' "$CONTAINER" 2>/dev/null || true)"
+
+if [[ -z "$ROLLBACK_IMAGE_ID" || -z "$IMAGE_REF" ]]; then
+  error "Could not determine the image the $CONTAINER container is running."
+  error "Refusing to update without a rollback target."
+  exit 1
+fi
+
+# The reference compose will actually deploy, which is not necessarily the one
+# the running container was created from. An operator who repins
+# BACKSPACE_IMAGE_TAG in .env changes the former without touching the latter, so
+# rolling back against the running container's reference would restore the old
+# image under a name compose no longer looks at, and the failed version would
+# come straight back up.
+target_ref_raw="$($COMPOSE config --images "$SERVICE" 2>/dev/null || true)"
+TARGET_REF="${target_ref_raw%%$'\n'*}"
+if [[ -z "$TARGET_REF" ]]; then
+  TARGET_REF="$IMAGE_REF"
+  info "Could not resolve the target image from compose; using $TARGET_REF."
+fi
+
+# prebuilt | source | unknown. install.sh records this after its pull/build
+# decision resolves. Absent on installs that predate that, which map to unknown
+# and are handled by looking at the image reference instead.
+INSTALL_CHANNEL="$(env_val BACKSPACE_INSTALL_CHANNEL)"
+if [[ -z "$INSTALL_CHANNEL" ]]; then
+  if [[ "$IMAGE_REF" == *"/"*"/"* || "$IMAGE_REF" == ghcr.io/* || "$IMAGE_REF" == *.*/* ]]; then
+    INSTALL_CHANNEL="prebuilt"
+  else
+    INSTALL_CHANNEL="unknown"
+  fi
+  info "No BACKSPACE_INSTALL_CHANNEL in .env; inferred '$INSTALL_CHANNEL' from $IMAGE_REF."
+fi
+
+echo ""
+echo -e "  Running version   ${BOLD}${CURRENT_VERSION:-unknown}${NC}"
+echo -e "  Image             ${IMAGE_REF}"
+if [[ "$TARGET_REF" != "$IMAGE_REF" ]]; then
+  echo -e "  Target image      ${TARGET_REF}  ${YELLOW}(repinned in .env)${NC}"
+fi
+echo -e "  Install channel   ${INSTALL_CHANNEL}"
+
+# ── --check: report and exit, touching nothing ──────────────
+
+if [[ "$MODE" == "check" ]]; then
+  step "Checking for a newer release"
+
+  fetch_url() {
+    if command -v curl >/dev/null 2>&1; then
+      curl -fsSL --max-time 10 -H 'Accept: application/vnd.github+json' \
+        -H 'User-Agent: Backspace' "$1" 2>/dev/null || true
+    elif command -v wget >/dev/null 2>&1; then
+      wget -qO- --timeout=10 --header='Accept: application/vnd.github+json' \
+        --header='User-Agent: Backspace' "$1" 2>/dev/null || true
+    fi
+  }
+
+  if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+    warn "Neither curl nor wget is available, so the latest release cannot be looked up."
+    warn "Run ./update.sh to pull whatever the registry currently serves."
+    exit 0
+  fi
+
+  body="$(fetch_url "$RELEASES_API")"
+  # Extracted in stages rather than one pipeline, for the same pipefail reason
+  # as contains_line above: `head -1` exits early and SIGPIPEs `grep`.
+  tag_matches="$(printf '%s' "$body" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' || true)"
+  latest="${tag_matches%%$'\n'*}"   # first match only
+  latest="${latest%\"}"             # drop the closing quote
+  latest="${latest##*\"}"           # then everything before the opening one
+  latest="${latest#v}"
+
+  if [[ -z "$latest" ]]; then
+    warn "Could not reach GitHub to look up the latest release."
+    warn "This says nothing about whether an update exists."
+    exit 0
+  fi
+
+  if [[ -z "$CURRENT_VERSION" ]]; then
+    info "Latest release is $latest. The running version could not be read, so no comparison was made."
+  elif [[ "$latest" == "$CURRENT_VERSION" ]]; then
+    success "You are on the latest release ($CURRENT_VERSION)."
+  else
+    echo ""
+    echo -e "  ${BOLD}Backspace $latest is available.${NC} You are on $CURRENT_VERSION."
+    echo -e "  Release notes: https://github.com/TheZwiss/backspace/releases/tag/v${latest}"
+    echo ""
+    echo -e "  Update with: ${BOLD}./update.sh${NC}"
+  fi
+  echo ""
+  info "Nothing was changed."
+  exit 0
+fi
+
+# ── Confirmation ────────────────────────────────────────────
+
+if [[ "$ASSUME_YES" != true ]]; then
+  if [[ ! -t 0 ]]; then
+    error "Not running interactively and --yes was not given."
+    error "Re-run as: ./update.sh --yes"
+    exit 1
+  fi
+  echo ""
+  echo "This will snapshot the database, fetch the newest image, and restart"
+  echo "the $SERVICE service. Other containers are left alone. Clients reconnect"
+  echo "on their own."
+  read -rp "Continue? [y/N] " yn
+  [[ "${yn,,}" == "y" ]] || { echo "Aborted. Nothing was changed."; exit 0; }
+fi
+
+# ── Phase 2: Refresh the checkout, tolerantly ───────────────
+
+step "Refreshing the checkout"
+
+if [[ ! -d .git ]]; then
+  info "Not a git checkout, so there is nothing to pull."
+  info "That is normal for an rsync-deployed host. The image update below still applies."
+elif ! git rev-parse --git-dir >/dev/null 2>&1; then
+  warn "A .git directory exists but git cannot read it. Skipping the pull."
+elif ! git diff --quiet HEAD 2>/dev/null; then
+  warn "This checkout has uncommitted changes, so it will not be pulled."
+  warn "Your local edits are untouched. The image update below still applies."
+elif ! git remote get-url origin >/dev/null 2>&1; then
+  warn "No 'origin' remote configured. Skipping the pull."
+elif git pull --ff-only 2>&1 | sed 's/^/       /'; then
+  success "Checkout is up to date"
+else
+  warn "Could not fast-forward this checkout, most likely because it has diverged."
+  warn "Nothing was rewritten. Resolve it by hand later if you want the newest"
+  warn "compose files and scripts. The image update below still applies."
+fi
+
+# ── Phase 3: Back up ────────────────────────────────────────
+# The one step whose failure is fatal. Everything after it is only safe to
+# attempt because it happened.
+
+step "Backing up the database"
+
+if [[ "$DO_BACKUP" != true ]]; then
+  warn "--no-backup given, so no snapshot was taken."
+elif [[ ! -x ./backup.sh ]]; then
+  error "./backup.sh is missing or not executable, so no snapshot can be taken."
+  error "Re-run with --no-backup if you have a backup by other means."
+  exit 1
+elif ./backup.sh; then
+  success "Snapshot written to data/backups/"
+else
+  error "The backup failed, so the update was not attempted."
+  error "Nothing was changed."
+  exit 1
+fi
+
+# ── Phase 4: Fetch the new image ────────────────────────────
+
+step "Fetching the new image"
+
+case "$INSTALL_CHANNEL" in
+  source)
+    info "From-source install: rebuilding $SERVICE."
+    build_commit=""
+    if git rev-parse --short HEAD >/dev/null 2>&1; then
+      build_commit="$(git rev-parse --short HEAD)"
+    fi
+    # AGPL-3.0 § 13: bake the commit so /api/instance/info advertises the exact
+    # build, the same way deploy.sh and install.sh do.
+    if ! $COMPOSE build --build-arg BACKSPACE_COMMIT="$build_commit" "$SERVICE"; then
+      error "The build failed. Nothing was restarted, so your instance is untouched."
+      exit 1
+    fi
+    ;;
+  *)
+    info "Prebuilt-image install: pulling $TARGET_REF."
+    if ! $COMPOSE pull "$SERVICE"; then
+      error "The pull failed. Nothing was restarted, so your instance is untouched."
+      exit 1
+    fi
+    ;;
+esac
+
+NEW_IMAGE_ID="$($DOCKER image inspect --format '{{.Id}}' "$TARGET_REF" 2>/dev/null || true)"
+
+# ── Phase 5: Skip a no-op ───────────────────────────────────
+# Restarting a chat server for nothing drops everyone in a voice call.
+
+if [[ -n "$NEW_IMAGE_ID" && "$NEW_IMAGE_ID" == "$ROLLBACK_IMAGE_ID" ]]; then
+  echo ""
+  success "Already running the newest image. Nothing to restart."
+  info "Version ${CURRENT_VERSION:-unknown} is current for $TARGET_REF."
+  exit 0
+fi
+
+# ── Phase 6 and 7: Restart, then wait for healthy ───────────
+
+wait_for_healthy() {
+  local deadline=$(( SECONDS + HEALTH_TIMEOUT ))
+  local status=""
+  while (( SECONDS < deadline )); do
+    status="$($DOCKER inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$CONTAINER" 2>/dev/null || echo "gone")"
+    case "$status" in
+      healthy) return 0 ;;
+      none)
+        # No healthcheck defined on this service. Fall back to "running".
+        if [[ "$($DOCKER inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)" == "true" ]]; then
+          return 0
+        fi
+        ;;
+    esac
+    sleep 3
+  done
+  return 1
+}
+
+roll_back() {
+  echo ""
+  warn "Rolling back to the image you were running before."
+  # Re-point the reference compose deploys at the previous image ID, then let
+  # compose recreate from it.
+  if ! $DOCKER tag "${ROLLBACK_IMAGE_ID#sha256:}" "$TARGET_REF"; then
+    error "Could not re-tag the previous image. Roll back by hand:"
+    error "  $DOCKER tag ${ROLLBACK_IMAGE_ID#sha256:} $TARGET_REF"
+    error "  $COMPOSE up -d $SERVICE"
+    return 1
+  fi
+  if ! $COMPOSE up -d "$SERVICE"; then
+    error "Could not restart the previous image. Check: $COMPOSE logs $SERVICE"
+    return 1
+  fi
+  if wait_for_healthy; then
+    success "Rolled back to version ${CURRENT_VERSION:-the previous build}"
+    echo ""
+    warn "The local tag $TARGET_REF now points at the image you were running,"
+    warn "not at what the registry serves under that name. Once the problem is"
+    warn "fixed, restore it with: $COMPOSE pull $SERVICE"
+    return 0
+  fi
+  error "The previous image did not come back healthy either."
+  error "Check: $COMPOSE logs $SERVICE"
+  error "Restore the database with: ./restore.sh"
+  return 1
+}
+
+step "Restarting $SERVICE"
+
+# The service is named explicitly and --remove-orphans is never passed, so
+# co-hosted containers in this project are not recreated or reaped.
+if ! $COMPOSE up -d "$SERVICE"; then
+  error "The restart failed."
+  roll_back || true
+  exit 1
+fi
+
+info "Waiting up to ${HEALTH_TIMEOUT}s for $CONTAINER to report healthy..."
+if ! wait_for_healthy; then
+  error "$CONTAINER did not become healthy within ${HEALTH_TIMEOUT}s."
+  # Container state first. A container that exited produces no logs worth
+  # tailing, and "exited with code 1" is the answer in that case.
+  error "Container state: $($DOCKER inspect --format '{{.State.Status}} (exit code {{.State.ExitCode}})' "$CONTAINER" 2>/dev/null || echo unknown)"
+  # The health probe output says why the check failed, which the service logs
+  # often do not. During the rollback rehearsal the logs were empty and this was
+  # the only line that explained anything.
+  probe="$($DOCKER inspect --format '{{range .State.Health.Log}}{{.Output}}{{end}}' "$CONTAINER" 2>/dev/null || true)"
+  if [[ -n "${probe// /}" ]]; then
+    error "Last health probe output:"
+    printf '%s\n' "$probe" | sed 's/^/       /'
+  fi
+  error "Recent logs:"
+  $COMPOSE logs --tail 40 "$SERVICE" 2>&1 | sed 's/^/       /' || true
+  roll_back || true
+  exit 1
+fi
+
+success "Container is healthy"
+
+# ── Phase 8: Verify the version actually moved ──────────────
+# A container that is healthy but still serving the old code is a failed update,
+# and this is the only check that catches it.
+
+step "Verifying the running version"
+
+NEW_VERSION="$(running_version)"
+
+if [[ -z "$CURRENT_VERSION" ]]; then
+  warn "The pre-update version was unreadable, so there is nothing to compare against."
+  success "Backspace is running version ${NEW_VERSION:-unknown}"
+elif [[ -z "$NEW_VERSION" ]]; then
+  error "The container is healthy but did not report a version."
+  roll_back || true
+  exit 1
+elif [[ "$NEW_VERSION" == "$CURRENT_VERSION" ]]; then
+  error "The container came up healthy but still reports version $CURRENT_VERSION."
+  error "The new image did not take effect."
+  roll_back || true
+  exit 1
+else
+  success "Updated from $CURRENT_VERSION to $NEW_VERSION"
+fi
+
+echo ""
+echo -e "${BOLD}Done.${NC}"
+echo "  Snapshot:  data/backups/  (restore with ./restore.sh)"
+echo "  Logs:      $COMPOSE logs -f $SERVICE"
+echo ""


### PR DESCRIPTION
## The bug

On macOS the app showed "Update ready" with a Restart button that did nothing.
Dismissing it revealed "Update failed", and the whole cycle repeated on every
launch. Nothing ever asked whether the user wanted to see it again.

## Root cause

Our macOS builds are ad-hoc signed, so the bundle's designated requirement is a
literal cdhash of that exact binary. Read off a shipped 1.0.3 build:

```
$ codesign -d -r- /Applications/Backspace.app
# designated => cdhash H"4a9e49fe20f82802702a4e9d752748e990909659"
```

Squirrel.Mac validates a staged update against the running app's designated
requirement. A later build has a different cdhash, so it can never satisfy that.
This is not intermittent, and it is not fixable without a real signing identity.

Two more defects follow from it:

1. `MacUpdater.doDownloadUpdate()` fires `update-downloaded` **inside its
   `server.listen` callback**, before Squirrel is asked to do anything. On macOS
   that event means "the archive is on disk", not "this can be installed". We
   rendered a Restart button off it.
2. `quitAndInstall()` then takes a branch that registers a listener for an event
   that never fires and returns. No error, no exception, no restart.

The error toast stayed hidden because `UpdateToast` held two independent state
values and checked the ready one first in render.

## What this changes

**Desktop.** The main process measures its own signature with `codesign -d -r-`
instead of hardcoding a platform. A bare cdhash reports `manual`, a
certificate-anchored requirement reports `auto`, anything unreadable reports
`manual`. **When a Developer ID lands in CI this flips to `auto` with no code
change.** In manual mode `autoDownload` is off, so the app stops fetching a
release archive it can never apply (228 MB per machine, stored twice, refetched
on every check), and archives already stranded are reclaimed at startup. One
status union replaces the two racing flags, so a failure arriving after a ready
state wins. Dismissal persists per version in userData, not localStorage,
because an available update belongs to the app rather than to whichever instance
the user is connected to. `download-progress` is wired for the first time, and
the settings "Checking..." state comes from real events instead of a five second
timer. The recovery surface gained an `available-manual` state so a user whose
app will not start is offered a download rather than a dead Restart button.

**Operator side.** `update.sh` snapshots the database, refreshes the checkout
where possible, fetches the new image, restarts only the `backspace` service,
waits for the healthcheck, and **verifies the running version actually changed**,
rolling back to the previous image if it did not. A no-op update skips the
restart entirely, because restarting a chat server for nothing drops everyone in
a voice call. The service is always named and `--remove-orphans` is never
passed: compose suggests that flag on hosts running other containers, and
following it deletes them.

**Admin.** `GET /api/admin/instance/update-status` and an Instance, Updates
panel showing the running version, commit, install channel, and the exact
command for that install. **There is no background poller.** The GitHub lookup
runs only while an admin has the panel open and the six hour cache is cold, so
an instance whose admin never opens it never contacts github.com.
`BACKSPACE_UPDATE_CHECK=false` turns it off entirely.

There is deliberately **no button that applies the update**. Doing that from
inside the container requires mounting `/var/run/docker.sock`, which grants the
container root on the host. Backspace parses uploaded media, scrapes URLs for
embeds, and accepts federation payloads from remote instances, so any RCE in it
would become host root the moment that socket exists.

## Compatibility

The desktop app and the instance it connects to version independently in both
directions, so:

- the legacy `update-available` / `update-downloaded` / `update-error` channels
  are kept, because a newer app can be pointed at an older instance serving a
  client that calls them;
- the new snapshot methods are declared optional and every call site feature
  detects, because a client from a newer instance can run inside an older app.

## Verification

- 1836 unit tests pass (136 desktop, 580 web, 1120 server). `tsc --noEmit` clean
  in all three packages, `pnpm -w build` succeeds, shellcheck clean on
  `update.sh` and `install.sh`.
- **`update.sh` rehearsed on real hardware**: a real update, a no-op re-run that
  correctly declined to restart, and a deliberately broken update (image
  repinned at `alpine:3.20`) that failed the 180s health gate and rolled back to
  a healthy instance on the previous image. Co-hosted containers untouched.
- **The capability probe checked against real apps**: it classifies our ad-hoc
  signed build as `manual` and a real Developer ID signed app as `auto`.
- **The endpoint exercised against a live server and the real GitHub API**: 401
  unauthenticated, 403 non-admin, cache hit proven by an identical `checkedAt`,
  `?refresh=true` proven by a changed one, and `BACKSPACE_UPDATE_CHECK=false`
  proven to open no socket even with `?refresh=true`.
- Every UI state rendered and reviewed.

## Known gap

`update.sh`'s from-source branch (`docker compose build`) is written and
shellcheck clean but has not been run on real hardware, because the test host is
a prebuilt install. The prebuilt path is fully rehearsed.

## Docs

`desktop.md`, `desktop-security.md`, `admin.md`, `api.md`, `deployment.md`,
`README.md`, and `.env.example` all updated. Design spec and plan under
`docs/superpowers/`.
