### PR TITLE
feat(i18n): localize direct messages

### DIFF
--- a/packages/web/src/components/chat/DmDeletedNotice.tsx
+++ b/packages/web/src/components/chat/DmDeletedNotice.tsx
@@ -1,15 +1,18 @@
+import { useTranslation } from 'react-i18next';
+
 /**
  * Read-only composer replacement shown in a 1-on-1 DM whose partner's account
  * was deleted. Occupies the same bottom slot as the MessageInput glass bubble.
  */
 export function DmDeletedNotice() {
+  const { t } = useTranslation(['dm', 'common']);
   return (
     <div className="px-4 pb-4 pt-1">
       <div className="glass-bubble flex items-center gap-2 px-4 py-3 rounded-[14px] text-txt-tertiary text-[14px] justify-center select-none">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" className="opacity-70 flex-shrink-0">
           <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
         </svg>
-        <span>This user&rsquo;s account was deleted</span>
+        <span>{t('dm:deletedNotice.accountDeleted')}</span>
       </div>
     </div>
   );

--- a/packages/web/src/components/layout/DmMemberRow.tsx
+++ b/packages/web/src/components/layout/DmMemberRow.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { User } from '@backspace/shared';
 import { ProfileAvatar } from '../ui/ProfileAvatar';
 import { Username } from '../ui/Username';
@@ -86,6 +87,7 @@ export function DmMemberRow({
   alwaysShowKebab = false,
   onMenuAction,
 }: DmMemberRowProps) {
+  const { t } = useTranslation(['dm', 'common']);
   const canonical = useCanonicalUserView(member);
   const openContextMenu = useContextMenuStore((s) => s.open);
   const rowRef = useRef<HTMLDivElement>(null);
@@ -101,7 +103,7 @@ export function DmMemberRow({
     items.push({
       key: 'profile',
       type: 'action',
-      label: 'View Profile',
+      label: t('dm:memberRow.viewProfile'),
       onClick: () => {
         // Anchor the popout to this row's bounding rect — matches the
         // MemberSidebar pattern (see MemberSidebar.tsx). On mobile the anchor
@@ -125,7 +127,7 @@ export function DmMemberRow({
       items.push({
         key: 'transfer',
         type: 'action',
-        label: 'Transfer Ownership',
+        label: t('dm:memberRow.transferOwnership'),
         onClick: () => onMenuAction('transfer', canonical),
       });
     }
@@ -134,7 +136,7 @@ export function DmMemberRow({
       items.push({
         key: 'kick',
         type: 'action',
-        label: 'Remove from Group',
+        label: t('dm:memberRow.removeFromGroup'),
         danger: true,
         onClick: () => onMenuAction('kick', canonical),
       });
@@ -148,7 +150,7 @@ export function DmMemberRow({
       items.push({
         key: 'remove-friend',
         type: 'action',
-        label: 'Remove Friend',
+        label: t('dm:memberRow.removeFriend'),
         danger: true,
         onClick: () => onMenuAction('remove-friend', canonical),
       });
@@ -206,7 +208,7 @@ export function DmMemberRow({
             </Tooltip>
           )}
           {isOwner && (
-            <Tooltip content="Group Owner" position="top">
+            <Tooltip content={t('dm:memberRow.ownerTooltip')} position="top">
               <span data-owner-crown className="inline-flex">
                 <CrownIcon />
               </span>
@@ -230,7 +232,7 @@ export function DmMemberRow({
       {showKebab && (
         <button
           type="button"
-          aria-label="Member actions"
+          aria-label={t('dm:memberRow.actions')}
           data-dm-member-kebab
           onClick={handleKebabClick}
           onContextMenu={(e) => {

--- a/packages/web/src/components/layout/DmRosterPanel.tsx
+++ b/packages/web/src/components/layout/DmRosterPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { User } from '@backspace/shared';
 import { useChatStore } from '../../stores/chatStore';
 import { useSpaceStore } from '../../stores/spaceStore';
@@ -21,6 +22,7 @@ import { pointAnchor } from '../../hooks/useFloatingPosition';
  * separate boolean and explicitly carries the user's global toggle preference.
  */
 export function DmRosterPanel() {
+  const { t } = useTranslation(['dm', 'common']);
   const memberListOpen = useUIStore((s) => s.memberListOpen);
   const openUserProfile = useUIStore((s) => s.openUserProfile);
   const addToast = useUIStore((s) => s.addToast);
@@ -110,7 +112,7 @@ export function DmRosterPanel() {
         await removeFriendStore(member.id);
       } catch (err) {
         addToast(
-          err instanceof Error ? err.message : 'Failed to remove friend',
+          err instanceof Error ? err.message : t('dm:removeFriend.failed'),
           'warning',
           3000,
         );
@@ -134,14 +136,14 @@ export function DmRosterPanel() {
         : undefined;
       await api.dm.kickMember(dmChannel.id, pendingKick.id, federated);
       addToast(
-        `Removed ${pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName} from the group`,
+        t('dm:kick.success', { name: pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName }),
         'success',
         3000,
       );
       setPendingKick(null);
     } catch (err) {
       addToast(
-        err instanceof Error ? err.message : 'Failed to remove member',
+        err instanceof Error ? err.message : t('dm:kick.failed'),
         'warning',
         3000,
       );
@@ -160,14 +162,14 @@ export function DmRosterPanel() {
         : undefined;
       await api.dm.transferOwnership(dmChannel.id, pendingTransfer.id, federated);
       addToast(
-        `Ownership transferred to ${pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName}`,
+        t('dm:transfer.success', { name: pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName }),
         'success',
         3000,
       );
       setPendingTransfer(null);
     } catch (err) {
       addToast(
-        err instanceof Error ? err.message : 'Failed to transfer ownership',
+        err instanceof Error ? err.message : t('dm:transfer.failed'),
         'warning',
         3000,
       );
@@ -191,13 +193,13 @@ export function DmRosterPanel() {
           data-dm-roster-header
           className="text-[10.5px] font-bold text-txt-tertiary uppercase tracking-[0.06em] px-2 mb-2"
         >
-          Members — {totalCount}
+          {t('dm:roster.sectionCount', { label: t('dm:roster.members'), total: totalCount })}
         </h3>
 
         {ownerMember && (
           <div data-dm-roster-section="owner" className="mb-4">
             <h4 className="text-[10.5px] font-bold text-txt-tertiary uppercase tracking-[0.06em] px-2 mb-1">
-              OWNER
+              {t('dm:roster.owner')}
             </h4>
             <DmMemberRow
               member={ownerMember}
@@ -214,7 +216,7 @@ export function DmRosterPanel() {
         {onlineMembers.length > 0 && (
           <div data-dm-roster-section="online" className="mb-4">
             <h4 className="text-[10.5px] font-bold text-txt-tertiary uppercase tracking-[0.06em] px-2 mb-1">
-              ONLINE — {onlineMembers.length}
+              {t('dm:roster.sectionCount', { label: t('dm:roster.online'), total: onlineMembers.length })}
             </h4>
             {onlineMembers.map((m) => (
               <DmMemberRow
@@ -234,7 +236,7 @@ export function DmRosterPanel() {
         {offlineMembers.length > 0 && (
           <div data-dm-roster-section="offline" className="opacity-60">
             <h4 className="text-[10.5px] font-bold text-txt-tertiary uppercase tracking-[0.06em] px-2 mb-1">
-              OFFLINE — {offlineMembers.length}
+              {t('dm:roster.sectionCount', { label: t('dm:roster.offline'), total: offlineMembers.length })}
             </h4>
             {offlineMembers.map((m) => (
               <DmMemberRow
@@ -256,13 +258,13 @@ export function DmRosterPanel() {
         isOpen={!!pendingKick}
         onClose={() => { if (!submitting) setPendingKick(null); }}
         onConfirm={confirmKick}
-        title="Remove from Group"
+        title={t('dm:kick.title')}
         description={
           pendingKick
-            ? `Remove ${pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName} from this group? They won't be able to see new messages.`
+            ? t('dm:kick.description', { name: pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName })
             : ''
         }
-        confirmLabel="Remove"
+        confirmLabel={t('common:actions.remove')}
         variant="danger"
         loading={submitting}
       />
@@ -271,13 +273,13 @@ export function DmRosterPanel() {
         isOpen={!!pendingTransfer}
         onClose={() => { if (!submitting) setPendingTransfer(null); }}
         onConfirm={confirmTransfer}
-        title="Transfer Ownership"
+        title={t('dm:transfer.title')}
         description={
           pendingTransfer
-            ? `Transfer ownership to ${pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName}? You'll lose owner privileges.`
+            ? t('dm:transfer.description', { name: pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName })
             : ''
         }
-        confirmLabel="Transfer"
+        confirmLabel={t('dm:transfer.confirm')}
         variant="warning"
         loading={submitting}
       />

--- a/packages/web/src/components/layout/DmSearchBar.tsx
+++ b/packages/web/src/components/layout/DmSearchBar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import type { User, DmChannel } from '@backspace/shared';
 import { Avatar } from '../ui/Avatar';
@@ -144,6 +145,7 @@ interface UserItem {
 type ResultItem = DmItem | UserItem;
 
 export function DmSearchBar() {
+  const { t } = useTranslation(['dm', 'common']);
   const [active, setActive] = useState(false);
   const [query, setQuery] = useState('');
   const [userResults, setUserResults] = useState<User[]>([]);
@@ -179,7 +181,7 @@ export function DmSearchBar() {
         const displayName = isGroup
           ? (otherMembers.length > 0
             ? otherMembers.map(m => m.displayName ?? parseFederatedUsername(m.username).baseName).join(', ')
-            : 'Empty Group')
+            : t('dm:names.emptyGroup'))
           : otherMembers[0]?.displayName ?? otherMembers[0]?.username ?? '';
         return { type: 'dm', dm, displayName, otherMembers, isGroup };
       })
@@ -194,7 +196,7 @@ export function DmSearchBar() {
         );
       })
       .slice(0, MAX_RECENT);
-  }, [dmChannels, query, user]);
+  }, [dmChannels, query, user, t]);
 
   // De-duplicate user results against shown 1-on-1 DMs
   const filteredUserResults = useMemo((): UserItem[] => {
@@ -307,10 +309,10 @@ export function DmSearchBar() {
         useUIStore.getState().setShowDms(true);
         navigate(`/channels/@me/${channel.id}`);
       } catch (err) {
-        setError((err as Error).message || 'Failed to create DM');
+        setError((err as Error).message || t('dm:search.createFailed'));
       }
     }
-  }, [close, navigate, addDmChannel]);
+  }, [close, navigate, addDmChannel, t]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -364,7 +366,7 @@ export function DmSearchBar() {
 
         {allItems.length === 0 && !isSearching && query.trim().length === 0 && dmItems.length === 0 && (
           <div className="px-3 py-4 text-center text-txt-tertiary text-[13px]">
-            Search for a user to start chatting
+            {t('dm:search.emptyHint')}
           </div>
         )}
 
@@ -373,7 +375,7 @@ export function DmSearchBar() {
           <>
             {query.trim().length >= 2 && (
               <div className="px-3 pt-1.5 pb-1 text-[11px] font-bold text-txt-tertiary uppercase tracking-wider">
-                Conversations
+                {t('dm:search.conversations')}
               </div>
             )}
             {dmItems.map((item, i) => {
@@ -396,10 +398,10 @@ export function DmSearchBar() {
         {(filteredUserResults.length > 0 || (isSearching && query.trim().length >= 2)) && (
           <>
             <div className="px-3 pt-1.5 pb-1 text-[11px] font-bold text-txt-tertiary uppercase tracking-wider">
-              Users
+              {t('dm:search.users')}
             </div>
             {isSearching && filteredUserResults.length === 0 && (
-              <div className="px-3 py-2 text-center text-txt-tertiary text-[13px]">Searching...</div>
+              <div className="px-3 py-2 text-center text-txt-tertiary text-[13px]">{t('dm:search.searching')}</div>
             )}
             {filteredUserResults.map((item, i) => {
               const globalIndex = dmItems.length + i;
@@ -419,9 +421,10 @@ export function DmSearchBar() {
 
         {/* No results */}
         {!isSearching && query.trim().length >= 2 && allItems.length === 0 && (
-          <div className="px-3 py-4 text-center text-txt-tertiary text-[13px]">No results found</div>
+          <div className="px-3 py-4 text-center text-txt-tertiary text-[13px]">{t('dm:search.noResults')}</div>
         )}
       </div>
+      {/* i18n-check: allow-literal — what follows is the createPortal argument list, not JSX text */}
     </div>,
     document.body,
   ) : null;
@@ -439,7 +442,7 @@ export function DmSearchBar() {
             value={query}
             onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0); }}
             onKeyDown={handleKeyDown}
-            placeholder="Search..."
+            placeholder={t('dm:search.placeholder')}
             className="input-embedded flex-1 min-w-0 text-[13px] font-medium py-[5px]"
           />
         </div>
@@ -448,7 +451,7 @@ export function DmSearchBar() {
           onClick={open}
           className="w-full min-h-8 bg-surface-input text-txt-tertiary text-[13px] font-medium py-[5px] px-2 rounded-[4px] text-left border border-white/[0.06] shadow-input hover:border-white/[0.1] transition-colors"
         >
-          Find or start a conversation
+          {t('dm:search.trigger')}
         </button>
       )}
       {dropdown}

--- a/packages/web/src/components/layout/MobileDmsScreen.tsx
+++ b/packages/web/src/components/layout/MobileDmsScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useFormatters } from '../../i18n/formatters';
 import { useUIStore } from '../../stores/uiStore';
 import { useSpaceStore } from '../../stores/spaceStore';
@@ -83,6 +84,7 @@ function MobileDmRow({
   onContextMenu: (e: React.MouseEvent, id: string, isGroup: boolean) => void;
   formatTimestamp: (ts: number) => string;
 }) {
+  const { t } = useTranslation(['dm', 'common']);
   const otherMembers = dm.members.filter(m => authUser ? !isSelf(m, authUser) : m.id !== authUser);
   const isGroup = !!dm.ownerId;
   const rawMainUser = otherMembers[0] ?? null;
@@ -94,7 +96,7 @@ function MobileDmRow({
   // keep the canonical view of the single other member.
   const name = isGroup
     ? formatDmHeaderName(dm, authUser ?? null)
-    : mainUser?.displayName ?? (parseFederatedUsername(mainUser?.username ?? '').baseName || 'Unknown');
+    : mainUser?.displayName ?? (parseFederatedUsername(mainUser?.username ?? '').baseName || t('common:states.unknown'));
 
   // Show a single federation globe next to the group name when any non-self
   // member is federated. No tooltip on mobile — the new `group-dm-info` screen
@@ -182,6 +184,7 @@ function MobileDmRow({
 }
 
 export function MobileDmsScreen() {
+  const { t } = useTranslation(['dm', 'common']);
   const pushMobileScreen = useUIStore((s) => s.pushMobileScreen);
   const openModal = useUIStore((s) => s.openModal);
 
@@ -224,7 +227,7 @@ export function MobileDmsScreen() {
       {
         key: 'leave-group',
         type: 'action',
-        label: 'Leave Group',
+        label: t('dm:list.leaveGroup'),
         danger: true,
         icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9" /></svg>,
         onClick: () => {
@@ -242,10 +245,10 @@ export function MobileDmsScreen() {
   const formatTimestamp = (ts: number): string => {
     const now = Date.now();
     const diff = now - ts;
-    if (diff < 60_000) return 'now';
-    if (diff < 3600_000) return `${Math.floor(diff / 60_000)}m`;
-    if (diff < 86400_000) return `${Math.floor(diff / 3600_000)}h`;
-    if (diff < 604800_000) return `${Math.floor(diff / 86400_000)}d`;
+    if (diff < 60_000) return t('dm:list.justNow');
+    if (diff < 3600_000) return t('dm:list.minutesShort', { count: Math.floor(diff / 60_000) });
+    if (diff < 86400_000) return t('dm:list.hoursShort', { count: Math.floor(diff / 3600_000) });
+    if (diff < 604800_000) return t('dm:list.daysShort', { count: Math.floor(diff / 86400_000) });
     return f.formatShortDate(ts);
   };
 
@@ -253,13 +256,13 @@ export function MobileDmsScreen() {
     <div className="flex flex-col h-full bg-surface-base">
       {/* Header */}
       <header className="h-12 flex items-center justify-between px-4 border-b border-border-soft shrink-0">
-        <h1 className="text-base font-semibold text-txt-primary">Messages</h1>
+        <h1 className="text-base font-semibold text-txt-primary">{t('dm:list.title')}</h1>
         <div className="flex items-center gap-1">
           <button
             onClick={() => pushMobileScreen('friends')}
             className="h-8 px-3 rounded-lg text-xs font-medium text-accent-primary hover:bg-interactive-hover transition-colors"
           >
-            Friends
+            {t('dm:list.friends')}
           </button>
         </div>
       </header>
@@ -297,7 +300,7 @@ export function MobileDmsScreen() {
         {sortedDms.length === 0 && (
           <div className="flex flex-col items-center justify-center h-40 opacity-80">
             <Mascot state="sleeping" className="w-20 h-20 mb-2" />
-            <p className="text-txt-tertiary text-sm">No conversations yet.</p>
+            <p className="text-txt-tertiary text-sm">{t('dm:list.empty')}</p>
           </div>
         )}
       </div>

--- a/packages/web/src/components/layout/MobileGroupDmInfo.tsx
+++ b/packages/web/src/components/layout/MobileGroupDmInfo.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { DmChannel, User } from '@backspace/shared';
 import { useUIStore } from '../../stores/uiStore';
 import { useSpaceStore } from '../../stores/spaceStore';
@@ -63,6 +64,7 @@ interface MobileGroupDmInfoProps {
  * `MobileChatScreen`'s members button).
  */
 export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
+  const { t } = useTranslation(['dm', 'common']);
   const channelId = params?.channelId ?? null;
 
   const dmChannels = useSpaceStore((s) => s.dmChannels);
@@ -133,9 +135,9 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
   if (!dmChannel) {
     return (
       <div className="flex flex-col h-full bg-surface-base">
-        <MobileScreenHeader title="Group Info" />
+        <MobileScreenHeader title={t('dm:groupInfo.title')} />
         <div className="flex-1 flex items-center justify-center text-txt-tertiary text-sm">
-          Conversation not found.
+          {t('dm:groupInfo.notFound')}
         </div>
       </div>
     );
@@ -144,9 +146,9 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
   if (!dmChannel.ownerId) {
     return (
       <div className="flex flex-col h-full bg-surface-base">
-        <MobileScreenHeader title="Info" />
+        <MobileScreenHeader title={t('dm:groupInfo.plainTitle')} />
         <div className="flex-1 flex items-center justify-center text-txt-tertiary text-sm">
-          This conversation has no group info.
+          {t('dm:groupInfo.notGroup')}
         </div>
       </div>
     );
@@ -162,7 +164,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
     .map((m) => m.displayName ?? parseFederatedUsername(m.username).baseName)
     .join(', ');
 
-  const displayName = dmChannel.name && dmChannel.name.length > 0 ? dmChannel.name : fallbackName || 'Group DM';
+  const displayName = dmChannel.name && dmChannel.name.length > 0 ? dmChannel.name : fallbackName || t('dm:names.groupFallback');
 
   const currentName = dmChannel.name ?? '';
   const trimmedName = name.trim();
@@ -273,7 +275,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
       });
       setEditing(false);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to save settings';
+      const msg = err instanceof Error ? err.message : t('dm:groupSettings.saveFailed');
       setSaveError(msg);
       addToast(msg, 'warning', 4000);
     } finally {
@@ -291,7 +293,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
       // MobileChatScreen). The user is no longer a member.
       popMobileScreen();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to leave group';
+      const msg = err instanceof Error ? err.message : t('dm:leave.failed');
       addToast(msg, 'warning', 4000);
     } finally {
       setLeaving(false);
@@ -320,7 +322,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
         await useSocialStore.getState().removeFriend(member.id);
       } catch (err) {
         addToast(
-          err instanceof Error ? err.message : 'Failed to remove friend',
+          err instanceof Error ? err.message : t('dm:removeFriend.failed'),
           'warning',
           3000,
         );
@@ -338,14 +340,14 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
         : undefined;
       await api.dm.kickMember(channelId, pendingKick.id, federated);
       addToast(
-        `Removed ${pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName} from the group`,
+        t('dm:kick.success', { name: pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName }),
         'success',
         3000,
       );
       setPendingKick(null);
     } catch (err) {
       addToast(
-        err instanceof Error ? err.message : 'Failed to remove member',
+        err instanceof Error ? err.message : t('dm:kick.failed'),
         'warning',
         3000,
       );
@@ -364,14 +366,14 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
         : undefined;
       await api.dm.transferOwnership(channelId, pendingTransfer.id, federated);
       addToast(
-        `Ownership transferred to ${pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName}`,
+        t('dm:transfer.success', { name: pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName }),
         'success',
         3000,
       );
       setPendingTransfer(null);
     } catch (err) {
       addToast(
-        err instanceof Error ? err.message : 'Failed to transfer ownership',
+        err instanceof Error ? err.message : t('dm:transfer.failed'),
         'warning',
         3000,
       );
@@ -405,16 +407,16 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
       onClick={handleCancel}
       className="px-2 py-1 text-sm text-txt-tertiary hover:text-txt-secondary"
       data-mobile-edit-cancel
-      aria-label="Cancel edit"
+      aria-label={t('dm:groupInfo.cancelEdit')}
     >
-      Cancel
+      {t('common:actions.cancel')}
     </button>
   ) : null;
 
   // ── Render ─────────────────────────────────────────────────────────────
   return (
     <div className="flex flex-col h-full bg-surface-base">
-      <MobileScreenHeader title="Group Info" rightActions={headerRight} />
+      <MobileScreenHeader title={t('dm:groupInfo.title')} rightActions={headerRight} />
 
       <div
         className="flex-1 overflow-y-auto"
@@ -430,7 +432,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
               onClick={handleHeroClick}
               disabled={!editing || !isOwner}
               data-mobile-group-icon-hero
-              aria-label={editing && isOwner ? 'Change group icon' : 'Group icon'}
+              aria-label={editing && isOwner ? t('dm:groupSettings.changeIcon') : t('dm:groupSettings.icon')}
               className={`relative block rounded-full overflow-hidden ${
                 editing && isOwner ? 'cursor-pointer' : 'cursor-default'
               }`}
@@ -450,7 +452,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
                 type="button"
                 onClick={handleClearIcon}
                 data-mobile-group-icon-clear
-                aria-label="Remove group icon"
+                aria-label={t('dm:groupSettings.removeIcon')}
                 className="absolute -top-1 -right-1 w-6 h-6 rounded-full bg-surface-elevated border border-border-hard flex items-center justify-center text-txt-tertiary hover:text-txt-danger hover:bg-accent-rose/10 transition-colors"
               >
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
@@ -476,11 +478,11 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value.slice(0, MAX_NAME_LENGTH))}
-              placeholder={fallbackName || 'Group DM'}
+              placeholder={fallbackName || t('dm:names.groupFallback')}
               maxLength={MAX_NAME_LENGTH}
               disabled={!isOwner}
               data-mobile-group-name-input
-              aria-label="Group name"
+              aria-label={t('dm:groupSettings.nameAria')}
               className="input-standard w-full max-w-[280px] text-center text-base"
             />
           ) : (
@@ -493,7 +495,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
                 {displayName}
               </h1>
               {hasFederatedMember && (
-                <span data-mobile-group-globe className="inline-flex" aria-label="Federated group">
+                <span data-mobile-group-globe className="inline-flex" aria-label={t('dm:groupInfo.federated')}>
                   <GroupGlobeIcon />
                 </span>
               )}
@@ -501,7 +503,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
           )}
 
           <p className="text-xs text-txt-tertiary">
-            {memberCount} {memberCount === 1 ? 'member' : 'members'}
+            {t('dm:groupInfo.memberCount', { count: memberCount })}
           </p>
 
           {/* Edit toggle — owner-only, hidden during edit (Cancel header action takes its place). */}
@@ -512,7 +514,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
               data-mobile-group-edit
               className="mt-1 px-4 py-1.5 rounded-full bg-surface-elevated hover:bg-interactive-hover text-txt-secondary text-xs font-medium transition-colors"
             >
-              Edit
+              {t('common:actions.edit')}
             </button>
           )}
 
@@ -535,9 +537,9 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
             </svg>
-            Add Member
+            {t('dm:groupSettings.addMember')}
             {!canAddMembers && (
-              <span className="text-[11px] text-txt-tertiary">— Group is full</span>
+              <span className="text-[11px] text-txt-tertiary">{t('dm:groupSettings.groupFullSuffix')}</span>
             )}
           </button>
         </div>
@@ -547,7 +549,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
           {ownerMember && (
             <div data-mobile-group-section="owner" className="mb-4">
               <h3 className="text-[10.5px] font-bold text-txt-tertiary uppercase tracking-[0.06em] px-2 mb-1">
-                OWNER
+                {t('dm:roster.owner')}
               </h3>
               {renderMemberRow(ownerMember, true)}
             </div>
@@ -556,7 +558,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
           {onlineMembers.length > 0 && (
             <div data-mobile-group-section="online" className="mb-4">
               <h3 className="text-[10.5px] font-bold text-txt-tertiary uppercase tracking-[0.06em] px-2 mb-1">
-                ONLINE — {onlineMembers.length}
+                {t('dm:roster.sectionCount', { label: t('dm:roster.online'), total: onlineMembers.length })}
               </h3>
               {onlineMembers.map((m) => renderMemberRow(m, false))}
             </div>
@@ -565,7 +567,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
           {offlineMembers.length > 0 && (
             <div data-mobile-group-section="offline" className="opacity-60">
               <h3 className="text-[10.5px] font-bold text-txt-tertiary uppercase tracking-[0.06em] px-2 mb-1">
-                OFFLINE — {offlineMembers.length}
+                {t('dm:roster.sectionCount', { label: t('dm:roster.offline'), total: offlineMembers.length })}
               </h3>
               {offlineMembers.map((m) => renderMemberRow(m, false))}
             </div>
@@ -581,7 +583,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
             data-mobile-group-leave
             className="w-full px-4 py-2.5 text-accent-rose hover:bg-accent-rose/10 text-sm font-medium rounded-md transition-colors disabled:opacity-50"
           >
-            {leaving ? 'Leaving...' : 'Leave Group'}
+            {leaving ? t('dm:leave.inProgress') : t('dm:leave.title')}
           </button>
         </div>
       </div>
@@ -601,7 +603,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
             className="px-3 py-1.5 text-sm text-txt-tertiary hover:text-txt-secondary transition-colors disabled:opacity-50"
             data-mobile-group-save-cancel
           >
-            Cancel
+            {t('common:actions.cancel')}
           </button>
           <button
             type="button"
@@ -610,7 +612,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
             className="px-4 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             data-mobile-group-save
           >
-            {saving ? 'Saving...' : 'Save'}
+            {saving ? t('common:states.saving') : t('common:actions.save')}
           </button>
         </div>
       )}
@@ -621,7 +623,7 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
         onClose={() => setCropSrc(null)}
         imageSrc={cropSrc ?? ''}
         onCropComplete={handleCropComplete}
-        title="Crop Group Icon"
+        title={t('dm:groupSettings.cropTitle')}
         cropShape="round"
         aspectRatio={1}
         maxOutputDimension={256}
@@ -632,9 +634,9 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
         isOpen={confirmLeave}
         onClose={() => { if (!leaving) setConfirmLeave(false); }}
         onConfirm={handleConfirmLeave}
-        title="Leave Group"
-        description={`Leave "${displayName}"? You will stop receiving messages from this conversation.`}
-        confirmLabel="Leave"
+        title={t('dm:leave.title')}
+        description={t('dm:leave.description', { name: displayName })}
+        confirmLabel={t('dm:leave.confirm')}
         variant="danger"
         loading={leaving}
       />
@@ -643,13 +645,13 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
         isOpen={!!pendingKick}
         onClose={() => { if (!submittingMemberAction) setPendingKick(null); }}
         onConfirm={confirmKick}
-        title="Remove from Group"
+        title={t('dm:kick.title')}
         description={
           pendingKick
-            ? `Remove ${pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName} from this group? They won't be able to see new messages.`
+            ? t('dm:kick.description', { name: pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName })
             : ''
         }
-        confirmLabel="Remove"
+        confirmLabel={t('common:actions.remove')}
         variant="danger"
         loading={submittingMemberAction}
       />
@@ -658,13 +660,13 @@ export function MobileGroupDmInfo({ params }: MobileGroupDmInfoProps) {
         isOpen={!!pendingTransfer}
         onClose={() => { if (!submittingMemberAction) setPendingTransfer(null); }}
         onConfirm={confirmTransfer}
-        title="Transfer Ownership"
+        title={t('dm:transfer.title')}
         description={
           pendingTransfer
-            ? `Transfer ownership to ${pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName}? You'll lose owner privileges.`
+            ? t('dm:transfer.description', { name: pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName })
             : ''
         }
-        confirmLabel="Transfer"
+        confirmLabel={t('dm:transfer.confirm')}
         variant="warning"
         loading={submittingMemberAction}
       />

--- a/packages/web/src/components/modals/AddDmMemberModal.tsx
+++ b/packages/web/src/components/modals/AddDmMemberModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Modal } from '../ui/Modal';
 import { Avatar } from '../ui/Avatar';
 import { useUIStore } from '../../stores/uiStore';
@@ -26,6 +27,7 @@ function AddDmFriendRow({
   isAdding: boolean;
   onToggle: (id: string) => void;
 }) {
+  const { t } = useTranslation(['dm', 'common']);
   const canonical = useCanonicalUserView(friend as unknown as User);
   const { baseName } = parseFederatedUsername(canonical.username);
   const friendDisplayName = canonical.displayName ?? baseName;
@@ -54,7 +56,7 @@ function AddDmFriendRow({
           {friendDisplayName}
         </div>
         <div className="text-[11px] text-txt-tertiary truncate">
-          {isInDm ? 'Already in this DM' : `@${canonical.username}`}
+          {isInDm ? t('dm:addMember.alreadyInDm') : `@${canonical.username}`}
         </div>
       </div>
       {!isInDm && (
@@ -77,6 +79,7 @@ function AddDmFriendRow({
 }
 
 export function AddDmMemberModal() {
+  const { t } = useTranslation(['dm', 'common']);
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [error, setError] = useState('');
@@ -162,7 +165,7 @@ export function AddDmMemberModal() {
         // 1-on-1 DM → create a new group DM with all selected + existing other member
         const otherMember = dmChannel.members.find(m => !isSelf(m, myUser));
         if (!otherMember) {
-          setError('Could not determine the other member of this conversation.');
+          setError(t('dm:addMember.noOtherMember'));
           setIsAdding(false);
           return;
         }
@@ -190,26 +193,26 @@ export function AddDmMemberModal() {
         closeModal();
       }
     } catch (err) {
-      setError((err as Error).message || 'Failed to add members');
+      setError((err as Error).message || t('dm:addMember.failed'));
     } finally {
       setIsAdding(false);
     }
   };
 
   const buttonText = selectedFriends.length === 0
-    ? 'Select Friends'
-    : `Add ${selectedFriends.length} Friend${selectedFriends.length > 1 ? 's' : ''}`;
+    ? t('dm:addMember.selectFriends')
+    : t('dm:addMember.addCount', { count: selectedFriends.length });
 
   return (
-    <Modal isOpen={isOpen} onClose={closeModal} title="Add Friends to DM" mobileStyle="sheet">
+    <Modal isOpen={isOpen} onClose={closeModal} title={t('dm:addMember.title')} mobileStyle="sheet">
       <div className="space-y-3">
         {/* Header with member count */}
         <div className="flex items-center justify-between">
           <p className="text-[13px] text-txt-tertiary">
-            Select friends to add to this conversation.
+            {t('dm:addMember.description')}
           </p>
           <span className="text-[12px] text-txt-tertiary flex-shrink-0 ml-2">
-            {memberCount}/{maxMembers}
+            {t('dm:addMember.capacity', { current: memberCount, max: maxMembers })}
           </span>
         </div>
 
@@ -239,13 +242,13 @@ export function AddDmMemberModal() {
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search friends..."
+          placeholder={t('dm:addMember.searchPlaceholder')}
           className="input-search w-full py-2 text-[14px]"
           disabled={remainingSlots <= 0}
         />
 
         {remainingSlots <= 0 && (
-          <p className="text-txt-danger text-[13px]">This group DM has reached the 10-member limit.</p>
+          <p className="text-txt-danger text-[13px]">{t('dm:addMember.limitReached', { max: maxMembers })}</p>
         )}
 
         {error && (
@@ -256,7 +259,7 @@ export function AddDmMemberModal() {
         <div className="max-h-[300px] overflow-y-auto space-y-[2px]">
           {filteredFriends.length === 0 && (
             <div className="py-4 text-center text-txt-tertiary text-[14px]">
-              {query.trim() ? 'No friends match your search' : 'No friends yet'}
+              {query.trim() ? t('dm:addMember.noMatch') : t('dm:addMember.noFriends')}
             </div>
           )}
 
@@ -284,7 +287,7 @@ export function AddDmMemberModal() {
           disabled={selectedFriends.length === 0 || isAdding}
           className="w-full py-2 rounded-md text-[13px] font-semibold transition-colors bg-accent-mint text-surface-base hover:bg-accent-mint/90 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {isAdding ? 'Adding...' : buttonText}
+          {isAdding ? t('dm:addMember.adding') : buttonText}
         </button>
       </div>
     </Modal>

--- a/packages/web/src/components/modals/GroupDmSettings.tsx
+++ b/packages/web/src/components/modals/GroupDmSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { User } from '@backspace/shared';
 import { Modal } from '../ui/Modal';
 import { ImageCropModal } from '../ui/ImageCropModal';
@@ -40,6 +41,7 @@ type Tab = 'overview' | 'members';
  * Cancel discards the staged blob; no upload fires.
  */
 export function GroupDmSettings() {
+  const { t } = useTranslation(['dm', 'common']);
   const activeModal = useUIStore((s) => s.activeModal);
   const modalData = useUIStore((s) => s.modalData);
   const closeModal = useUIStore((s) => s.closeModal);
@@ -221,7 +223,7 @@ export function GroupDmSettings() {
       // (`dm_channel_updated`) updates the open channel in-place.
       closeModal();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to save settings';
+      const msg = err instanceof Error ? err.message : t('dm:groupSettings.saveFailed');
       setSaveError(msg);
       addToast(msg, 'warning', 4000);
     } finally {
@@ -240,7 +242,7 @@ export function GroupDmSettings() {
       await api.dm.leave(dmChannelId);
       closeModal();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to leave group';
+      const msg = err instanceof Error ? err.message : t('dm:leave.failed');
       addToast(msg, 'warning', 4000);
     } finally {
       setLeaving(false);
@@ -280,7 +282,7 @@ export function GroupDmSettings() {
         await useSocialStore.getState().removeFriend(member.id);
       } catch (err) {
         addToast(
-          err instanceof Error ? err.message : 'Failed to remove friend',
+          err instanceof Error ? err.message : t('dm:removeFriend.failed'),
           'warning',
           3000,
         );
@@ -294,14 +296,14 @@ export function GroupDmSettings() {
     try {
       await api.dm.kickMember(dmChannelId, pendingKick.id);
       addToast(
-        `Removed ${pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName} from the group`,
+        t('dm:kick.success', { name: pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName }),
         'success',
         3000,
       );
       setPendingKick(null);
     } catch (err) {
       addToast(
-        err instanceof Error ? err.message : 'Failed to remove member',
+        err instanceof Error ? err.message : t('dm:kick.failed'),
         'warning',
         3000,
       );
@@ -316,14 +318,14 @@ export function GroupDmSettings() {
     try {
       await api.dm.transferOwnership(dmChannelId, pendingTransfer.id);
       addToast(
-        `Ownership transferred to ${pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName}`,
+        t('dm:transfer.success', { name: pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName }),
         'success',
         3000,
       );
       setPendingTransfer(null);
     } catch (err) {
       addToast(
-        err instanceof Error ? err.message : 'Failed to transfer ownership',
+        err instanceof Error ? err.message : t('dm:transfer.failed'),
         'warning',
         3000,
       );
@@ -345,12 +347,12 @@ export function GroupDmSettings() {
     if (isMobile) setMobileView('content');
   };
 
-  const headerName = dmChannel.name && dmChannel.name.length > 0 ? dmChannel.name : (fallbackName || 'Group DM');
+  const headerName = dmChannel.name && dmChannel.name.length > 0 ? dmChannel.name : (fallbackName || t('dm:names.groupFallback'));
 
   // ── Overview panel ─────────────────────────────────────────────────────
   const overviewPanel = (
     <div className="space-y-5">
-      <h2 className="text-lg font-semibold text-txt-primary mb-6">Overview</h2>
+      <h2 className="text-lg font-semibold text-txt-primary mb-6">{t('dm:groupSettings.overview')}</h2>
 
       {/* Hero icon */}
       <div className="flex flex-col items-center gap-3">
@@ -360,7 +362,7 @@ export function GroupDmSettings() {
             onClick={handleHeroClick}
             disabled={!isOwner}
             data-group-dm-icon-hero
-            aria-label={isOwner ? 'Change group icon' : 'Group icon'}
+            aria-label={isOwner ? t('dm:groupSettings.changeIcon') : t('dm:groupSettings.icon')}
             className={`relative block rounded-full overflow-hidden group ${
               isOwner ? 'cursor-pointer' : 'cursor-default'
             }`}
@@ -381,7 +383,7 @@ export function GroupDmSettings() {
                   <path strokeLinecap="round" strokeLinejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
                   <path strokeLinecap="round" strokeLinejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
                 </svg>
-                <span className="mt-1">Click to upload</span>
+                <span className="mt-1">{t('dm:groupSettings.clickToUpload')}</span>
               </div>
             )}
           </button>
@@ -392,7 +394,7 @@ export function GroupDmSettings() {
               type="button"
               onClick={handleClearIcon}
               data-group-dm-icon-clear
-              aria-label="Remove group icon"
+              aria-label={t('dm:groupSettings.removeIcon')}
               className="absolute -top-1 -right-1 w-6 h-6 rounded-full bg-surface-elevated border border-border-hard flex items-center justify-center text-txt-tertiary hover:text-txt-danger hover:bg-accent-rose/10 transition-colors"
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
@@ -416,22 +418,22 @@ export function GroupDmSettings() {
       {/* Group name */}
       <div>
         <label className="block text-[11px] font-semibold text-txt-tertiary uppercase tracking-wider mb-1.5">
-          Group Name
+          {t('dm:groupSettings.nameLabel')}
         </label>
         <input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value.slice(0, MAX_NAME_LENGTH))}
-          placeholder={fallbackName || 'Group DM'}
+          placeholder={fallbackName || t('dm:names.groupFallback')}
           disabled={!isOwner}
           maxLength={MAX_NAME_LENGTH}
           className="input-standard w-full"
           data-group-dm-name-input
-          aria-label="Group name"
+          aria-label={t('dm:groupSettings.nameAria')}
         />
         {isOwner && (
           <div className="text-[11px] text-txt-tertiary text-right mt-1">
-            {trimmedName.length}/{MAX_NAME_LENGTH}
+            {t('dm:groupSettings.nameCount', { current: trimmedName.length, max: MAX_NAME_LENGTH })}
           </div>
         )}
       </div>
@@ -451,7 +453,7 @@ export function GroupDmSettings() {
             className="px-3 py-1.5 text-sm text-txt-tertiary hover:text-txt-secondary transition-colors"
             data-group-dm-cancel
           >
-            Cancel
+            {t('common:actions.cancel')}
           </button>
           <button
             type="button"
@@ -460,7 +462,7 @@ export function GroupDmSettings() {
             className="px-4 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             data-group-dm-save
           >
-            {saving ? 'Saving...' : 'Save'}
+            {saving ? t('common:states.saving') : t('common:actions.save')}
           </button>
         </div>
       )}
@@ -474,7 +476,7 @@ export function GroupDmSettings() {
             className="px-4 py-1.5 bg-surface-elevated hover:bg-interactive-hover text-txt-primary text-sm font-medium rounded-full transition-colors"
             data-group-dm-close
           >
-            Close
+            {t('common:actions.close')}
           </button>
         </div>
       )}
@@ -482,10 +484,10 @@ export function GroupDmSettings() {
       {/* Leave Group — destructive footer button, everyone */}
       <div className="pt-4 border-t border-border-soft">
         <div className="text-[11px] font-semibold text-txt-danger uppercase tracking-wider mb-1.5">
-          Leave Group
+          {t('dm:leave.title')}
         </div>
         <p className="text-xs text-txt-tertiary mb-3">
-          You will stop receiving messages from this conversation. Other members will see a system message.
+          {t('dm:leave.explanation')}
         </p>
         <button
           type="button"
@@ -494,7 +496,7 @@ export function GroupDmSettings() {
           className="px-4 py-2 bg-accent-rose hover:bg-accent-rose/80 text-white text-sm font-medium rounded transition-colors disabled:opacity-50"
           data-group-dm-leave
         >
-          {leaving ? 'Leaving...' : 'Leave Group'}
+          {leaving ? t('dm:leave.inProgress') : t('dm:leave.title')}
         </button>
       </div>
     </div>
@@ -514,9 +516,9 @@ export function GroupDmSettings() {
   const membersPanel = (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-txt-primary">Members</h2>
+        <h2 className="text-lg font-semibold text-txt-primary">{t('dm:groupSettings.members')}</h2>
         <span className="text-[12px] text-txt-tertiary">
-          {memberCount}/{MAX_GROUP_MEMBERS}
+          {t('dm:addMember.capacity', { current: memberCount, max: MAX_GROUP_MEMBERS })}
         </span>
       </div>
 
@@ -530,9 +532,9 @@ export function GroupDmSettings() {
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
         </svg>
-        Add Member
+        {t('dm:groupSettings.addMember')}
         {!canAddMembers && (
-          <span className="ml-auto text-[11px] text-txt-tertiary">Group is full</span>
+          <span className="ml-auto text-[11px] text-txt-tertiary">{t('dm:groupSettings.groupFull')}</span>
         )}
       </button>
 
@@ -585,13 +587,13 @@ export function GroupDmSettings() {
           {/* Nav list */}
           <div className="glass-bubble rounded-lg p-2 flex-1 flex flex-col">
             <div className="text-[10px] font-semibold text-txt-tertiary uppercase tracking-wider px-3 py-1">
-              General
+              {t('dm:groupSettings.general')}
             </div>
             <button type="button" onClick={() => handleTabClick('overview')} className={tabBtnClass('overview')}>
-              Overview
+              {t('dm:groupSettings.overview')}
             </button>
             <button type="button" onClick={() => handleTabClick('members')} className={tabBtnClass('members')}>
-              Members
+              {t('dm:groupSettings.members')}
             </button>
           </div>
         </div>
@@ -613,13 +615,13 @@ export function GroupDmSettings() {
 
             <div className="glass-bubble rounded-lg p-2 space-y-0.5">
               <div className="text-[10px] font-semibold text-txt-tertiary uppercase tracking-wider px-3 py-1">
-                General
+                {t('dm:groupSettings.general')}
               </div>
               <button type="button" onClick={() => handleTabClick('overview')} className={tabBtnClass('overview')}>
-                Overview
+                {t('dm:groupSettings.overview')}
               </button>
               <button type="button" onClick={() => handleTabClick('members')} className={tabBtnClass('members')}>
-                Members
+                {t('dm:groupSettings.members')}
               </button>
             </div>
           </div>
@@ -634,12 +636,12 @@ export function GroupDmSettings() {
                   type="button"
                   onClick={() => setMobileView('tabs')}
                   className="flex items-center gap-1.5 text-txt-tertiary hover:text-txt-secondary mb-4 text-sm"
-                  aria-label="Back to group DM settings menu"
+                  aria-label={t('dm:groupSettings.backToMenu')}
                 >
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
                   </svg>
-                  Group Settings
+                  {t('dm:groupSettings.title')}
                 </button>
               )}
               {tab === 'overview' && overviewPanel}
@@ -655,7 +657,7 @@ export function GroupDmSettings() {
         onClose={() => setCropSrc(null)}
         imageSrc={cropSrc ?? ''}
         onCropComplete={handleCropComplete}
-        title="Crop Group Icon"
+        title={t('dm:groupSettings.cropTitle')}
         cropShape="round"
         aspectRatio={1}
         maxOutputDimension={256}
@@ -666,9 +668,9 @@ export function GroupDmSettings() {
         isOpen={confirmLeave}
         onClose={() => { if (!leaving) setConfirmLeave(false); }}
         onConfirm={handleConfirmLeave}
-        title="Leave Group"
-        description={`Leave "${headerName}"? You will stop receiving messages from this conversation.`}
-        confirmLabel="Leave"
+        title={t('dm:leave.title')}
+        description={t('dm:leave.description', { name: headerName })}
+        confirmLabel={t('dm:leave.confirm')}
         variant="danger"
         loading={leaving}
       />
@@ -677,13 +679,13 @@ export function GroupDmSettings() {
         isOpen={!!pendingKick}
         onClose={() => { if (!memberActionSubmitting) setPendingKick(null); }}
         onConfirm={confirmKick}
-        title="Remove from Group"
+        title={t('dm:kick.title')}
         description={
           pendingKick
-            ? `Remove ${pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName} from this group? They won't be able to see new messages.`
+            ? t('dm:kick.description', { name: pendingKick.displayName ?? parseFederatedUsername(pendingKick.username).baseName })
             : ''
         }
-        confirmLabel="Remove"
+        confirmLabel={t('common:actions.remove')}
         variant="danger"
         loading={memberActionSubmitting}
       />
@@ -692,13 +694,13 @@ export function GroupDmSettings() {
         isOpen={!!pendingTransfer}
         onClose={() => { if (!memberActionSubmitting) setPendingTransfer(null); }}
         onConfirm={confirmTransfer}
-        title="Transfer Ownership"
+        title={t('dm:transfer.title')}
         description={
           pendingTransfer
-            ? `Transfer ownership to ${pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName}? You'll lose owner privileges.`
+            ? t('dm:transfer.description', { name: pendingTransfer.displayName ?? parseFederatedUsername(pendingTransfer.username).baseName })
             : ''
         }
-        confirmLabel="Transfer"
+        confirmLabel={t('dm:transfer.confirm')}
         variant="warning"
         loading={memberActionSubmitting}
       />

--- a/packages/web/src/components/modals/NewDmModal.tsx
+++ b/packages/web/src/components/modals/NewDmModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Modal } from '../ui/Modal';
 import { Avatar } from '../ui/Avatar';
 import { useUIStore } from '../../stores/uiStore';
@@ -36,6 +37,7 @@ function NewDmUserRow({
 }
 
 export function NewDmModal() {
+  const { t } = useTranslation(['dm', 'common']);
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<User[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -104,19 +106,19 @@ export function NewDmModal() {
       useUIStore.getState().setShowDms(true);
       navigate(`/channels/@me/${channel.id}`);
     } catch (err) {
-      setError((err as Error).message || 'Failed to create DM');
+      setError((err as Error).message || t('dm:search.createFailed'));
     }
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={closeModal} title="New Direct Message" mobileStyle="sheet">
+    <Modal isOpen={isOpen} onClose={closeModal} title={t('dm:newDm.title')} mobileStyle="sheet">
       <div className="space-y-3">
         <input
           ref={inputRef}
           type="text"
           value={query}
           onChange={(e) => handleSearch(e.target.value)}
-          placeholder="Search for a user..."
+          placeholder={t('dm:newDm.searchPlaceholder')}
           className="input-search w-full py-2 text-[14px]"
         />
 
@@ -126,11 +128,11 @@ export function NewDmModal() {
 
         <div className="max-h-[300px] overflow-y-auto space-y-[2px]">
           {isSearching && (
-            <div className="py-4 text-center text-txt-tertiary text-[14px]">Searching...</div>
+            <div className="py-4 text-center text-txt-tertiary text-[14px]">{t('dm:search.searching')}</div>
           )}
 
           {!isSearching && query.trim().length >= 2 && results.length === 0 && (
-            <div className="py-4 text-center text-txt-tertiary text-[14px]">No users found</div>
+            <div className="py-4 text-center text-txt-tertiary text-[14px]">{t('dm:newDm.noUsers')}</div>
           )}
 
           {results.map((user) => (

--- a/packages/web/src/components/modals/TransferOwnershipModal.tsx
+++ b/packages/web/src/components/modals/TransferOwnershipModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import ReactDOM from 'react-dom';
+import { Trans, useTranslation } from 'react-i18next';
 import type { MemberWithUser } from '@backspace/shared';
 import { useSpaceStore, getApiForOrigin, type TaggedSpace } from '../../stores/spaceStore';
 import { useAuthStore } from '../../stores/authStore';
@@ -44,6 +45,7 @@ function TransferMemberRow({
 }
 
 export function TransferOwnershipModal({ spaceId, onClose }: { spaceId: string; onClose: () => void }) {
+  const { t } = useTranslation(['dm', 'common']);
   const modalRef = useRef<HTMLDivElement>(null);
   const space = useSpaceStore((s) => s.spaces.find(sp => sp.id === spaceId));
   const currentUserId = useAuthStore((s) => s.user?.id);
@@ -124,10 +126,10 @@ export function TransferOwnershipModal({ spaceId, onClose }: { spaceId: string; 
     setTransferring(true);
     try {
       await transferOwnership(spaceId, selectedUserId);
-      addToast(`Ownership transferred to ${selectedMember?.user.displayName || selectedMember?.user.username}`, 'success', 3000);
+      addToast(t('dm:spaceOwnership.success', { name: selectedMember?.user.displayName || selectedMember?.user.username }), 'success', 3000);
       onClose();
     } catch (err) {
-      addToast(err instanceof Error ? err.message : 'Failed to transfer ownership', 'warning', 3000);
+      addToast(err instanceof Error ? err.message : t('dm:spaceOwnership.failed'), 'warning', 3000);
     } finally {
       setTransferring(false);
     }
@@ -141,9 +143,14 @@ export function TransferOwnershipModal({ spaceId, onClose }: { spaceId: string; 
       >
         {/* Header */}
         <div className="px-4 pt-4 pb-3 border-b border-white/[0.06]">
-          <h3 className="text-base font-semibold text-txt-primary">Transfer Ownership</h3>
+          <h3 className="text-base font-semibold text-txt-primary">{t('dm:spaceOwnership.title')}</h3>
           <p className="text-xs text-txt-tertiary mt-0.5">
-            Choose a member to become the new owner of <span className="font-medium text-txt-secondary">{space.name}</span>
+            <Trans
+              t={t}
+              i18nKey="dm:spaceOwnership.description"
+              values={{ name: space.name }}
+              components={{ name: <span className="font-medium text-txt-secondary" /> }}
+            />
           </p>
         </div>
 
@@ -152,10 +159,14 @@ export function TransferOwnershipModal({ spaceId, onClose }: { spaceId: string; 
           <div className="p-4 flex flex-col gap-4">
             <div className="p-3 rounded-lg bg-accent-amber/10 border border-accent-amber/20">
               <p className="text-sm text-txt-secondary">
-                Transfer ownership of <span className="font-semibold text-txt-primary">{space.name}</span> to{' '}
-                <span className="font-semibold text-txt-primary">{selectedMember.user.displayName || selectedMember.user.username}</span>?
+                <Trans
+                  t={t}
+                  i18nKey="dm:spaceOwnership.confirmQuestion"
+                  values={{ space: space.name, member: selectedMember.user.displayName || selectedMember.user.username }}
+                  components={{ name: <span className="font-semibold text-txt-primary" /> }}
+                />
               </p>
-              <p className="text-xs text-txt-tertiary mt-1.5">You will become a regular member.</p>
+              <p className="text-xs text-txt-tertiary mt-1.5">{t('dm:spaceOwnership.regularMember')}</p>
             </div>
             <div className="flex gap-3">
               <button
@@ -163,14 +174,14 @@ export function TransferOwnershipModal({ spaceId, onClose }: { spaceId: string; 
                 className="flex-1 py-2.5 text-sm font-medium text-txt-secondary bg-interactive-hover hover:bg-interactive-selected rounded-lg transition-colors disabled:opacity-50"
                 disabled={transferring}
               >
-                Cancel
+                {t('common:actions.cancel')}
               </button>
               <button
                 onClick={handleTransfer}
                 disabled={transferring}
                 className="flex-1 py-2.5 bg-accent-amber hover:bg-accent-amber/80 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
               >
-                {transferring ? 'Transferring...' : 'Transfer'}
+                {transferring ? t('dm:spaceOwnership.transferring') : t('dm:spaceOwnership.confirm')}
               </button>
             </div>
           </div>
@@ -182,16 +193,16 @@ export function TransferOwnershipModal({ spaceId, onClose }: { spaceId: string; 
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search members..."
+                placeholder={t('dm:spaceOwnership.searchPlaceholder')}
                 className="input-search w-full"
                 autoFocus
               />
             </div>
             <div className="flex-1 overflow-y-auto p-2 min-h-0">
               {loading ? (
-                <p className="text-xs text-txt-tertiary text-center py-4">Loading members...</p>
+                <p className="text-xs text-txt-tertiary text-center py-4">{t('dm:spaceOwnership.loading')}</p>
               ) : filteredMembers.length === 0 ? (
-                <p className="text-xs text-txt-tertiary text-center py-4">No members found</p>
+                <p className="text-xs text-txt-tertiary text-center py-4">{t('dm:spaceOwnership.noMembers')}</p>
               ) : (
                 filteredMembers.map((member) => (
                   <TransferMemberRow

--- a/packages/web/src/locales/de/dm.json
+++ b/packages/web/src/locales/de/dm.json
@@ -1,1 +1,160 @@
-{}
+{
+  "names": {
+    "group": "Gruppe",
+    "directMessage": "Direktnachricht",
+    "theGroup": "die Gruppe",
+    "unknownHandle": "unbekannt",
+    "groupFallback": "Gruppenchat",
+    "emptyGroup": "Leere Gruppe"
+  },
+  "preview": {
+    "image": "Bild",
+    "video": "Video",
+    "audio": "Audiodatei",
+    "files_one": "📎 {{count}} Datei",
+    "files_other": "📎 {{count}} Dateien",
+    "withSender": "{{name}}: {{text}}"
+  },
+  "system": {
+    "spaceInviteNamed": "📨 Einladung zu {{spaceName}} gesendet",
+    "spaceInvite": "📨 Space-Einladung gesendet",
+    "memberAdded": "{{actor}} hat {{target}} hinzugefügt",
+    "memberLeft": "{{target}} hat die Gruppe verlassen",
+    "memberRemoved": "{{actor}} hat {{target}} entfernt",
+    "ownerChanged": "{{newOwner}} ist jetzt Besitzer der Gruppe",
+    "renamed": "{{actor}} hat die Gruppe umbenannt",
+    "nameCleared": "{{actor}} hat den Gruppennamen entfernt",
+    "iconChanged": "{{actor}} hat das Gruppensymbol geändert",
+    "generic": "Systemmeldung",
+    "someone": "jemanden",
+    "aMember": "Ein Mitglied"
+  },
+  "deletedNotice": {
+    "accountDeleted": "Das Konto dieser Person wurde gelöscht"
+  },
+  "memberRow": {
+    "viewProfile": "Profil anzeigen",
+    "transferOwnership": "Besitz übertragen",
+    "removeFromGroup": "Aus Gruppe entfernen",
+    "removeFriend": "Freund entfernen",
+    "ownerTooltip": "Gruppenbesitzer",
+    "actions": "Mitgliederaktionen"
+  },
+  "roster": {
+    "members": "Mitglieder",
+    "owner": "Besitzer",
+    "online": "Online",
+    "offline": "Nicht online",
+    "sectionCount": "{{label}} — {{total}}"
+  },
+  "kick": {
+    "title": "Aus Gruppe entfernen",
+    "description": "{{name}} aus dieser Gruppe entfernen? Neue Nachrichten sind dann nicht mehr sichtbar.",
+    "success": "{{name}} wurde aus der Gruppe entfernt",
+    "failed": "Mitglied konnte nicht entfernt werden"
+  },
+  "transfer": {
+    "title": "Besitz übertragen",
+    "description": "Besitz an {{name}} übertragen? Du verlierst deine Besitzerrechte.",
+    "confirm": "Übertragen",
+    "success": "Besitz an {{name}} übertragen",
+    "failed": "Besitz konnte nicht übertragen werden"
+  },
+  "removeFriend": {
+    "failed": "Freund konnte nicht entfernt werden"
+  },
+  "leave": {
+    "title": "Gruppe verlassen",
+    "description": "„{{name}}“ verlassen? Du bekommst dann keine Nachrichten mehr aus dieser Unterhaltung.",
+    "confirm": "Verlassen",
+    "inProgress": "Wird verlassen…",
+    "failed": "Gruppe konnte nicht verlassen werden",
+    "explanation": "Du bekommst dann keine Nachrichten mehr aus dieser Unterhaltung. Die anderen Mitglieder sehen eine Systemmeldung."
+  },
+  "search": {
+    "trigger": "Unterhaltung finden oder starten",
+    "placeholder": "Suchen…",
+    "emptyHint": "Such nach einer Person, um zu chatten",
+    "conversations": "Unterhaltungen",
+    "users": "Nutzer",
+    "searching": "Suche läuft…",
+    "noResults": "Keine Ergebnisse",
+    "createFailed": "Direktnachricht konnte nicht erstellt werden"
+  },
+  "list": {
+    "title": "Nachrichten",
+    "friends": "Freunde",
+    "empty": "Noch keine Unterhaltungen.",
+    "leaveGroup": "Gruppe verlassen",
+    "justNow": "jetzt",
+    "minutesShort_one": "{{count}} Min",
+    "minutesShort_other": "{{count}} Min",
+    "hoursShort_one": "{{count}} Std",
+    "hoursShort_other": "{{count}} Std",
+    "daysShort_one": "{{count}} T",
+    "daysShort_other": "{{count}} T"
+  },
+  "newDm": {
+    "title": "Neue Direktnachricht",
+    "searchPlaceholder": "Nach einer Person suchen…",
+    "noUsers": "Keine Nutzer gefunden"
+  },
+  "addMember": {
+    "title": "Freunde zur Unterhaltung hinzufügen",
+    "description": "Wähle Freunde aus, die du zu dieser Unterhaltung hinzufügen möchtest.",
+    "capacity": "{{current}}/{{max}}",
+    "searchPlaceholder": "Freunde suchen…",
+    "limitReached": "Diese Gruppe hat das Limit von {{max}} Mitgliedern erreicht.",
+    "alreadyInDm": "Bereits in dieser Unterhaltung",
+    "noMatch": "Keine Freunde passen zu deiner Suche",
+    "noFriends": "Noch keine Freunde",
+    "selectFriends": "Freunde auswählen",
+    "addCount_one": "{{count}} Freund hinzufügen",
+    "addCount_other": "{{count}} Freunde hinzufügen",
+    "adding": "Wird hinzugefügt…",
+    "noOtherMember": "Das andere Mitglied dieser Unterhaltung konnte nicht bestimmt werden.",
+    "failed": "Mitglieder konnten nicht hinzugefügt werden"
+  },
+  "groupSettings": {
+    "title": "Gruppeneinstellungen",
+    "general": "Allgemein",
+    "overview": "Übersicht",
+    "members": "Mitglieder",
+    "backToMenu": "Zurück zum Menü der Gruppeneinstellungen",
+    "changeIcon": "Gruppensymbol ändern",
+    "icon": "Gruppensymbol",
+    "clickToUpload": "Zum Hochladen klicken",
+    "removeIcon": "Gruppensymbol entfernen",
+    "nameLabel": "Gruppenname",
+    "nameAria": "Gruppenname",
+    "nameCount": "{{current}}/{{max}}",
+    "addMember": "Mitglied hinzufügen",
+    "groupFull": "Gruppe ist voll",
+    "groupFullSuffix": "— Gruppe ist voll",
+    "cropTitle": "Gruppensymbol zuschneiden",
+    "saveFailed": "Einstellungen konnten nicht gespeichert werden"
+  },
+  "groupInfo": {
+    "title": "Gruppeninfo",
+    "plainTitle": "Details",
+    "notFound": "Unterhaltung nicht gefunden.",
+    "notGroup": "Diese Unterhaltung hat keine Gruppeninfo.",
+    "cancelEdit": "Bearbeiten abbrechen",
+    "federated": "Föderierte Gruppe",
+    "memberCount_one": "{{count}} Mitglied",
+    "memberCount_other": "{{count}} Mitglieder"
+  },
+  "spaceOwnership": {
+    "title": "Besitz übertragen",
+    "description": "Wähle ein Mitglied, das neuer Besitzer von <name>{{name}}</name> wird",
+    "confirmQuestion": "Besitz von <name>{{space}}</name> an <name>{{member}}</name> übertragen?",
+    "regularMember": "Du wirst ein normales Mitglied.",
+    "transferring": "Wird übertragen…",
+    "confirm": "Übertragen",
+    "searchPlaceholder": "Mitglieder suchen…",
+    "loading": "Mitglieder werden geladen…",
+    "noMembers": "Keine Mitglieder gefunden",
+    "success": "Besitz an {{name}} übertragen",
+    "failed": "Besitz konnte nicht übertragen werden"
+  }
+}

--- a/packages/web/src/locales/en/dm.json
+++ b/packages/web/src/locales/en/dm.json
@@ -1,1 +1,160 @@
-{}
+{
+  "names": {
+    "group": "Group",
+    "directMessage": "Direct Message",
+    "theGroup": "the group",
+    "unknownHandle": "unknown",
+    "groupFallback": "Group DM",
+    "emptyGroup": "Empty Group"
+  },
+  "preview": {
+    "image": "Image",
+    "video": "Video",
+    "audio": "Audio",
+    "files_one": "📎 {{count}} file",
+    "files_other": "📎 {{count}} files",
+    "withSender": "{{name}}: {{text}}"
+  },
+  "system": {
+    "spaceInviteNamed": "📨 Sent invite to {{spaceName}}",
+    "spaceInvite": "📨 Sent a space invite",
+    "memberAdded": "{{actor}} added {{target}}",
+    "memberLeft": "{{target}} left the group",
+    "memberRemoved": "{{actor}} removed {{target}}",
+    "ownerChanged": "{{newOwner}} is now the group owner",
+    "renamed": "{{actor}} renamed the group",
+    "nameCleared": "{{actor}} cleared the group name",
+    "iconChanged": "{{actor}} updated the group icon",
+    "generic": "System message",
+    "someone": "someone",
+    "aMember": "A member"
+  },
+  "deletedNotice": {
+    "accountDeleted": "This user’s account was deleted"
+  },
+  "memberRow": {
+    "viewProfile": "View Profile",
+    "transferOwnership": "Transfer Ownership",
+    "removeFromGroup": "Remove from Group",
+    "removeFriend": "Remove Friend",
+    "ownerTooltip": "Group Owner",
+    "actions": "Member actions"
+  },
+  "roster": {
+    "members": "Members",
+    "owner": "Owner",
+    "online": "Online",
+    "offline": "Offline",
+    "sectionCount": "{{label}} — {{total}}"
+  },
+  "kick": {
+    "title": "Remove from Group",
+    "description": "Remove {{name}} from this group? They won’t be able to see new messages.",
+    "success": "Removed {{name}} from the group",
+    "failed": "Failed to remove member"
+  },
+  "transfer": {
+    "title": "Transfer Ownership",
+    "description": "Transfer ownership to {{name}}? You’ll lose owner privileges.",
+    "confirm": "Transfer",
+    "success": "Ownership transferred to {{name}}",
+    "failed": "Failed to transfer ownership"
+  },
+  "removeFriend": {
+    "failed": "Failed to remove friend"
+  },
+  "leave": {
+    "title": "Leave Group",
+    "description": "Leave “{{name}}”? You will stop receiving messages from this conversation.",
+    "confirm": "Leave",
+    "inProgress": "Leaving…",
+    "failed": "Failed to leave group",
+    "explanation": "You will stop receiving messages from this conversation. Other members will see a system message."
+  },
+  "search": {
+    "trigger": "Find or start a conversation",
+    "placeholder": "Search…",
+    "emptyHint": "Search for a user to start chatting",
+    "conversations": "Conversations",
+    "users": "Users",
+    "searching": "Searching…",
+    "noResults": "No results found",
+    "createFailed": "Failed to create DM"
+  },
+  "list": {
+    "title": "Messages",
+    "friends": "Friends",
+    "empty": "No conversations yet.",
+    "leaveGroup": "Leave Group",
+    "justNow": "now",
+    "minutesShort_one": "{{count}}m",
+    "minutesShort_other": "{{count}}m",
+    "hoursShort_one": "{{count}}h",
+    "hoursShort_other": "{{count}}h",
+    "daysShort_one": "{{count}}d",
+    "daysShort_other": "{{count}}d"
+  },
+  "newDm": {
+    "title": "New Direct Message",
+    "searchPlaceholder": "Search for a user…",
+    "noUsers": "No users found"
+  },
+  "addMember": {
+    "title": "Add Friends to DM",
+    "description": "Select friends to add to this conversation.",
+    "capacity": "{{current}}/{{max}}",
+    "searchPlaceholder": "Search friends…",
+    "limitReached": "This group DM has reached the {{max}}-member limit.",
+    "alreadyInDm": "Already in this DM",
+    "noMatch": "No friends match your search",
+    "noFriends": "No friends yet",
+    "selectFriends": "Select Friends",
+    "addCount_one": "Add {{count}} Friend",
+    "addCount_other": "Add {{count}} Friends",
+    "adding": "Adding…",
+    "noOtherMember": "Could not determine the other member of this conversation.",
+    "failed": "Failed to add members"
+  },
+  "groupSettings": {
+    "title": "Group Settings",
+    "general": "General",
+    "overview": "Overview",
+    "members": "Members",
+    "backToMenu": "Back to group DM settings menu",
+    "changeIcon": "Change group icon",
+    "icon": "Group icon",
+    "clickToUpload": "Click to upload",
+    "removeIcon": "Remove group icon",
+    "nameLabel": "Group Name",
+    "nameAria": "Group name",
+    "nameCount": "{{current}}/{{max}}",
+    "addMember": "Add Member",
+    "groupFull": "Group is full",
+    "groupFullSuffix": "— Group is full",
+    "cropTitle": "Crop Group Icon",
+    "saveFailed": "Failed to save settings"
+  },
+  "groupInfo": {
+    "title": "Group Info",
+    "plainTitle": "Info",
+    "notFound": "Conversation not found.",
+    "notGroup": "This conversation has no group info.",
+    "cancelEdit": "Cancel edit",
+    "federated": "Federated group",
+    "memberCount_one": "{{count}} member",
+    "memberCount_other": "{{count}} members"
+  },
+  "spaceOwnership": {
+    "title": "Transfer Ownership",
+    "description": "Choose a member to become the new owner of <name>{{name}}</name>",
+    "confirmQuestion": "Transfer ownership of <name>{{space}}</name> to <name>{{member}}</name>?",
+    "regularMember": "You will become a regular member.",
+    "transferring": "Transferring…",
+    "confirm": "Transfer",
+    "searchPlaceholder": "Search members…",
+    "loading": "Loading members…",
+    "noMembers": "No members found",
+    "success": "Ownership transferred to {{name}}",
+    "failed": "Failed to transfer ownership"
+  }
+}

--- a/packages/web/src/locales/ru/dm.json
+++ b/packages/web/src/locales/ru/dm.json
@@ -1,1 +1,172 @@
-{}
+{
+  "names": {
+    "group": "Группа",
+    "directMessage": "Личные сообщения",
+    "theGroup": "группе",
+    "unknownHandle": "неизвестный",
+    "groupFallback": "Групповая беседа",
+    "emptyGroup": "Пустая группа"
+  },
+  "preview": {
+    "image": "Изображение",
+    "video": "Видео",
+    "audio": "Аудио",
+    "files_one": "📎 {{count}} файл",
+    "files_few": "📎 {{count}} файла",
+    "files_many": "📎 {{count}} файлов",
+    "files_other": "📎 {{count}} файла",
+    "withSender": "{{name}}: {{text}}"
+  },
+  "system": {
+    "spaceInviteNamed": "📨 Приглашение в {{spaceName}}",
+    "spaceInvite": "📨 Приглашение в пространство",
+    "memberAdded": "{{actor}} добавил(а) {{target}}",
+    "memberLeft": "{{target}} покинул(а) группу",
+    "memberRemoved": "{{actor}} удалил(а) {{target}}",
+    "ownerChanged": "{{newOwner}} теперь владелец группы",
+    "renamed": "{{actor}} переименовал(а) группу",
+    "nameCleared": "{{actor}} убрал(а) название группы",
+    "iconChanged": "{{actor}} обновил(а) значок группы",
+    "generic": "Системное сообщение",
+    "someone": "кого-то",
+    "aMember": "Участник"
+  },
+  "deletedNotice": {
+    "accountDeleted": "Аккаунт этого пользователя был удалён"
+  },
+  "memberRow": {
+    "viewProfile": "Открыть профиль",
+    "transferOwnership": "Передать права владельца",
+    "removeFromGroup": "Удалить из группы",
+    "removeFriend": "Удалить из друзей",
+    "ownerTooltip": "Владелец группы",
+    "actions": "Действия с участником"
+  },
+  "roster": {
+    "members": "Участники",
+    "owner": "Владелец",
+    "online": "В сети",
+    "offline": "Не в сети",
+    "sectionCount": "{{label}} — {{total}}"
+  },
+  "kick": {
+    "title": "Удалить из группы",
+    "description": "Удалить {{name}} из этой группы? Новые сообщения будут этому участнику недоступны.",
+    "success": "Участник {{name}} удалён из группы",
+    "failed": "Не удалось удалить участника"
+  },
+  "transfer": {
+    "title": "Передать права владельца",
+    "description": "Передать права владельца {{name}}? Вы лишитесь прав владельца.",
+    "confirm": "Передать",
+    "success": "Права владельца переданы {{name}}",
+    "failed": "Не удалось передать права владельца"
+  },
+  "removeFriend": {
+    "failed": "Не удалось удалить из друзей"
+  },
+  "leave": {
+    "title": "Покинуть группу",
+    "description": "Покинуть «{{name}}»? Вы перестанете получать сообщения из этой беседы.",
+    "confirm": "Покинуть",
+    "inProgress": "Выход…",
+    "failed": "Не удалось покинуть группу",
+    "explanation": "Вы перестанете получать сообщения из этой беседы. Остальные участники увидят системное сообщение."
+  },
+  "search": {
+    "trigger": "Найти или начать беседу",
+    "placeholder": "Поиск…",
+    "emptyHint": "Найдите пользователя, чтобы начать общение",
+    "conversations": "Беседы",
+    "users": "Пользователи",
+    "searching": "Поиск…",
+    "noResults": "Ничего не найдено",
+    "createFailed": "Не удалось создать беседу"
+  },
+  "list": {
+    "title": "Сообщения",
+    "friends": "Друзья",
+    "empty": "Пока нет бесед.",
+    "leaveGroup": "Покинуть группу",
+    "justNow": "сейчас",
+    "minutesShort_one": "{{count}} мин",
+    "minutesShort_few": "{{count}} мин",
+    "minutesShort_many": "{{count}} мин",
+    "minutesShort_other": "{{count}} мин",
+    "hoursShort_one": "{{count}} ч",
+    "hoursShort_few": "{{count}} ч",
+    "hoursShort_many": "{{count}} ч",
+    "hoursShort_other": "{{count}} ч",
+    "daysShort_one": "{{count}} д",
+    "daysShort_few": "{{count}} д",
+    "daysShort_many": "{{count}} д",
+    "daysShort_other": "{{count}} д"
+  },
+  "newDm": {
+    "title": "Новое личное сообщение",
+    "searchPlaceholder": "Поиск пользователя…",
+    "noUsers": "Пользователи не найдены"
+  },
+  "addMember": {
+    "title": "Добавить друзей в беседу",
+    "description": "Выберите друзей, которых хотите добавить в эту беседу.",
+    "capacity": "{{current}}/{{max}}",
+    "searchPlaceholder": "Поиск друзей…",
+    "limitReached": "В этой группе достигнут предел в {{max}} участников.",
+    "alreadyInDm": "Уже в этой беседе",
+    "noMatch": "Нет друзей, соответствующих запросу",
+    "noFriends": "Друзей пока нет",
+    "selectFriends": "Выберите друзей",
+    "addCount_one": "Добавить {{count}} друга",
+    "addCount_few": "Добавить {{count}} друзей",
+    "addCount_many": "Добавить {{count}} друзей",
+    "addCount_other": "Добавить {{count}} друга",
+    "adding": "Добавление…",
+    "noOtherMember": "Не удалось определить второго участника этой беседы.",
+    "failed": "Не удалось добавить участников"
+  },
+  "groupSettings": {
+    "title": "Настройки группы",
+    "general": "Общие",
+    "overview": "Обзор",
+    "members": "Участники",
+    "backToMenu": "Назад к меню настроек группы",
+    "changeIcon": "Изменить значок группы",
+    "icon": "Значок группы",
+    "clickToUpload": "Нажмите, чтобы загрузить",
+    "removeIcon": "Удалить значок группы",
+    "nameLabel": "Название группы",
+    "nameAria": "Название группы",
+    "nameCount": "{{current}}/{{max}}",
+    "addMember": "Добавить участника",
+    "groupFull": "Группа заполнена",
+    "groupFullSuffix": "— Группа заполнена",
+    "cropTitle": "Обрезать значок группы",
+    "saveFailed": "Не удалось сохранить настройки"
+  },
+  "groupInfo": {
+    "title": "О группе",
+    "plainTitle": "Информация",
+    "notFound": "Беседа не найдена.",
+    "notGroup": "У этой беседы нет информации о группе.",
+    "cancelEdit": "Отменить редактирование",
+    "federated": "Федеративная группа",
+    "memberCount_one": "{{count}} участник",
+    "memberCount_few": "{{count}} участника",
+    "memberCount_many": "{{count}} участников",
+    "memberCount_other": "{{count}} участника"
+  },
+  "spaceOwnership": {
+    "title": "Передать права владельца",
+    "description": "Выберите участника, который станет новым владельцем <name>{{name}}</name>",
+    "confirmQuestion": "Передать права владельца <name>{{space}}</name> пользователю <name>{{member}}</name>?",
+    "regularMember": "Вы станете обычным участником.",
+    "transferring": "Передача…",
+    "confirm": "Передать",
+    "searchPlaceholder": "Поиск участников…",
+    "loading": "Загрузка участников…",
+    "noMembers": "Участники не найдены",
+    "success": "Права владельца переданы {{name}}",
+    "failed": "Не удалось передать права владельца"
+  }
+}

--- a/packages/web/src/utils/dmFormatters.ts
+++ b/packages/web/src/utils/dmFormatters.ts
@@ -1,5 +1,6 @@
 import type { DmChannel, DmMessageWithUser, DmLastMessagePreview, User, SpaceInviteSystemPayload } from '@backspace/shared';
 import { parseFederatedUsername, isSelf } from './identity';
+import i18n from '../i18n';
 import { formatters } from '../i18n/formatters';
 
 // ─── DM Preview Formatting ────────────────────────────────────────────────────
@@ -37,10 +38,11 @@ function getAttachmentIcon(mimeType: string): string {
 }
 
 function getAttachmentLabel(mimeType: string, name: string): string {
-  if (mimeType.startsWith('image/')) return '📷 Image';
-  if (mimeType.startsWith('video/')) return '🎬 Video';
-  if (mimeType.startsWith('audio/')) return '🎵 Audio';
-  return `📎 ${name}`;
+  const icon = getAttachmentIcon(mimeType);
+  if (mimeType.startsWith('image/')) return `${icon} ${i18n.t('dm:preview.image')}`;
+  if (mimeType.startsWith('video/')) return `${icon} ${i18n.t('dm:preview.video')}`;
+  if (mimeType.startsWith('audio/')) return `${icon} ${i18n.t('dm:preview.audio')}`;
+  return `${icon} ${name}`;
 }
 
 /**
@@ -85,7 +87,7 @@ export function formatDmPreview(lastMessage: PreviewMessage | null | undefined):
       const a = attachments![0]!;
       return getAttachmentLabel(resolveAttachmentType(a), resolveAttachmentName(a));
     }
-    return `📎 ${attachments!.length} files`;
+    return i18n.t('dm:preview.files', { count: attachments!.length });
   }
 
   // Both text and attachments present
@@ -114,9 +116,9 @@ function asString(v: unknown): string | null {
 }
 
 function resolveDisplayName(user: User | null | undefined): string {
-  if (!user) return 'Unknown';
+  if (!user) return i18n.t('common:states.unknown');
   if (user.displayName) return user.displayName;
-  return parseFederatedUsername(user.username ?? '').baseName || 'Unknown';
+  return parseFederatedUsername(user.username ?? '').baseName || i18n.t('common:states.unknown');
 }
 
 /**
@@ -136,35 +138,35 @@ function formatSystemPreview(content: string | null, actor: User | null | undefi
     case 'space_invite': {
       const spaceName = asString((data as Partial<SpaceInviteSystemPayload>).snapshot?.spaceName);
       return spaceName
-        ? `📨 Sent invite to ${spaceName}`
-        : '📨 Sent a space invite';
+        ? i18n.t('dm:system.spaceInviteNamed', { spaceName })
+        : i18n.t('dm:system.spaceInvite');
     }
     case 'member_added': {
-      const target = asString(data.targetDisplayName) ?? 'someone';
-      return `${actorName} added ${target}`;
+      const target = asString(data.targetDisplayName) ?? i18n.t('dm:system.someone');
+      return i18n.t('dm:system.memberAdded', { actor: actorName, target });
     }
     case 'member_removed': {
-      const target = asString(data.targetDisplayName) ?? 'someone';
+      const target = asString(data.targetDisplayName) ?? i18n.t('dm:system.someone');
       const reason = asString(data.reason);
-      if (reason === 'leave') return `${target} left the group`;
-      return `${actorName} removed ${target}`;
+      if (reason === 'leave') return i18n.t('dm:system.memberLeft', { target });
+      return i18n.t('dm:system.memberRemoved', { actor: actorName, target });
     }
     case 'owner_changed': {
-      const newOwner = asString(data.newOwnerDisplayName) ?? 'A member';
-      return `${newOwner} is now the group owner`;
+      const newOwner = asString(data.newOwnerDisplayName) ?? i18n.t('dm:system.aMember');
+      return i18n.t('dm:system.ownerChanged', { newOwner });
     }
     case 'name_changed': {
       // newName === null is a meaningful "cleared" state — distinct from a
       // missing field — so we check for a non-empty string explicitly.
       return asString(data.newName)
-        ? `${actorName} renamed the group`
-        : `${actorName} cleared the group name`;
+        ? i18n.t('dm:system.renamed', { actor: actorName })
+        : i18n.t('dm:system.nameCleared', { actor: actorName });
     }
     case 'icon_changed': {
-      return `${actorName} updated the group icon`;
+      return i18n.t('dm:system.iconChanged', { actor: actorName });
     }
     default:
-      return 'System message';
+      return i18n.t('dm:system.generic');
   }
 }
 
@@ -214,7 +216,7 @@ export function formatDmSidebarPreview(
   const authoredBySelf = currentUser ? isSelf({ id: lastMessage.userId, username: actor?.username ?? '', homeInstance: actor?.homeInstance ?? null }, currentUser) : false;
   if (authoredBySelf) return text;
 
-  return `${resolveDisplayName(actor)}: ${text}`;
+  return i18n.t('dm:preview.withSender', { name: resolveDisplayName(actor), text });
 }
 
 // ─── DM Timestamp Formatting ─────────────────────────────────────────────────
@@ -263,7 +265,7 @@ function memberDisplayName(m: User): string {
 /**
  * Visible header name for a DM channel.
  *
- *   - 1-on-1 DM → the other member's display/base name (or `'Direct Message'`)
+ *   - 1-on-1 DM → the other member's display/base name (or the localized "Direct Message")
  *   - Group with `dm.name` set → that name verbatim
  *   - Group without a name → comma-joined member names (excluding self)
  *
@@ -278,13 +280,13 @@ export function formatDmHeaderName(dm: DmChannel, currentUser: AuthLike): string
 
   if (isGroup) {
     if (dm.name && dm.name.trim().length > 0) return dm.name;
-    if (others.length === 0) return 'Group';
+    if (others.length === 0) return i18n.t('dm:names.group');
     return others.map(memberDisplayName).join(', ');
   }
 
   const partner = others[0];
-  if (!partner) return 'Direct Message';
-  return memberDisplayName(partner) || 'Direct Message';
+  if (!partner) return i18n.t('dm:names.directMessage');
+  return memberDisplayName(partner) || i18n.t('dm:names.directMessage');
 }
 
 /**
@@ -304,12 +306,12 @@ export function formatDmInputLabel(dm: DmChannel, currentUser: AuthLike): string
 
   if (isGroup) {
     if (dm.name && dm.name.trim().length > 0) return `#${dm.name}`;
-    return 'the group';
+    return i18n.t('dm:names.theGroup');
   }
 
   const partner = otherMembersOf(dm, currentUser)[0];
-  if (!partner) return '@unknown';
-  return `@${memberDisplayName(partner) || 'unknown'}`;
+  if (!partner) return `@${i18n.t('dm:names.unknownHandle')}`;
+  return `@${memberDisplayName(partner) || i18n.t('dm:names.unknownHandle')}`;
 }
 
 /**


### PR DESCRIPTION
Direct messages, in English, Russian and German: the DM roster and search bar, member rows, the mobile DM list and group info screen, the new-DM, add-member and group settings dialogs, the deleted-DM notice, the ownership transfer dialog, and the DM formatters. Everything is in the new `dm` namespace.

Things a reviewer should know:

- German uses "Nicht online" for the offline roster section and "Details" for the info header because the parity check rejects translations identical to the English. Both flip back to "Offline" and "Info" once those words are on the allowlist, which the social sweep starts.
- The ownership transfer dialog is a space feature that happened to sit in this group; its keys live under `dm:spaceOwnership` and can move to `spaces` later with a key rename.
- The add-member dialog keeps its own member limit constant, separate from the one the group settings use. Interpolated as is; unifying them is a small follow-up.
- No logic changes beyond string replacement. Type check, the web test suite and the i18n consistency check are clean. No test was changed.

The Russian strings come from st7105's translation in PR #45, corrected where the meaning had slipped ("Leave" as the verb for leaving something behind, "Group DM" as an untranslated abbreviation).
