### PR TITLE
ci(release): trust the checkout inside the Flatpak container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,14 @@ jobs:
 
       - name: Checkout the release tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
+
+      # The job runs inside the Flatpak builder container as a different user
+      # than the one the runner used for the checkout. Git treats a repository
+      # owned by another user as untrusted and refuses every command with
+      # "detected dubious ownership", which is how the v1.0.6 run failed on the
+      # `git show` below before it produced anything.
+      - name: Trust the checked-out repository
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install the pinned Node SDK extension
         run: |

--- a/docs/systems/security-scanning.md
+++ b/docs/systems/security-scanning.md
@@ -538,6 +538,15 @@ rename.
       deliberately does **not** require pull requests or status checks: the
       collector commits directly, and requiring a PR would break every run. This
       branch holds the only irreplaceable data in the repository.
+- [x] Settings → Actions → General: **Allow GitHub Actions to create and approve
+      pull requests** enabled (`can_approve_pull_request_reviews: true` on
+      `GET /repos/{owner}/{repo}/actions/permissions/workflow`; the default
+      workflow token permission stays **read**). The `update-flatpak-metadata`
+      job in `release.yml` opens the `automation/flatpak-<tag>` pull request
+      with `GITHUB_TOKEN`, which GitHub rejects while this is off. It was off
+      when the v1.0.6 chain first ran (2026-09-04) and was turned on before the
+      re-run. Every job still declares its own `permissions:` block, so this
+      widens nothing for jobs that do not ask for `pull-requests: write`.
 
 ### Outstanding
 


### PR DESCRIPTION
The first run of the Flatpak release chain (tag v1.0.6, run 33822134479) failed in `prepare-flatpak-metadata` before producing anything:

```
fatal: detected dubious ownership in repository at '/__w/backspace/backspace'
##[error]Process completed with exit code 128.
```

The job runs inside the flatpak-github-actions container, where the step user is not the user that performed the checkout, and git refuses to touch a repository owned by someone else. This adds the workspace to `safe.directory` right after the checkout, which is the standard fix for container jobs that run git. The full-history fetch on that checkout is dropped since the only git command in the job reads HEAD's commit date.

The other two jobs in the chain do not run git inside a container: the builds let flatpak-builder do its own clone, and the PR job runs on the plain runner.

After this merges, the v1.0.6 tag will be moved to the merge commit and the release re-run. The draft release created by the failed run will be deleted first so the re-run starts clean. The app binaries are unaffected, since the only change is in the workflow file.
