### PR TITLE
docs(contributing): set expectations on review size and runtime evidence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,8 @@ Closes #
 - [ ] `pnpm build` succeeds (shared types, server, and web all build)
 - [ ] `pnpm dev` starts the server and web client without errors
 - [ ] Tests pass where applicable (`pnpm test`)
+- [ ] I ran the change myself, and attached evidence (screenshot, recording, or
+      terminal output) if it affects packaging, installation, or the UI
 - [ ] I updated the relevant `docs/systems/` spec if this changed schema, API routes, WebSocket events, the federation protocol, permissions, or the design system
 - [ ] This change resolves the correct federated identity where it compares IDs, checks permissions, or talks to remote servers (no assumption of a single global user ID)
 - [ ] I have read and agree to the [CLA](../CLA.md) — ticking this box is not the
@@ -27,4 +29,5 @@ Closes #
 
 ## Notes for reviewers
 
-<!-- Anything that helps review: screenshots for UI, migration notes, edge cases, follow-ups. -->
+<!-- Anything that helps review: screenshots for UI, migration notes, edge cases, follow-ups.
+     For packaging or platform work, say which OS and desktop environment you ran it on. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,16 @@ sizes are welcome: bug reports, fixes, features, documentation, and design.
   something that conflicts with planned direction. Small fixes can go straight
   to a pull request.
 - **One logical change per pull request.** Keep diffs focused and reviewable.
+- **Keep pull requests small enough to review.** Review capacity is the
+  bottleneck on this project, not authoring capacity. A change touching a
+  hundred files waits longer than five changes touching twenty, and may be asked
+  to split. If something is genuinely large and indivisible, agree the shape on
+  an issue before writing it.
+- **You own your diff.** Use whatever tools you like, including AI assistants;
+  nobody will ask. What matters is that you can explain any line of it, that you
+  have run it, and that it does not contain two solutions to the same problem
+  sitting side by side. Code the author has not read is the only kind of
+  contribution that costs more to review than it did to write.
 
 ## Contributor License Agreement (required)
 
@@ -82,6 +92,18 @@ it.
 - **Complete implementations only.** No placeholder code, no `TODO` stubs, no
   partial components. Handle the error and edge cases.
 
+## Packaging, platform, and UI changes need evidence
+
+A build that compiles is not a build that runs. If a change affects how the app
+is packaged, installed, sandboxed, or launched (Electron builds, Flatpak, Docker,
+installers, the desktop shell), run the result and show it: a screenshot, a short
+recording, or a terminal session, and say which OS and desktop environment. UI
+work is the same, with a screenshot of the changed surface.
+
+Automated checks cover the scriptable part. Whether the app actually starts,
+finds its tray icon, shows a notification, or can open a file is not scriptable,
+and it is the part that breaks.
+
 ## Before you open a pull request
 
 - `pnpm build` succeeds (shared types, server, and web all build).
@@ -90,6 +112,8 @@ it.
 - You updated the relevant `docs/systems/` spec if your change altered schema,
   API routes, WebSocket events, the federation protocol, permissions, or the
   design system.
+- You ran the thing you changed, and attached evidence if it affects packaging,
+  installation, or the UI (see above).
 
 ## Reporting bugs and requesting features
 


### PR DESCRIPTION
## What this changes

Adds two things CONTRIBUTING.md and the pull request template were missing, both of which surfaced while reviewing #48.

**Runtime evidence for packaging work.** Nothing asked contributors to run what they changed. The existing checklist covers `pnpm build`, `pnpm dev` and tests, which is the scriptable half. For packaging, installer, sandbox and desktop shell changes, the half that breaks is whether the app starts, finds its tray icon, shows a notification and can open a file, and CI cannot reach any of it. #48 built cleanly in a headless container and was never launched. Those changes now have to be run and shown, naming the OS and desktop environment.

**Review size.** "One logical change per pull request" says nothing about scale. Review capacity is the constraint on this project rather than authoring capacity, so large changes are now asked to agree their shape on an issue first, and may be asked to split.

It also states the tooling position outright, since it is better written down than assumed in either direction: use whatever tools you like, including AI assistants, and own the result. The requirement is that the author can explain the diff, has run it, and has not left two solutions to the same problem sitting side by side.

No code changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Other

## Checklist

- [x] `pnpm build` succeeds (shared types, server, and web all build)
- [x] `pnpm dev` starts the server and web client without errors
- [x] Tests pass where applicable (`pnpm test`)
- [x] I ran the change myself, and attached evidence (screenshot, recording, or terminal output) if it affects packaging, installation, or the UI
- [x] I updated the relevant `docs/systems/` spec if this changed schema, API routes, WebSocket events, the federation protocol, permissions, or the design system
- [x] This change resolves the correct federated identity where it compares IDs, checks permissions, or talks to remote servers (no assumption of a single global user ID)

## Notes for reviewers

Documentation only, so the build and test boxes are unaffected by it. The new checklist item is added to the template it describes, which is why this pull request already carries it.
