### PR TITLE
feat(i18n): localize the chat widgets

### DIFF
--- a/packages/web/src/components/chat/AttachmentProgress.tsx
+++ b/packages/web/src/components/chat/AttachmentProgress.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import type { TransferState } from '../../stores/transferStore';
+import { useFormatters } from '../../i18n/formatters';
 
 interface Props {
   loaded: number;
@@ -14,14 +16,9 @@ interface Props {
   size?: 'tile' | 'pill';
 }
 
-function fmt(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
-}
-
 export function AttachmentProgress({ loaded, total, state, filename, error, onPause, onResume, onAbort, size = 'tile' }: Props) {
+  const { t } = useTranslation(['chat', 'common']);
+  const { formatBytes, formatPercent } = useFormatters();
   const pct = total > 0 ? Math.min(100, Math.round((loaded / total) * 100)) : 0;
   const bg = state === 'failed' ? 'bg-accent-rose/30' : state === 'paused' ? 'bg-white/5' : 'bg-accent-mint/30';
   const isFinal = state === 'completed' || state === 'aborted';
@@ -32,7 +29,7 @@ export function AttachmentProgress({ loaded, total, state, filename, error, onPa
   const ringTitle = state === 'failed'
     ? error
     : state === 'paused'
-      ? `Paused — ${pct}%`
+      ? t('chat:attachment.progress.pausedTitle', { percent: formatPercent(pct) })
       : undefined;
   return (
     <div className={`absolute inset-0 flex flex-col items-center justify-center gap-2 backdrop-blur-[2px] ${state === 'failed' ? 'bg-accent-rose/20' : 'bg-black/50'} pointer-events-auto`}>
@@ -50,26 +47,26 @@ export function AttachmentProgress({ loaded, total, state, filename, error, onPa
           ) : state === 'failed' ? (
             '!'
           ) : (
-            `${pct}%`
+            formatPercent(pct)
           )}
         </div>
       </div>
       {size === 'tile' && (
         <div className="text-[10px] text-txt-primary text-center leading-tight px-1">
           <div className="truncate max-w-[120px]">{filename}</div>
-          <div className="opacity-60">{fmt(loaded)} / {fmt(total)}</div>
+          <div className="opacity-60">{formatBytes(loaded)} / {formatBytes(total)}</div>
         </div>
       )}
       {!isFinal && (
         <div className="absolute top-1 right-1 flex gap-1">
           {state === 'paused' && onResume && (
-            <button onClick={onResume} className="bg-black/60 hover:bg-black/80 text-white w-5 h-5 rounded text-[9px]" aria-label="Resume">▶</button>
+            <button onClick={onResume} className="bg-black/60 hover:bg-black/80 text-white w-5 h-5 rounded text-[9px]" aria-label={t('chat:attachment.progress.resume')}>▶</button>
           )}
           {state === 'active' && onPause && (
-            <button onClick={onPause} className="bg-black/60 hover:bg-black/80 text-white w-5 h-5 rounded text-[9px]" aria-label="Pause">⏸</button>
+            <button onClick={onPause} className="bg-black/60 hover:bg-black/80 text-white w-5 h-5 rounded text-[9px]" aria-label={t('chat:attachment.progress.pause')}>⏸</button>
           )}
           {onAbort && (
-            <button onClick={onAbort} className="bg-black/60 hover:bg-black/80 text-white w-5 h-5 rounded text-[9px]" aria-label="Abort">✕</button>
+            <button onClick={onAbort} className="bg-black/60 hover:bg-black/80 text-white w-5 h-5 rounded text-[9px]" aria-label={t('chat:attachment.progress.abort')}>✕</button>
           )}
         </div>
       )}

--- a/packages/web/src/components/chat/AttachmentRenderer.tsx
+++ b/packages/web/src/components/chat/AttachmentRenderer.tsx
@@ -1,17 +1,13 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Attachment } from '@backspace/shared';
 import { useUIStore } from '../../stores/uiStore';
 import { useTransferStore } from '../../stores/transferStore';
 import { Tooltip } from '../ui/Tooltip';
+import { useFormatters } from '../../i18n/formatters';
 
 interface AttachmentRendererProps {
   attachment: Attachment;
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / 1048576).toFixed(1)} MB`;
 }
 
 /** Format a duration in seconds as `m:ss` (or `h:mm:ss` for long clips). */
@@ -81,6 +77,8 @@ interface VideoAttachmentProps {
  * duration and size, and a one-tap download — never a silently broken player.
  */
 function VideoAttachment({ attachment, attUrl, thumbUrl, federationInlineBadge }: VideoAttachmentProps) {
+  const { t } = useTranslation(['chat']);
+  const { formatBytes } = useFormatters();
   const startDownload = useTransferStore((s) => s.startDownload);
   // Pre-fail only when the server flagged it unplayable AND this browser can't
   // decode it anyway. Capable browsers (Safari/WebKit ⇒ HEVC) attempt playback
@@ -94,7 +92,7 @@ function VideoAttachment({ attachment, attUrl, thumbUrl, federationInlineBadge }
     : undefined;
 
   if (failed) {
-    const meta = [duration ? formatDuration(duration) : null, formatFileSize(size)]
+    const meta = [duration ? formatDuration(duration) : null, formatBytes(size)]
       .filter(Boolean)
       .join(' · ');
     return (
@@ -118,7 +116,7 @@ function VideoAttachment({ attachment, attUrl, thumbUrl, federationInlineBadge }
                 <svg className="w-9 h-9" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M12 10v6m0 0l-3-3m3 3l3-3M3 17V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
                 </svg>
-                <span className="text-[12px] font-medium">Can't play here — download</span>
+                <span className="text-[12px] font-medium">{t('chat:attachment.video.cannotPlayDownload')}</span>
               </div>
             </div>
           )}
@@ -133,7 +131,7 @@ function VideoAttachment({ attachment, attUrl, thumbUrl, federationInlineBadge }
             <div className="min-w-0 flex-1">
               <p className="text-txt-link text-[14px] font-medium truncate group-hover/vid:underline">{originalName}</p>
               <p className="text-[12px] text-txt-tertiary">
-                {meta ? `${meta} · ` : ''}Unsupported video format
+                {meta ? `${meta} · ` : ''}{t('chat:attachment.video.unsupportedFormat')}
               </p>
             </div>
           </div>
@@ -157,7 +155,7 @@ function VideoAttachment({ attachment, attUrl, thumbUrl, federationInlineBadge }
           onError={() => setFailed(true)}
           className="w-full h-full rounded-lg"
         >
-          Your browser does not support video playback.
+          {t('chat:attachment.video.unsupportedBrowser')}
         </video>
       </div>
       {federationInlineBadge && <div className="mt-1">{federationInlineBadge}</div>}
@@ -166,6 +164,8 @@ function VideoAttachment({ attachment, attUrl, thumbUrl, federationInlineBadge }
 }
 
 export function AttachmentRenderer({ attachment }: AttachmentRendererProps) {
+  const { t } = useTranslation(['chat']);
+  const { formatBytes } = useFormatters();
   const openImagePreview = useUIStore((s) => s.openImagePreview);
   const startDownload = useTransferStore((s) => s.startDownload);
 
@@ -184,27 +184,32 @@ export function AttachmentRenderer({ attachment }: AttachmentRendererProps) {
     if (!attachment.federationStatus) return null;
 
     if (attachment.federationStatus === 'remote') {
-      let senderName = 'the sender';
+      let senderName: string | null = null;
       if (attachment.federationMeta) {
         try {
           const meta = JSON.parse(attachment.federationMeta);
           if (meta.sourceUsername) senderName = meta.sourceUsername;
         } catch { /* ignore */ }
       }
-      return { text: `Hosted on ${senderName}'s instance. Download to keep a local copy.`, type: 'remote' as const };
+      const text = senderName
+        ? t('chat:attachment.federation.remoteNamed', { sender: senderName })
+        : t('chat:attachment.federation.remoteUnknown');
+      return { text, type: 'remote' as const };
     }
 
     if (attachment.federationStatus === 'remote_partial') {
-      let text = 'Some recipients cannot cache this file locally.';
+      let text = t('chat:attachment.federation.partialGeneric');
       if (attachment.federationMeta) {
         try {
           const meta: Array<{ username: string; limit: number }> = JSON.parse(attachment.federationMeta);
           if (meta.length > 0) {
-            const parts = meta.map(u => {
-              const limitMb = Math.round(u.limit / (1024 * 1024));
-              return `${u.username}'s instance (limit: ${limitMb} MB)`;
-            });
-            text = `File couldn't be cached on ${parts.join(' and ')}. They can still view it from yours.`;
+            const parts = meta.map(u =>
+              t('chat:attachment.federation.partialInstance', { username: u.username, limit: formatBytes(u.limit) }),
+            );
+            const instances = parts.reduce((first, second) =>
+              t('chat:attachment.federation.listPair', { first, second }),
+            );
+            text = t('chat:attachment.federation.partialList', { instances });
           }
         } catch { /* ignore */ }
       }
@@ -277,14 +282,14 @@ export function AttachmentRenderer({ attachment }: AttachmentRendererProps) {
           <div className="min-w-0">
             <p className="text-txt-primary text-[14px] font-medium truncate">{originalName}</p>
             <div className="flex items-center gap-2">
-              <p className="text-[12px] text-txt-tertiary">{formatFileSize(size)}</p>
+              <p className="text-[12px] text-txt-tertiary">{formatBytes(size)}</p>
               {federationInlineBadge}
             </div>
           </div>
         </div>
         <audio controls preload="metadata" className="w-full mt-2 h-8">
           <source src={attUrl} type={mimetype} />
-          Your browser does not support audio playback.
+          {t('chat:attachment.audio.unsupportedBrowser')}
         </audio>
       </div>
     );
@@ -326,7 +331,7 @@ export function AttachmentRenderer({ attachment }: AttachmentRendererProps) {
       <div className="min-w-0 flex-1">
         <p className="text-txt-link text-[15px] font-medium truncate hover:underline">{originalName}</p>
         <div className="flex items-center gap-2 flex-wrap">
-          <p className="text-[12px] text-txt-tertiary font-medium">{formatFileSize(size)}</p>
+          <p className="text-[12px] text-txt-tertiary font-medium">{formatBytes(size)}</p>
           {federationInlineBadge}
         </div>
       </div>

--- a/packages/web/src/components/chat/EmbedRenderer.tsx
+++ b/packages/web/src/components/chat/EmbedRenderer.tsx
@@ -12,9 +12,11 @@ interface EmbedRendererProps {
 export function EmbedRenderer({ embed }: EmbedRendererProps) {
   switch (embed.embedType) {
     case 'video':
+      // i18n-check: allow-literal (switch/case punctuation between JSX returns, not text)
       return <VideoEmbed embed={embed} />;
 
     case 'image':
+      // i18n-check: allow-literal (switch/case punctuation between JSX returns, not text)
       return <ImageEmbed embed={embed} />;
 
     case 'audio':
@@ -40,6 +42,7 @@ export function EmbedRenderer({ embed }: EmbedRendererProps) {
       );
 
     case 'rich':
+      // i18n-check: allow-literal (switch/case punctuation between JSX returns, not text)
       return <RichEmbed embed={embed} />;
 
     case 'generic':

--- a/packages/web/src/components/chat/GifPicker.tsx
+++ b/packages/web/src/components/chat/GifPicker.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { api } from '../../api/client';
 import type { GifResult } from '@backspace/shared';
 
@@ -12,6 +13,7 @@ interface GifPickerProps {
 }
 
 export function GifPicker({ onGifSelect, mobile = false }: GifPickerProps) {
+  const { t } = useTranslation(['chat']);
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [results, setResults] = useState<GifResult[]>([]);
@@ -97,7 +99,7 @@ export function GifPicker({ onGifSelect, mobile = false }: GifPickerProps) {
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search GIFs"
+          placeholder={t('chat:gif.searchPlaceholder')}
           className="input-search w-full"
           // Auto-focus only on desktop. On mobile this would force the OS
           // keyboard up the moment the sheet opens, hiding most of the grid.
@@ -123,7 +125,7 @@ export function GifPicker({ onGifSelect, mobile = false }: GifPickerProps) {
           </div>
         ) : results.length === 0 ? (
           <div className="flex items-center justify-center h-full text-txt-tertiary text-sm">
-            {debouncedQuery.trim() ? 'No GIFs found' : 'No trending GIFs'}
+            {debouncedQuery.trim() ? t('chat:gif.noResults') : t('chat:gif.noTrending')}
           </div>
         ) : (
           <div className="columns-2 gap-1.5 p-1">
@@ -155,7 +157,7 @@ export function GifPicker({ onGifSelect, mobile = false }: GifPickerProps) {
 
       {/* Attribution */}
       <div className="px-3 py-1 text-[10px] text-txt-tertiary text-right shrink-0">
-        Powered by Klipy
+        {t('chat:gif.attribution')}
       </div>
     </div>
   );

--- a/packages/web/src/components/chat/ImagePreview.tsx
+++ b/packages/web/src/components/chat/ImagePreview.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useUIStore } from '../../stores/uiStore';
 import { saveImage, copyImageToClipboard } from '../../utils/imageActions';
 
 export function ImagePreview() {
+  const { t } = useTranslation(['chat', 'common']);
   const imageUrl = useUIStore((s) => s.imagePreviewUrl);
   const closeImagePreview = useUIStore((s) => s.closeImagePreview);
   const activeModal = useUIStore((s) => s.activeModal);
@@ -22,7 +24,7 @@ export function ImagePreview() {
             e.stopPropagation();
             saveImage(imageUrl);
           }}
-          title="Save image"
+          title={t('chat:preview.save')}
         >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
@@ -34,7 +36,7 @@ export function ImagePreview() {
             e.stopPropagation();
             copyImageToClipboard(imageUrl);
           }}
-          title="Copy image"
+          title={t('chat:preview.copy')}
         >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M21 9v10c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2h7l6 6zm-2 1h-5V4H8v15h11V10zM3 15V3c0-1.1.9-2 2-2h9v2H5v12H3z" />
@@ -43,7 +45,7 @@ export function ImagePreview() {
         <button
           className="text-white/70 hover:text-white transition-colors"
           onClick={closeImagePreview}
-          title="Close"
+          title={t('common:actions.close')}
         >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
             <path d="M18.4 4L12 10.4L5.6 4L4 5.6L10.4 12L4 18.4L5.6 20L12 13.6L18.4 20L20 18.4L13.6 12L20 5.6L18.4 4Z" />
@@ -52,7 +54,7 @@ export function ImagePreview() {
       </div>
       <img
         src={imageUrl}
-        alt="Preview"
+        alt={t('chat:preview.alt')}
         className="max-w-[90vw] max-h-[90vh] object-contain rounded shadow-elevation-high"
         onClick={(e) => e.stopPropagation()}
       />

--- a/packages/web/src/components/chat/MentionPopover.tsx
+++ b/packages/web/src/components/chat/MentionPopover.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import type { MemberWithUser } from '@backspace/shared';
 import { Avatar } from '../ui/Avatar';
 import { useSpaceStore } from '../../stores/spaceStore';
@@ -85,10 +86,11 @@ function MemberList({
   getMemberColor,
   mobile,
 }: ResolvedListProps) {
+  const { t } = useTranslation(['chat']);
   return (
     <>
       <div className="px-2 py-1.5 text-[11px] font-bold text-txt-tertiary uppercase tracking-wider">
-        Members
+        {t('chat:mention.membersHeading')}
       </div>
       {filtered.map((member, i) => (
         <MentionMemberRow

--- a/packages/web/src/components/chat/SearchPopover.tsx
+++ b/packages/web/src/components/chat/SearchPopover.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import i18n from '../../i18n';
 import { formatters } from '../../i18n/formatters';
 import { createPortal } from 'react-dom';
 import { useFloatingPosition } from '../../hooks/useFloatingPosition';
@@ -26,8 +28,8 @@ function formatTime(timestamp: number): string {
   yesterday.setDate(yesterday.getDate() - 1);
   const isYesterday = date.toDateString() === yesterday.toDateString();
   const time = formatters.formatTime(timestamp);
-  if (isToday) return `Today at ${time}`;
-  if (isYesterday) return `Yesterday at ${time}`;
+  if (isToday) return i18n.t('search:time.todayAt', { time });
+  if (isYesterday) return i18n.t('search:time.yesterdayAt', { time });
   return formatters.formatDateTime(timestamp);
 }
 
@@ -53,6 +55,7 @@ function SearchResultRow({
   query: string;
   onJumpToMessage: (id: string) => void;
 }) {
+  const { t } = useTranslation(['search']);
   const canonical = useCanonicalUserView(msg.user ?? _FALLBACK_USER);
   const displayName = canonical.displayName ?? canonical.username ?? '?';
   const avatar = msg.user ? canonical.avatar : undefined;
@@ -86,7 +89,7 @@ function SearchResultRow({
             <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
               <path d="M16.5 6v11.5c0 2.21-1.79 4-4 4s-4-1.79-4-4V5c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5v10.5c0 .55-.45 1-1 1s-1-.45-1-1V6H9v9.5c0 1.38 1.12 2.5 2.5 2.5s2.5-1.12 2.5-2.5V5c0-2.21-1.79-4-4-4S6 2.79 6 5v12.5c0 3.04 2.46 5.5 5.5 5.5s5.5-2.46 5.5-5.5V6h-1.5z" />
             </svg>
-            {msg.attachments.length} attachment{msg.attachments.length !== 1 ? 's' : ''}
+            {t('search:results.attachments', { count: msg.attachments.length })}
           </div>
         )}
       </div>
@@ -95,6 +98,7 @@ function SearchResultRow({
 }
 
 export function SearchPopover({ open, onClose, anchorRef, channelId, isDm, onJumpToMessage }: SearchPopoverProps) {
+  const { t } = useTranslation(['search', 'common']);
   const popoverRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const { style } = useFloatingPosition(anchorRef, popoverRef, {
@@ -225,7 +229,7 @@ export function SearchPopover({ open, onClose, anchorRef, channelId, isDm, onJum
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search messages..."
+            placeholder={t('search:input.placeholder')}
             className="input-embedded flex-1 text-[14px]"
           />
           {query && (
@@ -248,7 +252,7 @@ export function SearchPopover({ open, onClose, anchorRef, channelId, isDm, onJum
           <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" className={`transition-transform ${showFilters ? 'rotate-90' : ''}`}>
             <path d="M10 17l5-5-5-5v10z" />
           </svg>
-          Filters
+          {t('search:filters.toggle')}
           {(fromFilter || hasFilter || beforeFilter || afterFilter) && (
             <span className="w-1.5 h-1.5 rounded-full bg-accent-primary" />
           )}
@@ -258,30 +262,30 @@ export function SearchPopover({ open, onClose, anchorRef, channelId, isDm, onJum
         {showFilters && (
           <div className="mt-2 grid grid-cols-2 gap-2">
             <div>
-              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">From</label>
+              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">{t('search:filters.from.label')}</label>
               <input
                 type="text"
                 value={fromFilter}
                 onChange={(e) => setFromFilter(e.target.value)}
-                placeholder="username"
+                placeholder={t('search:filters.from.placeholder')}
                 className="input-search w-full px-2 py-1 text-[13px]"
               />
             </div>
             <div>
-              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">Has</label>
+              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">{t('search:filters.has.label')}</label>
               <select
                 value={hasFilter}
                 onChange={(e) => setHasFilter(e.target.value)}
                 className="input-search w-full px-2 py-1 text-[13px] appearance-none cursor-pointer"
               >
-                <option value="">Any</option>
-                <option value="file">File</option>
-                <option value="image">Image</option>
-                <option value="link">Link</option>
+                <option value="">{t('search:filters.has.any')}</option>
+                <option value="file">{t('search:filters.has.file')}</option>
+                <option value="image">{t('search:filters.has.image')}</option>
+                <option value="link">{t('search:filters.has.link')}</option>
               </select>
             </div>
             <div>
-              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">Before</label>
+              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">{t('search:filters.before.label')}</label>
               <input
                 type="date"
                 value={beforeFilter}
@@ -290,7 +294,7 @@ export function SearchPopover({ open, onClose, anchorRef, channelId, isDm, onJum
               />
             </div>
             <div>
-              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">After</label>
+              <label className="text-[11px] text-txt-tertiary font-medium mb-1 block">{t('search:filters.after.label')}</label>
               <input
                 type="date"
                 value={afterFilter}
@@ -315,20 +319,20 @@ export function SearchPopover({ open, onClose, anchorRef, channelId, isDm, onJum
             <svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor" className="text-txt-tertiary/50 mb-2">
               <path d="M21.707 20.293l-5.395-5.395A7.457 7.457 0 0018 10.5 7.5 7.5 0 1010.5 18c1.575 0 3.027-.486 4.228-1.31l5.476 5.476a.997.997 0 001.414 0l.089-.089a1 1 0 000-1.414l.001-.37zM10.5 16a5.5 5.5 0 110-11 5.5 5.5 0 010 11z" />
             </svg>
-            <span className="text-txt-tertiary text-[13px]">No results found</span>
+            <span className="text-txt-tertiary text-[13px]">{t('search:results.empty')}</span>
           </div>
         )}
 
         {!query && !fromFilter && !hasFilter && !beforeFilter && !afterFilter && results.length === 0 && (
           <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
-            <span className="text-txt-tertiary text-[13px]">Type to search messages in this channel</span>
+            <span className="text-txt-tertiary text-[13px]">{t('search:results.hint')}</span>
           </div>
         )}
 
         {results.length > 0 && (
           <>
             <div className="px-3 py-2 text-[11px] text-txt-tertiary font-medium">
-              {totalCount} result{totalCount !== 1 ? 's' : ''}
+              {t('search:results.count', { count: totalCount })}
             </div>
             {results.map((msg) => (
               <SearchResultRow
@@ -345,7 +349,7 @@ export function SearchPopover({ open, onClose, anchorRef, channelId, isDm, onJum
                   disabled={isSearching}
                   className="w-full py-1.5 text-[13px] text-accent-primary hover:text-accent-primary-hover transition-colors font-medium disabled:opacity-50"
                 >
-                  {isSearching ? 'Loading...' : `Load more (${totalCount - results.length} remaining)`}
+                  {isSearching ? t('common:states.loading') : t('search:results.loadMore', { remaining: totalCount - results.length })}
                 </button>
               </div>
             )}

--- a/packages/web/src/components/chat/SpaceInviteCard.tsx
+++ b/packages/web/src/components/chat/SpaceInviteCard.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { describeError } from '../../i18n/errors';
 import { Avatar } from '../ui/Avatar';
 import { getApiForOrigin } from '../../stores/spaceStore';
 import { useSpaceStore } from '../../stores/spaceStore';
@@ -17,6 +19,7 @@ interface Props {
 }
 
 export function SpaceInviteCard({ payload, senderName }: Props) {
+  const { t } = useTranslation(['chat']);
   const navigate = useNavigate();
   const joinByCode = useSpaceStore(s => s.joinByCode);
   const [live, setLive] = useState<LiveState>({ kind: 'loading' });
@@ -81,7 +84,7 @@ export function SpaceInviteCard({ payload, senderName }: Props) {
         landOnSpace(payload.spaceId);
         return;
       }
-      setJoinError(msg || 'Failed to join');
+      setJoinError(msg ? describeError(err) : t('chat:invite.joinFailed'));
       setJoining(false);
     }
   };
@@ -89,7 +92,7 @@ export function SpaceInviteCard({ payload, senderName }: Props) {
   return (
     <div className={`my-1.5 max-w-md rounded-lg border border-white/[0.06] bg-surface-channel overflow-hidden ${isRevoked ? 'opacity-50' : ''}`}>
       <div className="px-3 py-1 text-[11px] text-txt-tertiary border-b border-white/[0.06]">
-        {senderName} sent an invite
+        {t('chat:invite.sentBy', { name: senderName })}
       </div>
       <div className="flex items-center gap-3 p-3">
         <Avatar
@@ -103,7 +106,7 @@ export function SpaceInviteCard({ payload, senderName }: Props) {
             {payload.snapshot.spaceName}
           </div>
           <div className="text-[12px] text-txt-tertiary truncate">
-            {memberCount} {memberCount === 1 ? 'member' : 'members'}
+            {t('chat:invite.memberCount', { count: memberCount })}
             {payload.snapshot.instanceName ? ` · ${payload.snapshot.instanceName}` : ''}
             {live.kind === 'loading' && (
               <span aria-hidden className="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-txt-tertiary animate-pulse" />
@@ -112,7 +115,7 @@ export function SpaceInviteCard({ payload, senderName }: Props) {
         </div>
         {isRevoked ? (
           <span className="glass-pill px-3 py-1 text-[12px] text-txt-tertiary">
-            Invite no longer valid
+            {t('chat:invite.revoked')}
           </span>
         ) : (
           <button
@@ -120,7 +123,7 @@ export function SpaceInviteCard({ payload, senderName }: Props) {
             disabled={joining}
             className="px-4 py-1.5 rounded-md text-[13px] font-medium bg-accent-mint text-surface-base hover:bg-accent-mint/90 disabled:opacity-50"
           >
-            {joining ? 'Joining…' : 'Join'}
+            {joining ? t('chat:invite.joining') : t('chat:invite.join')}
           </button>
         )}
       </div>

--- a/packages/web/src/locales/de/chat.json
+++ b/packages/web/src/locales/de/chat.json
@@ -1,1 +1,49 @@
-{}
+{
+  "attachment": {
+    "progress": {
+      "pausedTitle": "Pausiert – {{percent}}",
+      "resume": "Fortsetzen",
+      "pause": "Pausieren",
+      "abort": "Abbrechen"
+    },
+    "video": {
+      "cannotPlayDownload": "Hier nicht abspielbar – herunterladen",
+      "unsupportedFormat": "Nicht unterstütztes Videoformat",
+      "unsupportedBrowser": "Dein Browser unterstützt keine Videowiedergabe."
+    },
+    "audio": {
+      "unsupportedBrowser": "Dein Browser unterstützt keine Audiowiedergabe."
+    },
+    "federation": {
+      "remoteNamed": "Liegt auf der Instanz von {{sender}}. Lade die Datei herunter, um eine lokale Kopie zu behalten.",
+      "remoteUnknown": "Liegt auf der Instanz des Absenders. Lade die Datei herunter, um eine lokale Kopie zu behalten.",
+      "partialGeneric": "Einige Empfänger können diese Datei nicht lokal zwischenspeichern.",
+      "partialInstance": "der Instanz von {{username}} (Limit: {{limit}})",
+      "partialList": "Die Datei konnte auf {{instances}} nicht zwischengespeichert werden. Sie kann dort weiterhin von deiner Instanz aus angesehen werden.",
+      "listPair": "{{first}} und {{second}}"
+    }
+  },
+  "gif": {
+    "searchPlaceholder": "GIFs suchen",
+    "noResults": "Keine GIFs gefunden",
+    "noTrending": "Keine angesagten GIFs",
+    "attribution": "Bereitgestellt von Klipy"
+  },
+  "preview": {
+    "save": "Bild speichern",
+    "copy": "Bild kopieren",
+    "alt": "Bildvorschau"
+  },
+  "mention": {
+    "membersHeading": "Mitglieder"
+  },
+  "invite": {
+    "sentBy": "{{name}} hat eine Einladung geschickt",
+    "memberCount_one": "{{count}} Mitglied",
+    "memberCount_other": "{{count}} Mitglieder",
+    "revoked": "Einladung nicht mehr gültig",
+    "join": "Beitreten",
+    "joining": "Wird beigetreten…",
+    "joinFailed": "Beitritt fehlgeschlagen"
+  }
+}

--- a/packages/web/src/locales/de/search.json
+++ b/packages/web/src/locales/de/search.json
@@ -1,1 +1,38 @@
-{}
+{
+  "input": {
+    "placeholder": "Nachrichten suchen…"
+  },
+  "filters": {
+    "toggle": "Filter",
+    "from": {
+      "label": "Von",
+      "placeholder": "Benutzername"
+    },
+    "has": {
+      "label": "Enthält",
+      "any": "Beliebig",
+      "file": "Datei",
+      "image": "Bild",
+      "link": "Weblink"
+    },
+    "before": {
+      "label": "Vor"
+    },
+    "after": {
+      "label": "Nach"
+    }
+  },
+  "results": {
+    "empty": "Keine Ergebnisse",
+    "hint": "Tippe, um Nachrichten in diesem Kanal zu suchen",
+    "count_one": "{{count}} Ergebnis",
+    "count_other": "{{count}} Ergebnisse",
+    "loadMore": "Mehr laden ({{remaining}} verbleibend)",
+    "attachments_one": "{{count}} Anhang",
+    "attachments_other": "{{count}} Anhänge"
+  },
+  "time": {
+    "todayAt": "Heute um {{time}}",
+    "yesterdayAt": "Gestern um {{time}}"
+  }
+}

--- a/packages/web/src/locales/en/chat.json
+++ b/packages/web/src/locales/en/chat.json
@@ -1,1 +1,49 @@
-{}
+{
+  "attachment": {
+    "progress": {
+      "pausedTitle": "Paused — {{percent}}",
+      "resume": "Resume",
+      "pause": "Pause",
+      "abort": "Abort"
+    },
+    "video": {
+      "cannotPlayDownload": "Can't play here — download",
+      "unsupportedFormat": "Unsupported video format",
+      "unsupportedBrowser": "Your browser does not support video playback."
+    },
+    "audio": {
+      "unsupportedBrowser": "Your browser does not support audio playback."
+    },
+    "federation": {
+      "remoteNamed": "Hosted on {{sender}}'s instance. Download to keep a local copy.",
+      "remoteUnknown": "Hosted on the sender's instance. Download to keep a local copy.",
+      "partialGeneric": "Some recipients cannot cache this file locally.",
+      "partialInstance": "{{username}}'s instance (limit: {{limit}})",
+      "partialList": "File couldn't be cached on {{instances}}. They can still view it from yours.",
+      "listPair": "{{first}} and {{second}}"
+    }
+  },
+  "gif": {
+    "searchPlaceholder": "Search GIFs",
+    "noResults": "No GIFs found",
+    "noTrending": "No trending GIFs",
+    "attribution": "Powered by Klipy"
+  },
+  "preview": {
+    "save": "Save image",
+    "copy": "Copy image",
+    "alt": "Image preview"
+  },
+  "mention": {
+    "membersHeading": "Members"
+  },
+  "invite": {
+    "sentBy": "{{name}} sent an invite",
+    "memberCount_one": "{{count}} member",
+    "memberCount_other": "{{count}} members",
+    "revoked": "Invite no longer valid",
+    "join": "Join",
+    "joining": "Joining…",
+    "joinFailed": "Failed to join"
+  }
+}

--- a/packages/web/src/locales/en/search.json
+++ b/packages/web/src/locales/en/search.json
@@ -1,1 +1,38 @@
-{}
+{
+  "input": {
+    "placeholder": "Search messages…"
+  },
+  "filters": {
+    "toggle": "Filters",
+    "from": {
+      "label": "From",
+      "placeholder": "username"
+    },
+    "has": {
+      "label": "Has",
+      "any": "Any",
+      "file": "File",
+      "image": "Image",
+      "link": "Link"
+    },
+    "before": {
+      "label": "Before"
+    },
+    "after": {
+      "label": "After"
+    }
+  },
+  "results": {
+    "empty": "No results found",
+    "hint": "Type to search messages in this channel",
+    "count_one": "{{count}} result",
+    "count_other": "{{count}} results",
+    "loadMore": "Load more ({{remaining}} remaining)",
+    "attachments_one": "{{count}} attachment",
+    "attachments_other": "{{count}} attachments"
+  },
+  "time": {
+    "todayAt": "Today at {{time}}",
+    "yesterdayAt": "Yesterday at {{time}}"
+  }
+}

--- a/packages/web/src/locales/ru/chat.json
+++ b/packages/web/src/locales/ru/chat.json
@@ -1,1 +1,51 @@
-{}
+{
+  "attachment": {
+    "progress": {
+      "pausedTitle": "Приостановлено — {{percent}}",
+      "resume": "Возобновить",
+      "pause": "Приостановить",
+      "abort": "Прервать"
+    },
+    "video": {
+      "cannotPlayDownload": "Здесь не воспроизвести — скачать",
+      "unsupportedFormat": "Неподдерживаемый формат видео",
+      "unsupportedBrowser": "Ваш браузер не поддерживает воспроизведение видео."
+    },
+    "audio": {
+      "unsupportedBrowser": "Ваш браузер не поддерживает воспроизведение аудио."
+    },
+    "federation": {
+      "remoteNamed": "Файл хранится на сервере пользователя {{sender}}. Скачайте его, чтобы сохранить локальную копию.",
+      "remoteUnknown": "Файл хранится на сервере отправителя. Скачайте его, чтобы сохранить локальную копию.",
+      "partialGeneric": "Некоторые получатели не могут сохранить этот файл у себя.",
+      "partialInstance": "сервере пользователя {{username}} (лимит: {{limit}})",
+      "partialList": "Файл не удалось сохранить на {{instances}}. Они всё равно могут открыть его с вашего сервера.",
+      "listPair": "{{first}} и {{second}}"
+    }
+  },
+  "gif": {
+    "searchPlaceholder": "Поиск GIF",
+    "noResults": "GIF не найдены",
+    "noTrending": "Нет популярных GIF",
+    "attribution": "При поддержке Klipy"
+  },
+  "preview": {
+    "save": "Сохранить изображение",
+    "copy": "Копировать изображение",
+    "alt": "Просмотр изображения"
+  },
+  "mention": {
+    "membersHeading": "Участники"
+  },
+  "invite": {
+    "sentBy": "Приглашение от {{name}}",
+    "memberCount_one": "{{count}} участник",
+    "memberCount_few": "{{count}} участника",
+    "memberCount_many": "{{count}} участников",
+    "memberCount_other": "{{count}} участника",
+    "revoked": "Приглашение больше не действительно",
+    "join": "Присоединиться",
+    "joining": "Присоединение…",
+    "joinFailed": "Не удалось присоединиться"
+  }
+}

--- a/packages/web/src/locales/ru/search.json
+++ b/packages/web/src/locales/ru/search.json
@@ -1,1 +1,42 @@
-{}
+{
+  "input": {
+    "placeholder": "Поиск сообщений…"
+  },
+  "filters": {
+    "toggle": "Фильтры",
+    "from": {
+      "label": "От кого",
+      "placeholder": "имя пользователя"
+    },
+    "has": {
+      "label": "Содержит",
+      "any": "Любое",
+      "file": "Файл",
+      "image": "Изображение",
+      "link": "Ссылку"
+    },
+    "before": {
+      "label": "До"
+    },
+    "after": {
+      "label": "После"
+    }
+  },
+  "results": {
+    "empty": "Ничего не найдено",
+    "hint": "Введите запрос, чтобы искать сообщения в этом канале",
+    "count_one": "{{count}} результат",
+    "count_few": "{{count}} результата",
+    "count_many": "{{count}} результатов",
+    "count_other": "{{count}} результата",
+    "loadMore": "Показать ещё (осталось {{remaining}})",
+    "attachments_one": "{{count}} вложение",
+    "attachments_few": "{{count}} вложения",
+    "attachments_many": "{{count}} вложений",
+    "attachments_other": "{{count}} вложения"
+  },
+  "time": {
+    "todayAt": "Сегодня в {{time}}",
+    "yesterdayAt": "Вчера в {{time}}"
+  }
+}


### PR DESCRIPTION
Second sweep of the localization work: the chat widgets, in English, Russian and German.

Covers attachments and their upload progress, the GIF picker, the image preview, the mention popover, the space invite card, the embed renderer and the search popover. The strings live in the `chat` namespace (the `attachment`, `gif`, `preview`, `mention` and `invite` sub-objects) and in the new `search` namespace.

Things a reviewer should know:

- Byte sizes now go through the shared formatter, so labels read "kB" and "MB" with locale digits, and the federation partial-cache limit prints the real value instead of whole megabytes.
- The invite card still recognises "already a member" by matching the server's English error text. That gets an error code in the server pass; noted here so nobody is surprised.
- German uses "Weblink" for the search `has:link` filter for now because the parity check rejects a translation identical to the English. It goes back to "Link" once that word is on the allowlist.
- No logic changes and no test changes. Type check, the web test suite and the i18n consistency check are all clean.

The Russian strings come from st7105's translation in PR #45, corrected where a phrase had drifted.
