### PR TITLE
feat(i18n): localize the chat messages

### DIFF
--- a/packages/web/src/components/chat/Message.tsx
+++ b/packages/web/src/components/chat/Message.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { formatters } from '../../i18n/formatters';
+import { Trans, useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import { formatters, useFormatters } from '../../i18n/formatters';
 import type { MessageWithUser, Embed, User } from '@backspace/shared';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { MentionBadge } from './MentionBadge';
@@ -65,7 +67,7 @@ function PendingAttachmentTile({ transferId }: PendingAttachmentTileProps) {
   );
 }
 
-function formatTime(timestamp: number): string {
+function formatMessageTimestamp(t: TFunction<['chat', 'common']>, fmt: typeof formatters, timestamp: number): string {
   const date = new Date(timestamp);
   const now = new Date();
   const isToday = date.toDateString() === now.toDateString();
@@ -73,11 +75,11 @@ function formatTime(timestamp: number): string {
   yesterday.setDate(yesterday.getDate() - 1);
   const isYesterday = date.toDateString() === yesterday.toDateString();
 
-  const time = formatters.formatTime(timestamp);
+  const time = fmt.formatTime(timestamp);
 
-  if (isToday) return `Today at ${time}`;
-  if (isYesterday) return `Yesterday at ${time}`;
-  return formatters.formatDateTime(timestamp);
+  if (isToday) return t('chat:message.timestamp.today', { time });
+  if (isYesterday) return t('chat:message.timestamp.yesterday', { time });
+  return fmt.formatDateTime(timestamp);
 }
 
 function formatHoverTime(timestamp: number): string {
@@ -120,6 +122,8 @@ function getImageEmbedSourceUrl(content: string | null, embeds: Embed[]): string
 }
 
 export function Message({ message, isCompact, isFirstInGroup, previousMessageId }: MessageProps) {
+  const { t } = useTranslation(['chat', 'common']);
+  const fmt = useFormatters();
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(message.content ?? '');
   const [isHovered, setIsHovered] = useState(false);
@@ -463,7 +467,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
               />
             </span>
             <span className="text-[11px] text-txt-tertiary leading-tight hover:cursor-default">
-              {formatTime(message.createdAt)}
+              {formatMessageTimestamp(t, fmt, message.createdAt)}
             </span>
           </div>
         )}
@@ -479,13 +483,24 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
               autoFocus
             />
             <p className="text-[12px] text-txt-tertiary mt-1.5 ml-1">
-              escape to <button onClick={() => setIsEditing(false)} className="text-txt-link hover:underline">cancel</button>
-              {' '}&bull; enter to <button onClick={() => {
-                if (editContent.trim()) {
-                  editMessage(message.id, editContent.trim(), channelKey);
-                  setIsEditing(false);
-                }
-              }} className="text-txt-link hover:underline">save</button>
+              <Trans
+                t={t}
+                i18nKey="chat:message.edit.hint"
+                components={{ // i18n-check: allow-literal (the next line is an object key after a JSX element, not text)
+                  cancel: <button onClick={() => setIsEditing(false)} className="text-txt-link hover:underline" />,
+                  save: (
+                    <button
+                      onClick={() => {
+                        if (editContent.trim()) {
+                          editMessage(message.id, editContent.trim(), channelKey);
+                          setIsEditing(false);
+                        }
+                      }}
+                      className="text-txt-link hover:underline"
+                    />
+                  ),
+                }}
+              />
             </p>
           </div>
         ) : (
@@ -494,7 +509,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
               <div className="mt-1 max-w-[400px]">
                 <img
                   src={message.content!.trim()}
-                  alt="GIF"
+                  alt={t('chat:message.gifAlt')}
                   className="max-w-full max-h-[300px] rounded-lg"
                   loading="lazy"
                 />
@@ -510,7 +525,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                   </div>
                 )}
                 {message.editedAt && (
-                  <span className="text-[10px] text-txt-tertiary select-none font-medium">(edited)</span>
+                  <span className="text-[10px] text-txt-tertiary select-none font-medium">{t('chat:message.edited')}</span>
                 )}
               </>
             ) : (
@@ -519,7 +534,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                   <div className="text-txt-message text-[15px] leading-[1.5] break-words whitespace-pre-wrap selection:bg-accent-primary/30">
                     <MarkdownRenderer content={message.content} />
                     {message.editedAt && (
-                      <span className="text-[10px] text-txt-tertiary ml-1 select-none font-medium">(edited)</span>
+                      <span className="text-[10px] text-txt-tertiary ml-1 select-none font-medium">{t('chat:message.edited')}</span>
                     )}
                   </div>
                 )}
@@ -555,7 +570,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                   <svg width="13" height="13" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fillRule="evenodd" d="M10 2a8 8 0 100 16 8 8 0 000-16zm0 4a.875.875 0 01.875.875v4a.875.875 0 11-1.75 0v-4A.875.875 0 0110 6zm0 8.25a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
                   </svg>
-                  Upload failed
+                  {t('chat:message.upload.failed')}
                 </span>
                 <span className="w-px h-3.5 bg-accent-rose/25" aria-hidden="true" />
                 {canRetry && (
@@ -575,7 +590,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                     }}
                     className="px-2 py-0.5 rounded-md text-[11.5px] font-medium text-accent-mint bg-accent-mint/10 hover:bg-accent-mint/20 transition-colors"
                   >
-                    Retry
+                    {t('common:actions.retry')}
                   </button>
                 )}
                 <button
@@ -600,7 +615,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                   }}
                   className="px-2 py-0.5 rounded-md text-[11.5px] font-medium text-txt-secondary bg-surface-channel/50 hover:bg-accent-rose/15 hover:text-accent-rose transition-colors"
                 >
-                  Discard
+                  {t('chat:message.upload.discard')}
                 </button>
               </div>
             )}
