### PR TITLE
chore: release 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backspace",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "description": "Open, self-hosted communication platform \u2014 text, voice, video, and federation",
   "license": "AGPL-3.0-only",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/desktop",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backspace",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/server",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/shared",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/web",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/metrics",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",


### PR DESCRIPTION
Version bump only. Sets 1.0.6 in all six release manifests via
`scripts/bump-version.mjs`, which is the supported path and the reason
`test/version-consistency.test.ts` exists.

The lockfile is deliberately untouched, matching the 1.0.3 through 1.0.5
precedent: these are workspace-internal versions and no dependency
resolution changes.

Contents of the release are in #48 (Flatpak packaging) and #90
(contributing guidelines).

Tagging this merge commit `v1.0.6` will be the first run of the Flatpak
release chain added in #48. That run pins the Flatpak manifest to this
commit, which is the prerequisite for a Flathub submission.