@@ -677,7 +692,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                 className={`p-1 hover:bg-interactive-hover rounded transition-colors text-[14px] leading-none ${
                   showReactionPicker ? 'text-accent-primary' : 'text-txt-tertiary hover:text-txt-secondary'
                 }`}
-                title="Add reaction"
+                title={t('chat:message.actions.addReaction')}
               >
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm1-13h-2v4H7v2h4v4h2v-4h4v-2h-4V7z" />
@@ -688,7 +703,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
           <button
             onClick={() => setReplyTo(message)}
             className="px-2 h-full text-txt-tertiary hover:text-txt-primary hover:bg-interactive-hover transition-all flex items-center justify-center"
-            title="Reply"
+            title={t('chat:message.actions.reply')}
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
               <path d="M10 9V5L3 12L10 19V14.9C15 14.9 18.5 16.5 21 20C20 15 17 10 10 9Z" />
@@ -701,7 +716,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                 setIsEditing(true);
               }}
               className="px-2 h-full text-txt-tertiary hover:text-txt-primary hover:bg-interactive-hover transition-all flex items-center justify-center"
-              title="Edit"
+              title={t('common:actions.edit')}
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
@@ -723,7 +738,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                   ? 'bg-green-500/20 text-green-400'
                   : 'text-txt-tertiary hover:text-txt-danger hover:bg-interactive-hover'
               }`}
-              title={confirmingDelete ? 'Confirm delete' : 'Delete'}
+              title={confirmingDelete ? t('chat:message.actions.confirmDelete') : t('common:actions.delete')}
             >
               {/* Trash icon */}
               <svg

--- a/packages/web/src/components/chat/MessageInput.tsx
+++ b/packages/web/src/components/chat/MessageInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useCallback, useMemo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useChatStore } from '../../stores/chatStore';
 import { isDmChannel, getChannelOrigin, useSpaceStore } from '../../stores/spaceStore';
 import { wsSend } from '../../hooks/useWebSocket';
@@ -44,6 +45,7 @@ function makeFileHandleKey(): string {
 }
 
 export function MessageInput({ channelId, channelName, placeholder }: MessageInputProps) {
+  const { t } = useTranslation(['chat', 'common']);
   // Composer state lives in composerStore (per-channel, persisted)
   const composerState = useComposerStore((s) => s.states.get(channelId)) ?? {
     draftText: '',
@@ -173,14 +175,14 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
   // Surface permanent transfer failures as toasts (one toast per id, latched)
   const toastedFailuresRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    for (const t of stagedTransfers) {
-      if (t.state === 'failed' && !toastedFailuresRef.current.has(t.id)) {
-        toastedFailuresRef.current.add(t.id);
-        const msg = t.error?.message ?? 'Upload failed';
-        addToast(`Failed to upload ${t.file.name}: ${msg}`, 'warning');
+    for (const transfer of stagedTransfers) {
+      if (transfer.state === 'failed' && !toastedFailuresRef.current.has(transfer.id)) {
+        toastedFailuresRef.current.add(transfer.id);
+        const reason = transfer.error?.message ?? t('chat:composer.uploadFailedReason');
+        addToast(t('chat:composer.uploadFailed', { file: transfer.file.name, reason }), 'warning');
       }
     }
-  }, [stagedTransfers, addToast]);
+  }, [stagedTransfers, addToast, t]);
 
   // Filter members for the mention popover (used for keyboard nav clamping)
   const filteredMembers = useMemo(() => {
@@ -251,11 +253,11 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
           }
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Upload failed';
-        addToast(`Failed to upload ${file.name}: ${msg}`, 'warning');
+        const reason = err instanceof Error ? err.message : t('chat:composer.uploadFailedReason');
+        addToast(t('chat:composer.uploadFailed', { file: file.name, reason }), 'warning');
       }
     },
-    [channelId, startUpload, attachToComposer, addToast],
+    [channelId, startUpload, attachToComposer, addToast, t],
   );
 
   const removeStagedTransfer = useCallback(
@@ -330,7 +332,7 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
           textareaRef.current.focus();
         }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Failed to send message';
+        const msg = err instanceof Error ? err.message : t('chat:composer.sendFailed');
         addToast(msg, 'warning');
       }
       return;
@@ -743,7 +745,7 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
       <div ref={setComposerRef} data-pip-obstacle="bottom" className={composerClass} style={composerStyle}>
         <div className="flex items-center justify-center py-[14px] px-4">
           <span className="text-txt-tertiary text-[14px]">
-            You do not have permission to send messages in this channel
+            {t('chat:composer.noPermission')}
           </span>
         </div>
       </div>
@@ -775,7 +777,7 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
       {chatReplyTo && (
         <div className="bg-interactive-hover rounded-t-lg px-4 py-2 flex items-center justify-between border-b border-white/[0.06]">
           <div className="flex items-center gap-1 text-[14px] text-txt-message truncate">
-            <span className="opacity-60">Replying to</span>
+            <span className="opacity-60">{t('chat:composer.replyingTo')}</span>
             <span className="font-bold">
               {chatReplyTo.user.displayName ?? chatReplyTo.user.username}
             </span>
@@ -783,7 +785,7 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
           <button
             onClick={() => chatSetReplyTo(null)}
             className="text-txt-tertiary hover:text-txt-primary transition-colors"
-            aria-label="Cancel reply"
+            aria-label={t('chat:composer.cancelReply')}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
               <path d="M18.4 4L12 10.4L5.6 4L4 5.6L10.4 12L4 18.4L5.6 20L12 13.6L18.4 20L20 18.4L13.6 12L20 5.6L18.4 4Z" />
@@ -810,14 +812,14 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
         {/* Staged transfer tiles */}
         {stagedTransfers.length > 0 && (
           <div className="p-4 flex flex-wrap gap-4 bg-surface-channel/30">
-            {stagedTransfers.map((t) => {
-              const isImage = t.file.mimetype.startsWith('image/');
-              const isFinal = t.state === 'completed';
-              const showOverlay = t.state !== 'completed';
-              const previewUrl = previewUrlsRef.current.get(t.id);
+            {stagedTransfers.map((transfer) => {
+              const isImage = transfer.file.mimetype.startsWith('image/');
+              const isFinal = transfer.state === 'completed';
+              const showOverlay = transfer.state !== 'completed';
+              const previewUrl = previewUrlsRef.current.get(transfer.id);
               return (
                 <div
-                  key={t.id}
+                  key={transfer.id}
                   className="relative group bg-surface-channel rounded-lg p-2 max-w-[200px] shadow-elevation-low border border-border-hard overflow-hidden"
                 >
                   {isImage ? (
@@ -825,7 +827,7 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
                       {previewUrl ? (
                         <img
                           src={previewUrl}
-                          alt={t.file.name}
+                          alt={transfer.file.name}
                           className="w-full h-full object-cover"
                         />
                       ) : (
@@ -844,30 +846,30 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
                           d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                         />
                       </svg>
-                      <span className="truncate max-w-[120px] font-medium">{t.file.name}</span>
+                      <span className="truncate max-w-[120px] font-medium">{transfer.file.name}</span>
                     </div>
                   )}
 
                   {/* Overlay: progress / paused / failed indicator (driven by AttachmentProgress) */}
                   {showOverlay && (
                     <AttachmentProgress
-                      loaded={t.progress.loaded}
-                      total={t.progress.total}
-                      state={t.state}
-                      filename={t.file.name}
+                      loaded={transfer.progress.loaded}
+                      total={transfer.progress.total}
+                      state={transfer.state}
+                      filename={transfer.file.name}
                       size="tile"
-                      onPause={t.state === 'active' ? () => pauseUpload(t.id) : undefined}
-                      onResume={t.state === 'paused' ? () => void resumeUpload(t.id) : undefined}
-                      onAbort={() => removeStagedTransfer(t.id)}
+                      onPause={transfer.state === 'active' ? () => pauseUpload(transfer.id) : undefined}
+                      onResume={transfer.state === 'paused' ? () => void resumeUpload(transfer.id) : undefined}
+                      onAbort={() => removeStagedTransfer(transfer.id)}
                     />
                   )}
 
                   {/* Final-state remove button (top-right rose chip) — only when completed */}
                   {isFinal && (
                     <button
-                      onClick={() => removeStagedTransfer(t.id)}
+                      onClick={() => removeStagedTransfer(transfer.id)}
                       className="absolute -top-2 -right-2 w-7 h-7 bg-accent-rose hover:bg-accent-rose/80 shadow-elevation-high rounded-lg flex items-center justify-center text-white transition-colors z-10"
-                      aria-label="Remove attachment"
+                      aria-label={t('chat:composer.removeAttachment')}
                     >
                       <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
                         <path d="M5 2a1 1 0 011-1h4a1 1 0 011 1v1h3a1 1 0 110 2h-.08L13 14a2 2 0 01-2 2H5a2 2 0 01-2-2L2.08 5H2a1 1 0 110-2h3V2zm2 0v1h2V2H7z" />
@@ -886,8 +888,8 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
             <button
               onClick={() => fileInputRef.current?.click()}
               className="w-10 h-10 md:w-[34px] md:h-[34px] flex items-center justify-center rounded-[6px] text-txt-tertiary hover:text-txt-secondary transition-colors flex-shrink-0"
-              title="Attach file"
-              aria-label="Attach file"
+              title={t('chat:composer.attachFile')}
+              aria-label={t('chat:composer.attachFile')}
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" />
@@ -915,14 +917,19 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             onPaste={canAttachFiles ? handlePaste : undefined}
-            placeholder={placeholder ?? `Message ${channelName.startsWith('@') ? channelName : `#${channelName}`}`}
+            placeholder={
+              placeholder ??
+              (channelName.startsWith('@')
+                ? t('chat:composer.placeholder.dm', { name: channelName.slice(1) })
+                : t('chat:composer.placeholder.channel', { name: channelName }))
+            }
             className="input-embedded flex-1 py-[10px] px-1 resize-none text-[15px] leading-[1.375rem] max-h-[50vh] scrollbar-thin"
             rows={1}
           />
 
           {/* Active-upload indicator */}
           {anyActiveOrQueued && (
-            <div className="p-3 text-txt-tertiary" title="Uploading…" aria-label="Uploading">
+            <div className="p-3 text-txt-tertiary" title={t('chat:composer.uploading')} aria-label={t('chat:composer.uploadingLabel')}>
               <svg className="w-5 h-5 animate-spin" viewBox="0 0 24 24" fill="none">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
@@ -934,9 +941,9 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
           {failedCount > 0 && (
             <span
               className="text-[12px] font-medium text-accent-rose px-1 flex-shrink-0"
-              title="Remove or retry the failed attachment to send"
+              title={t('chat:composer.failedHint')}
             >
-              {failedCount} failed
+              {t('chat:composer.failedCount', { count: failedCount })}
             </span>
           )}
 
@@ -956,8 +963,8 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
               className={`w-10 h-10 md:w-[34px] md:h-[34px] flex items-center justify-center rounded-[6px] transition-colors flex-shrink-0 ${
                 activePopover === 'gif' ? 'text-accent-primary' : 'text-txt-tertiary hover:text-txt-secondary'
               }`}
-              title="GIF"
-              aria-label="GIF picker"
+              title={t('chat:composer.gif')}
+              aria-label={t('chat:composer.gifPicker')}
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M2 5.5A2.5 2.5 0 0 1 4.5 3h15A2.5 2.5 0 0 1 22 5.5v13a2.5 2.5 0 0 1-2.5 2.5h-15A2.5 2.5 0 0 1 2 18.5v-13ZM5.1 14V10h3.2v1.2H6.5v.6h1.6v1.1H6.5V14H5.1Zm4.5 0V10h1.4v4H9.6Zm2.5 0V10h3.2v1.2h-1.8v.5h1.6v1h-1.6V14h-1.4Z" />
@@ -971,8 +978,8 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
             className={`w-10 h-10 md:w-[34px] md:h-[34px] flex items-center justify-center rounded-[6px] transition-colors flex-shrink-0 ${
               activePopover === 'emoji' ? 'text-accent-primary' : 'text-txt-tertiary hover:text-txt-secondary'
             }`}
-            title="Emoji"
-            aria-label="Emoji picker"
+            title={t('chat:composer.emoji')}
+            aria-label={t('chat:composer.emojiPicker')}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm3.5-9c.83 0 1.5-.67 1.5-1.5S16.33 8 15.5 8 14 8.67 14 9.5s.67 1.5 1.5 1.5zm-7 0c.83 0 1.5-.67 1.5-1.5S9.33 8 8.5 8 7 8.67 7 9.5s.67 1.5 1.5 1.5zm3.5 6.5c2.33 0 4.31-1.46 5.11-3.5H6.89c.8 2.04 2.78 3.5 5.11 3.5z" />
@@ -985,8 +992,8 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
               onClick={() => void handleSubmit()}
               disabled={anyUnshippable}
               className="w-10 h-10 md:w-[34px] md:h-[34px] flex items-center justify-center rounded-[6px] bg-accent-primary hover:bg-accent-primary-hover text-white transition-all duration-150 flex-shrink-0 disabled:opacity-50"
-              aria-label="Send message"
-              title="Send"
+              aria-label={t('chat:composer.sendMessage')}
+              title={t('chat:composer.send')}
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M3.4 20.4l17.45-7.48a1 1 0 000-1.84L3.4 3.6a.993.993 0 00-1.39.91L2 9.12c0 .5.37.93.87.99L17 12 2.87 13.88c-.5.07-.87.5-.87 1l.01 4.61c0 .71.73 1.2 1.39.91z" />

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { formatters } from '../../i18n/formatters';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../../api/client';
@@ -60,6 +61,7 @@ function shouldShowDateDivider(prev: MessageWithUser | undefined, curr: MessageW
 }
 
 export function MessageList({ channelId, jumpToMessageId, onJumpComplete }: MessageListProps) {
+  const { t } = useTranslation(['chat', 'common']);
   const messages = useChatStore((s) => s.messages.get(channelId)) ?? EMPTY_MESSAGES;
   const loadMessages = useChatStore((s) => s.loadMessages);
   const loadMoreMessages = useChatStore((s) => s.loadMoreMessages);
@@ -654,7 +656,7 @@ export function MessageList({ channelId, jumpToMessageId, onJumpComplete }: Mess
   if (!canReadHistory) {
     return (
       <div className="flex-1 flex items-center justify-center">
-        <span className="text-txt-tertiary text-[14px]">You do not have permission to view message history in this channel</span>
+        <span className="text-txt-tertiary text-[14px]">{t('chat:list.noHistoryPermission')}</span>
       </div>
     );
   }
@@ -680,7 +682,7 @@ export function MessageList({ channelId, jumpToMessageId, onJumpComplete }: Mess
         {hasMore && (
           <div style={{ height: PAGINATION_SLOT_HEIGHT_PX }}>
             {showPaginationSkeleton && (
-              <div className="px-4 pt-4" role="status" aria-label="Loading older messages">
+              <div className="px-4 pt-4" role="status" aria-label={t('chat:list.loadingOlder')}>
                 {Array.from({ length: 3 }, (_, i) => (
                   <div
                     key={i}
@@ -756,7 +758,7 @@ export function MessageList({ channelId, jumpToMessageId, onJumpComplete }: Mess
         <div
           className="absolute inset-0 z-10 bg-surface-chat flex flex-col justify-end px-4 pb-6 pointer-events-none"
           role="status"
-          aria-label="Loading messages"
+          aria-label={t('chat:list.loading')}
         >
           {Array.from({ length: 7 }, (_, i) => (
             <div key={i} className="flex gap-3 mb-5" style={{ animationDelay: `${i * 0.15}s` }}>
@@ -784,7 +786,7 @@ export function MessageList({ channelId, jumpToMessageId, onJumpComplete }: Mess
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
             <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
           </svg>
-          <span className="text-[13px] font-medium">Jump to Present</span>
+          <span className="text-[13px] font-medium">{t('chat:list.jumpToPresent')}</span>
         </button>
       )}
     </div>
@@ -792,6 +794,7 @@ export function MessageList({ channelId, jumpToMessageId, onJumpComplete }: Mess
 }
 
 function WelcomeHeader({ channelId }: { channelId: string }) {
+  const { t } = useTranslation(['chat', 'common']);
   const dmChannels = useSpaceStore((s) => s.dmChannels);
   const authUser = useAuthStore((s) => s.user);
   const removeFriend = useSocialStore((s) => s.removeFriend);
@@ -810,7 +813,7 @@ function WelcomeHeader({ channelId }: { channelId: string }) {
     if (isGroupDm) {
       const groupName = formatDmHeaderName(dm, authUser);
       const ownerMember = dm.members.find(m => m.id === dm.ownerId);
-      const ownerName = ownerMember?.displayName ?? ownerMember?.username ?? 'Unknown';
+      const ownerName = ownerMember?.displayName ?? ownerMember?.username ?? t('common:states.unknown');
       const hasFederated = dm.members.some(m => m.homeInstance);
 
       const handleLeaveGroup = async () => {
@@ -838,25 +841,29 @@ function WelcomeHeader({ channelId }: { channelId: string }) {
           </div>
           <h3 className="text-[32px] leading-10 font-bold text-txt-primary mt-2">{groupName}</h3>
           <p className="text-txt-secondary text-[14px] mt-1">
-            This is the beginning of your group conversation.
+            {t('chat:list.welcome.group.intro')}
           </p>
           <p className="text-xs text-txt-tertiary mt-1">
-            Owner:{' '}
-            {ownerMember ? (
-              <button
-                type="button"
-                onClick={handleOwnerClick}
-                className="font-bold text-txt-secondary hover:text-txt-primary hover:underline transition-colors"
-              >
-                @{ownerName}
-              </button>
-            ) : (
-              <strong>@{ownerName}</strong>
-            )}
+            <Trans
+              t={t}
+              i18nKey="chat:list.welcome.group.owner"
+              values={{ name: ownerName }}
+              components={{
+                owner: ownerMember ? (
+                  <button
+                    type="button"
+                    onClick={handleOwnerClick}
+                    className="font-bold text-txt-secondary hover:text-txt-primary hover:underline transition-colors"
+                  />
+                ) : (
+                  <strong />
+                ),
+              }}
+            />
           </p>
           {hasFederated && (
             <p className="text-xs text-txt-tertiary mt-1">
-              Messages are stored on your and your recipients' home instances. They are not end-to-end encrypted.
+              {t('chat:list.welcome.group.federatedNotice')}
             </p>
           )}
           <div className="mt-4 flex items-center gap-2">
@@ -864,13 +871,13 @@ function WelcomeHeader({ channelId }: { channelId: string }) {
               onClick={handleOpenSettings}
               className="px-4 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-[14px] font-medium rounded-[3px] transition-colors"
             >
-              Open Group Settings
+              {t('chat:list.welcome.group.openSettings')}
             </button>
             <button
               onClick={handleLeaveGroup}
               className="px-4 py-1.5 bg-surface-elevated hover:bg-interactive-hover text-[14px] font-medium text-txt-primary rounded-[3px] transition-colors"
             >
-              Leave Group
+              {t('chat:list.welcome.group.leave')}
             </button>
           </div>
           <div className="mt-6 border-b border-interactive-muted" />
@@ -881,7 +888,7 @@ function WelcomeHeader({ channelId }: { channelId: string }) {
     // 1-on-1 DM welcome header
     const otherUser = otherMembers[0];
     const { baseName } = parseFederatedUsername(otherUser?.username ?? '');
-    const displayName = otherUser?.displayName ?? (baseName || 'Direct Message');
+    const displayName = otherUser?.displayName ?? (baseName || t('chat:list.welcome.dm.fallbackName'));
     const mentionName = otherUser?.displayName ?? baseName;
     const isFriend = otherUser ? friends.some(f => f.id === otherUser.id) : false;
 
@@ -892,11 +899,16 @@ function WelcomeHeader({ channelId }: { channelId: string }) {
         </div>
         <h3 className="text-[32px] leading-10 font-bold text-txt-primary">{displayName}</h3>
         <p className="text-txt-secondary text-[14px] mt-1">
-          This is the beginning of your direct message history with <strong>@{mentionName}</strong>.
+          <Trans
+            t={t}
+            i18nKey="chat:list.welcome.dm.intro"
+            values={{ name: mentionName }}
+            components={{ strong: <strong /> }}
+          />
         </p>
         {otherUser?.homeInstance && (
           <p className="text-xs text-txt-tertiary mt-1">
-            Messages are stored on your and your recipient's home instances. They are not end-to-end encrypted.
+            {t('chat:list.welcome.dm.federatedNotice')}
           </p>
         )}
         {isFriend && otherUser && (
@@ -905,7 +917,7 @@ function WelcomeHeader({ channelId }: { channelId: string }) {
               onClick={() => removeFriend(otherUser.id)}
               className="px-4 py-1.5 bg-surface-elevated hover:bg-surface-elevated text-[14px] font-medium text-txt-primary rounded-[3px] transition-colors"
             >
-              Remove Friend
+              {t('chat:list.welcome.dm.removeFriend')}
             </button>
           </div>
         )}
@@ -921,8 +933,8 @@ function WelcomeHeader({ channelId }: { channelId: string }) {
           <path d="M5.88657 21C5.57547 21 5.3399 20.7189 5.39427 20.4126L6.00001 17H2.59511C2.28449 17 2.04905 16.7198 2.10259 16.4138L2.27759 15.4138C2.31946 15.1746 2.52722 15 2.77011 15H6.35001L7.41001 9H4.00511C3.69449 9 3.45905 8.71977 3.51259 8.41381L3.68759 7.41381C3.72946 7.17456 3.93722 7 4.18011 7H7.76001L8.39677 3.41262C8.43914 3.17391 8.64664 3 8.88907 3H9.87344C10.1845 3 10.4201 3.28107 10.3657 3.58738L9.76001 7H15.76L16.3968 3.41262C16.4391 3.17391 16.6466 3 16.8891 3H17.8734C18.1845 3 18.4201 3.28107 18.3657 3.58738L17.76 7H21.1649C21.4755 7 21.711 7.28023 21.6574 7.58619L21.4824 8.58619C21.4406 8.82544 21.2328 9 20.9899 9H17.41L16.35 15H19.7549C20.0655 15 20.301 15.2802 20.2474 15.5862L20.0724 16.5862C20.0306 16.8254 19.8228 17 19.5799 17H16L15.3632 20.5874C15.3209 20.8261 15.1134 21 14.8709 21H13.8866C13.5755 21 13.3399 20.7189 13.3943 20.4126L14 17H8.00001L7.36325 20.5874C7.32088 20.8261 7.11337 21 6.87094 21H5.88657ZM9.41001 9L8.35001 15H14.35L15.41 9H9.41001Z" />
         </svg>
       </div>
-      <h3 className="text-[32px] leading-10 font-bold text-txt-primary">Welcome to the channel!</h3>
-      <p className="text-txt-secondary text-[16px] mt-2">This is the start of the conversation.</p>
+      <h3 className="text-[32px] leading-10 font-bold text-txt-primary">{t('chat:list.welcome.channel.title')}</h3>
+      <p className="text-txt-secondary text-[16px] mt-2">{t('chat:list.welcome.channel.description')}</p>
       <div className="mt-6 border-b border-interactive-muted" />
     </div>
   );

--- a/packages/web/src/components/chat/messageMenuItems.tsx
+++ b/packages/web/src/components/chat/messageMenuItems.tsx
@@ -4,6 +4,7 @@ import type { MessageWithUser } from '@backspace/shared';
 import { saveImage, copyImageToClipboard } from '../../utils/imageActions';
 import { useUIStore } from '../../stores/uiStore';
 import { useTransferStore } from '../../stores/transferStore';
+import i18n from '../../i18n';
 
 const QUICK_EMOJIS = ['👍', '❤️', '😂', '😮'];
 
@@ -65,7 +66,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'save-image',
       type: 'action',
-      label: 'Save Image',
+      label: i18n.t('chat:menu.saveImage'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
@@ -76,7 +77,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'copy-image',
       type: 'action',
-      label: 'Copy Image',
+      label: i18n.t('chat:menu.copyImage'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M21 9v10c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2h7l6 6zm-2 1h-5V4H8v15h11V10zM3 15V3c0-1.1.9-2 2-2h9v2H5v12H3z" />
@@ -90,7 +91,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
       items.push({
         key: 'open-original',
         type: 'action',
-        label: 'Open Original',
+        label: i18n.t('chat:menu.openOriginal'),
         icon: (
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
             <path d="M19 19H5V5h7V3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
@@ -109,7 +110,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'save-video',
       type: 'action',
-      label: 'Save Video',
+      label: i18n.t('chat:menu.saveVideo'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
@@ -132,7 +133,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'save-audio',
       type: 'action',
-      label: 'Save Audio',
+      label: i18n.t('chat:menu.saveAudio'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
@@ -155,7 +156,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'copy-link',
       type: 'action',
-      label: 'Copy Link',
+      label: i18n.t('chat:menu.copyLink'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z" />
@@ -163,16 +164,16 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
       ),
       onClick: () => {
         navigator.clipboard.writeText(sourceUrl).then(() => {
-          useUIStore.getState().addToast('Copied link', 'success', 3000);
+          useUIStore.getState().addToast(i18n.t('chat:menu.linkCopied'), 'success', 3000);
         }).catch(() => {
-          useUIStore.getState().addToast('Failed to copy link', 'warning', 3000);
+          useUIStore.getState().addToast(i18n.t('chat:menu.linkCopyFailed'), 'warning', 3000);
         });
       },
     });
     items.push({
       key: 'open-link',
       type: 'action',
-      label: 'Open Link',
+      label: i18n.t('chat:menu.openLink'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M19 19H5V5h7V3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" />
@@ -210,7 +211,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
               onOpenEmojiPicker();
             }}
             className="glass-pill w-9 h-9 flex items-center justify-center text-txt-tertiary hover:text-txt-secondary hover:bg-interactive-hover rounded-lg transition-colors"
-            title="Add reaction"
+            title={i18n.t('chat:menu.addReaction')}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm1-13h-2v4H7v2h4v4h2v-4h4v-2h-4V7z" />
@@ -228,7 +229,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'reply',
       type: 'action',
-      label: 'Reply',
+      label: i18n.t('chat:menu.reply'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M10 9V5L3 12L10 19V14.9C15 14.9 18.5 16.5 21 20C20 15 17 10 10 9Z" />
@@ -243,7 +244,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
   items.push({
     key: 'copy-selected',
     type: 'action',
-    label: 'Copy Selected Text',
+    label: i18n.t('chat:menu.copySelectedText'),
     hidden: selectedText.length === 0,
     icon: (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -258,7 +259,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
   items.push({
     key: 'copy-text',
     type: 'action',
-    label: 'Copy Text',
+    label: i18n.t('chat:menu.copyText'),
     hidden: !message.content || !!sourceUrl,
     icon: (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
@@ -276,7 +277,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
   items.push({
     key: 'mark-unread',
     type: 'action',
-    label: 'Mark Unread',
+    label: i18n.t('chat:menu.markUnread'),
     icon: (
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
@@ -296,7 +297,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'edit',
       type: 'action',
-      label: 'Edit Message',
+      label: i18n.t('chat:menu.editMessage'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
@@ -312,7 +313,7 @@ export function buildMessageMenuItems(params: MessageMenuParams): ContextMenuIte
     items.push({
       key: 'delete',
       type: 'action',
-      label: 'Delete Message',
+      label: i18n.t('chat:menu.deleteMessage'),
       icon: (
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />

--- a/packages/web/src/locales/de/chat.json
+++ b/packages/web/src/locales/de/chat.json
@@ -1,1 +1,90 @@
-{}
+{
+  "message": {
+    "timestamp": {
+      "today": "Heute um {{time}}",
+      "yesterday": "Gestern um {{time}}"
+    },
+    "edit": {
+      "hint": "Esc zum <cancel>Abbrechen</cancel> • Enter zum <save>Speichern</save>"
+    },
+    "edited": "(bearbeitet)",
+    "gifAlt": "GIF-Animation",
+    "upload": {
+      "failed": "Upload fehlgeschlagen",
+      "discard": "Verwerfen"
+    },
+    "actions": {
+      "addReaction": "Reaktion hinzufügen",
+      "reply": "Antworten",
+      "confirmDelete": "Löschen bestätigen"
+    }
+  },
+  "list": {
+    "noHistoryPermission": "Du hast keine Berechtigung, den Nachrichtenverlauf dieses Kanals zu sehen",
+    "loading": "Nachrichten werden geladen",
+    "loadingOlder": "Ältere Nachrichten werden geladen",
+    "jumpToPresent": "Zu den neuesten Nachrichten",
+    "welcome": {
+      "channel": {
+        "title": "Willkommen im Kanal!",
+        "description": "Hier beginnt die Unterhaltung."
+      },
+      "group": {
+        "intro": "Hier beginnt eure Gruppenunterhaltung.",
+        "owner": "Besitzer: <owner>@{{name}}</owner>",
+        "federatedNotice": "Nachrichten werden auf deiner Heimatinstanz und denen deiner Gesprächspartner gespeichert. Sie sind nicht Ende-zu-Ende-verschlüsselt.",
+        "openSettings": "Gruppeneinstellungen öffnen",
+        "leave": "Gruppe verlassen"
+      },
+      "dm": {
+        "fallbackName": "Direktnachricht",
+        "intro": "Hier beginnt dein Direktnachrichten-Verlauf mit <strong>@{{name}}</strong>.",
+        "federatedNotice": "Nachrichten werden auf deiner Heimatinstanz und der deines Gesprächspartners gespeichert. Sie sind nicht Ende-zu-Ende-verschlüsselt.",
+        "removeFriend": "Freund entfernen"
+      }
+    }
+  },
+  "composer": {
+    "noPermission": "Du hast keine Berechtigung, in diesem Kanal Nachrichten zu senden",
+    "placeholder": {
+      "channel": "Nachricht an #{{name}}",
+      "dm": "Nachricht an @{{name}}"
+    },
+    "replyingTo": "Antwort an",
+    "cancelReply": "Antwort abbrechen",
+    "removeAttachment": "Anhang entfernen",
+    "attachFile": "Datei anhängen",
+    "uploading": "Wird hochgeladen…",
+    "uploadingLabel": "Wird hochgeladen",
+    "failedCount_one": "{{count}} fehlgeschlagen",
+    "failedCount_other": "{{count}} fehlgeschlagen",
+    "failedHint": "Entferne den fehlgeschlagenen Anhang oder versuche es erneut, um zu senden",
+    "gif": "GIFs",
+    "gifPicker": "GIF-Auswahl",
+    "emoji": "Emojis",
+    "emojiPicker": "Emoji-Auswahl",
+    "send": "Senden",
+    "sendMessage": "Nachricht senden",
+    "uploadFailed": "{{file}} konnte nicht hochgeladen werden: {{reason}}",
+    "uploadFailedReason": "Upload fehlgeschlagen",
+    "sendFailed": "Nachricht konnte nicht gesendet werden"
+  },
+  "menu": {
+    "saveImage": "Bild speichern",
+    "copyImage": "Bild kopieren",
+    "openOriginal": "Original öffnen",
+    "saveVideo": "Video speichern",
+    "saveAudio": "Audio speichern",
+    "copyLink": "Link kopieren",
+    "openLink": "Link öffnen",
+    "addReaction": "Reaktion hinzufügen",
+    "reply": "Antworten",
+    "copySelectedText": "Markierten Text kopieren",
+    "copyText": "Text kopieren",
+    "markUnread": "Als ungelesen markieren",
+    "editMessage": "Nachricht bearbeiten",
+    "deleteMessage": "Nachricht löschen",
+    "linkCopied": "Link kopiert",
+    "linkCopyFailed": "Link konnte nicht kopiert werden"
+  }
+}

--- a/packages/web/src/locales/en/chat.json
+++ b/packages/web/src/locales/en/chat.json
@@ -1,1 +1,90 @@
-{}
+{
+  "message": {
+    "timestamp": {
+      "today": "Today at {{time}}",
+      "yesterday": "Yesterday at {{time}}"
+    },
+    "edit": {
+      "hint": "escape to <cancel>cancel</cancel> • enter to <save>save</save>"
+    },
+    "edited": "(edited)",
+    "gifAlt": "GIF",
+    "upload": {
+      "failed": "Upload failed",
+      "discard": "Discard"
+    },
+    "actions": {
+      "addReaction": "Add reaction",
+      "reply": "Reply",
+      "confirmDelete": "Confirm delete"
+    }
+  },
+  "list": {
+    "noHistoryPermission": "You do not have permission to view message history in this channel",
+    "loading": "Loading messages",
+    "loadingOlder": "Loading older messages",
+    "jumpToPresent": "Jump to Present",
+    "welcome": {
+      "channel": {
+        "title": "Welcome to the channel!",
+        "description": "This is the start of the conversation."
+      },
+      "group": {
+        "intro": "This is the beginning of your group conversation.",
+        "owner": "Owner: <owner>@{{name}}</owner>",
+        "federatedNotice": "Messages are stored on your and your recipients' home instances. They are not end-to-end encrypted.",
+        "openSettings": "Open Group Settings",
+        "leave": "Leave Group"
+      },
+      "dm": {
+        "fallbackName": "Direct Message",
+        "intro": "This is the beginning of your direct message history with <strong>@{{name}}</strong>.",
+        "federatedNotice": "Messages are stored on your and your recipient's home instances. They are not end-to-end encrypted.",
+        "removeFriend": "Remove Friend"
+      }
+    }
+  },
+  "composer": {
+    "noPermission": "You do not have permission to send messages in this channel",
+    "placeholder": {
+      "channel": "Message #{{name}}",
+      "dm": "Message @{{name}}"
+    },
+    "replyingTo": "Replying to",
+    "cancelReply": "Cancel reply",
+    "removeAttachment": "Remove attachment",
+    "attachFile": "Attach file",
+    "uploading": "Uploading…",
+    "uploadingLabel": "Uploading",
+    "failedCount_one": "{{count}} failed",
+    "failedCount_other": "{{count}} failed",
+    "failedHint": "Remove or retry the failed attachment to send",
+    "gif": "GIF",
+    "gifPicker": "GIF picker",
+    "emoji": "Emoji",
+    "emojiPicker": "Emoji picker",
+    "send": "Send",
+    "sendMessage": "Send message",
+    "uploadFailed": "Failed to upload {{file}}: {{reason}}",
+    "uploadFailedReason": "Upload failed",
+    "sendFailed": "Failed to send message"
+  },
+  "menu": {
+    "saveImage": "Save Image",
+    "copyImage": "Copy Image",
+    "openOriginal": "Open Original",
+    "saveVideo": "Save Video",
+    "saveAudio": "Save Audio",
+    "copyLink": "Copy Link",
+    "openLink": "Open Link",
+    "addReaction": "Add reaction",
+    "reply": "Reply",
+    "copySelectedText": "Copy Selected Text",
+    "copyText": "Copy Text",
+    "markUnread": "Mark Unread",
+    "editMessage": "Edit Message",
+    "deleteMessage": "Delete Message",
+    "linkCopied": "Copied link",
+    "linkCopyFailed": "Failed to copy link"
+  }
+}

--- a/packages/web/src/locales/ru/chat.json
+++ b/packages/web/src/locales/ru/chat.json
@@ -1,1 +1,92 @@
-{}
+{
+  "message": {
+    "timestamp": {
+      "today": "Сегодня в {{time}}",
+      "yesterday": "Вчера в {{time}}"
+    },
+    "edit": {
+      "hint": "Esc для <cancel>отмены</cancel> • Enter для <save>сохранения</save>"
+    },
+    "edited": "(изменено)",
+    "gifAlt": "GIF-анимация",
+    "upload": {
+      "failed": "Не удалось загрузить файл",
+      "discard": "Отменить отправку"
+    },
+    "actions": {
+      "addReaction": "Добавить реакцию",
+      "reply": "Ответить",
+      "confirmDelete": "Подтвердить удаление"
+    }
+  },
+  "list": {
+    "noHistoryPermission": "У вас нет разрешения на просмотр истории сообщений в этом канале",
+    "loading": "Загрузка сообщений",
+    "loadingOlder": "Загрузка предыдущих сообщений",
+    "jumpToPresent": "К новым сообщениям",
+    "welcome": {
+      "channel": {
+        "title": "Добро пожаловать в канал!",
+        "description": "Это начало беседы."
+      },
+      "group": {
+        "intro": "Это начало вашей групповой беседы.",
+        "owner": "Владелец: <owner>@{{name}}</owner>",
+        "federatedNotice": "Сообщения хранятся на домашних серверах — вашем и ваших собеседников. Сквозное шифрование не используется.",
+        "openSettings": "Открыть настройки группы",
+        "leave": "Покинуть группу"
+      },
+      "dm": {
+        "fallbackName": "Личные сообщения",
+        "intro": "Это начало вашей переписки с <strong>@{{name}}</strong>.",
+        "federatedNotice": "Сообщения хранятся на домашних серверах — вашем и вашего собеседника. Сквозное шифрование не используется.",
+        "removeFriend": "Удалить из друзей"
+      }
+    }
+  },
+  "composer": {
+    "noPermission": "У вас нет разрешения на отправку сообщений в этом канале",
+    "placeholder": {
+      "channel": "Написать в #{{name}}",
+      "dm": "Написать @{{name}}"
+    },
+    "replyingTo": "Ответ для",
+    "cancelReply": "Отменить ответ",
+    "removeAttachment": "Удалить вложение",
+    "attachFile": "Прикрепить файл",
+    "uploading": "Загрузка…",
+    "uploadingLabel": "Загрузка",
+    "failedCount_one": "{{count}} с ошибкой",
+    "failedCount_few": "{{count}} с ошибкой",
+    "failedCount_many": "{{count}} с ошибкой",
+    "failedCount_other": "{{count}} с ошибкой",
+    "failedHint": "Удалите вложение с ошибкой или повторите загрузку, чтобы отправить сообщение",
+    "gif": "GIF-анимации",
+    "gifPicker": "Выбор GIF",
+    "emoji": "Эмодзи",
+    "emojiPicker": "Выбор эмодзи",
+    "send": "Отправить",
+    "sendMessage": "Отправить сообщение",
+    "uploadFailed": "Не удалось загрузить {{file}}: {{reason}}",
+    "uploadFailedReason": "Ошибка загрузки",
+    "sendFailed": "Не удалось отправить сообщение"
+  },
+  "menu": {
+    "saveImage": "Сохранить изображение",
+    "copyImage": "Копировать изображение",
+    "openOriginal": "Открыть оригинал",
+    "saveVideo": "Сохранить видео",
+    "saveAudio": "Сохранить аудио",
+    "copyLink": "Копировать ссылку",
+    "openLink": "Открыть ссылку",
+    "addReaction": "Добавить реакцию",
+    "reply": "Ответить",
+    "copySelectedText": "Копировать выделенный текст",
+    "copyText": "Копировать текст",
+    "markUnread": "Отметить как непрочитанное",
+    "editMessage": "Изменить сообщение",
+    "deleteMessage": "Удалить сообщение",
+    "linkCopied": "Ссылка скопирована",
+    "linkCopyFailed": "Не удалось скопировать ссылку"
+  }
+}


### PR DESCRIPTION
The message surface of the chat, in English, Russian and German: the message row and its hover bar, the message list with its welcome and loading states, the composer, and the message context menu. The strings live in the `chat` namespace under `message`, `list`, `composer` and `menu`.

Things a reviewer should know:

- The composer placeholder is now built per case ("Message #channel", "Message @name"). DM screens that pass their own placeholder still send English until the DM sweep lands.
- The welcome strings for DMs and group DMs live in `chat` because the message list renders them. Moving them under `dm` later is a key rename, not a code change.
- One loop parameter in the staged-transfer render was renamed because it shadowed the translation function. That is the only code change beyond string replacement.
- Type check, the web test suite and the i18n consistency check are clean. No test was changed.

The Russian strings come from st7105's translation in PR #45. A few had drifted (an imperfective "send", the edit hint had been translated word by word) and were corrected.
