### PR TITLE
feat(i18n): finish the error-code wiring and the remaining shell strings

### DIFF
--- a/docs/superpowers/plans/2026-09-04-localization-foundation.md
+++ b/docs/superpowers/plans/2026-09-04-localization-foundation.md
@@ -3,7 +3,39 @@
 Written 2026-09-04 before a context compact. Everything below was verified in the
 session that wrote it; the "open" items are marked.
 
-## Status (2026-09-04, later the same day)
+## Status (2026-09-05, morning)
+
+Everything in the plan below is on `main` except the release itself.
+
+- The foundation is #95 (`ef6b9069`).
+- All eleven surface sweeps merged: chat widgets #96, chat messages #97,
+  auth #98, shell #99, DMs #100, social #101, space layout #102, voice #103,
+  federation #104, admin #105, space dialogs #106. Every squash carries
+  `Co-authored-by: st7105` for the Russian lifted from #45.
+- The server error-code pass merged for every route file: spaces #109 (its
+  squash also carried the search/voice/upload and channel/message work, so
+  #107 and #108 were closed as superseded), social and explore #110, admin
+  and settings #111, DMs #112, auth and users #113.
+- The consolidation PR #114 moved shared strings into `common`, extended the
+  allowlist, and regenerated the pending list to empty. The literal check
+  now covers the whole web package.
+- The leftovers PR (this branch) removed the last English-text matching in
+  the client, gave the space-invite endpoint and the auth hooks their codes,
+  converted the two files no sweep owned, and updated the spec.
+- Not done, on purpose: `released` is still false for Russian and German.
+  The gate is a native read of the German; the least-certain phrases are
+  listed in the fork reports. The 1.1.0 release PR flips the flags and bumps
+  the version after that read.
+- Also merged during the night: st7105's Flatpak permissions fix #93.
+- Repo setting changed: pull-request auto-merge is enabled (it was off).
+
+Overnight list from the section below, for the record: sweeps done; PRs
+opened and merged with the co-author trailer, done; shared namespaces
+deep-merged, done; common consolidation, done; server error codes, done;
+#93 merged; nothing tagged, nothing released, no flags flipped, Flathub
+untouched, no deploys.
+
+### Status as it stood on 2026-09-04, later that day
 
 - Step 1 done. `v1.0.6` is tagged at `b3d570eb` (the first tag at `34e69f87`
   was deleted with its draft after the Flatpak prepare job failed on

--- a/docs/systems/localization.md
+++ b/docs/systems/localization.md
@@ -223,10 +223,10 @@ Detection order on startup:
 Each entry in `supportedLanguages` carries a `released` flag. Only released
 languages appear in the picker (`availableLanguages`) or can be chosen by
 detection; a stored choice for an unreleased language is ignored. Russian and
-German are complete in code and tests but stay unreleased until every surface
-is translated, so a release cut between the foundation and 1.1.0 is
-English-only by construction rather than half translated. The PR that empties
-the pending list flips the flags. Tests reach the unreleased languages with
+German are complete in code and tests and every surface is translated, but
+they stay unreleased until the German has had a native read, so a release
+cut before 1.1.0 is English-only by construction rather than unreviewed. A
+separate release PR flips the flags. Tests reach the unreleased languages with
 `setLanguage` or `initI18n({ releasedLanguages })`; people reach them with
 `?lang=de` on the URL, which works in development builds only and is never
 persisted.
@@ -300,13 +300,22 @@ Federation: error bodies relayed from a peer instance follow the same
 contract, so a code from a newer peer is localized and a bare `error` from
 an older peer is shown as is.
 
-Converted so far: the profile, password and account-deletion routes in
-`users.ts`. Auth, joins, uploads, friends and DM management follow with their
-surface sweeps.
+Every route file is converted: auth, users, spaces, channels, messages, DMs
+(including the space-invite endpoint), social, explore, admin, settings,
+search, LiveKit, uploads, GIF and URL metadata. The `authenticate`,
+`requireAdmin` and `requireLocalUser` hooks in `utils/auth.ts` send codes
+too (`unauthorized`, `account_deleted`, `forbidden`) while keeping their
+English text. Two responses carry extra fields next to the shared shape: the
+username availability check (`available`, `reason`) and the owned-spaces
+rejection (`ownedSpaces`). The only sites left without codes are the
+test-only peer seeding route and the WebSocket handler's error messages,
+which are a separate protocol.
 
-The conversion order is by what users actually see: auth, joining spaces
-and DMs, uploads, friend requests, DM management. Internal and admin errors
-follow as their panels are swept.
+The web client no longer matches on English error text. The places that
+used to (the join page, the space invite card, the invite modal, the roles
+panel, the federated account registration in `instanceStore`) check
+`err.code`; the join helper in `utils/joinErrors.ts` keeps a text fallback
+for a federated peer on a version that predates the codes.
 
 ---
 
@@ -361,16 +370,18 @@ It fails on:
 3. A plural key missing a CLDR category for its language.
 4. A `t()` call that passes `count` to a key without plural forms.
 5. A non-English value byte-identical to the English one, outside the
-   allowlist in `scripts/i18n-allowlist.json` (brand names, "OK", URLs).
+   allowlist in `scripts/i18n-allowlist.json` (brand names, "OK", URLs, and
+   the words German shares with English such as Link, Info, Token, Codec).
 6. A direct `toLocale*` or `Intl.*` call in the web package outside
    `formatters.ts`.
 7. An `ErrorCode` with no entry in `errors.json`.
 8. A literal user-facing string in JSX or in a `addToast(...)` call, in any
-   file not listed in `scripts/i18n-pending.txt`. That file is the list of
-   source files not yet swept; each sweep PR removes its files from it, and
-   the list reaching zero is the definition of done for the first localized
-   release. `node scripts/check-i18n.mjs --write-pending` regenerates it from
-   the current tree. A line that is a false positive carries
+   file not listed in `scripts/i18n-pending.txt`. That file listed the
+   source files not yet swept while the sweeps ran; it has been empty since
+   they finished, so the rule covers every file, and it stays as the
+   mechanism for a surface that has to land untranslated for a while.
+   `node scripts/check-i18n.mjs --write-pending` regenerates it from the
+   current tree. A line that is a false positive carries
    `// i18n-check: allow-literal` on the line above.
 
 The check reports every finding at once, with file and line, so a sweep PR

--- a/packages/server/src/routes/dm.spaceInvite.test.ts
+++ b/packages/server/src/routes/dm.spaceInvite.test.ts
@@ -149,7 +149,7 @@ describe('POST /api/dm/space-invite', () => {
       },
     });
     expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toBe('not_a_friend');
+    expect(JSON.parse(res.body).code).toBe('not_a_friend');
     // Snapshot should not be looked up if friendship gate fails first.
     expect(fetchSpaceInviteSnapshot).not.toHaveBeenCalled();
     expect(getLocalInviteSnapshot).not.toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe('POST /api/dm/space-invite', () => {
       },
     });
     expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toBe('invite_invalid');
+    expect(JSON.parse(res.body).code).toBe('invite_invalid');
     // No DM message should be inserted on failure.
     const messageCount = testDb.select().from(schema.dmMessages).all().length;
     expect(messageCount).toBe(0);
@@ -195,7 +195,7 @@ describe('POST /api/dm/space-invite', () => {
       },
     });
     expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body).error).toBe('invite_invalid');
+    expect(JSON.parse(res.body).code).toBe('invite_invalid');
     const messageCount = testDb.select().from(schema.dmMessages).all().length;
     expect(messageCount).toBe(0);
   });

--- a/packages/server/src/routes/dm.ts
+++ b/packages/server/src/routes/dm.ts
@@ -2359,7 +2359,7 @@ export async function dmRoutes(app: FastifyInstance): Promise<void> {
   }, async (request, reply) => {
     const body = request.body;
     if (!body || !body.spaceId || !body.inviteCode || !body.target) {
-      return reply.code(400).send({ error: 'invalid_body', statusCode: 400 });
+      return sendError(reply, 400, 'invalid_body');
     }
 
     const db = getDb();
@@ -2377,14 +2377,14 @@ export async function dmRoutes(app: FastifyInstance): Promise<void> {
         db,
       );
     } else {
-      return reply.code(400).send({ error: 'invalid_target', statusCode: 400 });
+      return sendError(reply, 400, 'invalid_target');
     }
 
     if (!targetUser) {
-      return reply.code(404).send({ error: 'user_not_found', statusCode: 404 });
+      return sendError(reply, 404, 'user_not_found');
     }
     if (targetUser.id === callerId) {
-      return reply.code(400).send({ error: 'cannot_invite_self', statusCode: 400 });
+      return sendError(reply, 400, 'cannot_invite_self');
     }
 
     // 2. Friendship check (anti-spam, NOT a permission gate — see spec).
@@ -2395,7 +2395,7 @@ export async function dmRoutes(app: FastifyInstance): Promise<void> {
       ),
     ).get();
     if (!friendship) {
-      return reply.code(400).send({ error: 'not_a_friend', statusCode: 400 });
+      return sendError(reply, 400, 'not_a_friend');
     }
 
     // 3. Snapshot lookup. For local spaces, read the DB directly — fetching
@@ -2408,11 +2408,11 @@ export async function dmRoutes(app: FastifyInstance): Promise<void> {
       ? getLocalInviteSnapshot(body.inviteCode)
       : await fetchSpaceInviteSnapshot(spaceOrigin, body.inviteCode);
     if (!snapshot) {
-      return reply.code(400).send({ error: 'invite_invalid', statusCode: 400 });
+      return sendError(reply, 400, 'invite_invalid');
     }
     if (snapshot.spaceId !== body.spaceId) {
       // spaceId mismatch — code points at a different space than the client claimed.
-      return reply.code(400).send({ error: 'invite_invalid', statusCode: 400 });
+      return sendError(reply, 400, 'invite_invalid');
     }
 
     // Request-only spaces are approval-gated and have no usable invite links, so
@@ -2425,7 +2425,7 @@ export async function dmRoutes(app: FastifyInstance): Promise<void> {
     const localSpace = db.select({ visibility: schema.spaces.visibility })
       .from(schema.spaces).where(eq(schema.spaces.id, body.spaceId)).get();
     if (localSpace?.visibility === 'request') {
-      return reply.code(403).send({ error: 'space_requires_approval', statusCode: 403 });
+      return sendError(reply, 403, 'space_requires_approval');
     }
 
     // 4. Resolve / create the 1-on-1 DM (delegate to dedup helper).
@@ -2461,7 +2461,7 @@ export async function dmRoutes(app: FastifyInstance): Promise<void> {
     // 6. Hydrate + broadcast locally.
     const message = getDmMessageWithUser(messageId);
     if (!message) {
-      return reply.code(500).send({ error: 'message_lookup_failed', statusCode: 500 });
+      return sendError(reply, 500, 'message_lookup_failed');
     }
     broadcastDmMessage(dmChannelId, message);
 

--- a/packages/server/src/utils/auth.test.ts
+++ b/packages/server/src/utils/auth.test.ts
@@ -32,6 +32,7 @@ describe('requireLocalUser', () => {
     expect(reply.code).toHaveBeenCalledWith(403);
     expect(reply.send).toHaveBeenCalledWith({
       error: 'Federated users must use their home instance for DM operations',
+      code: 'forbidden',
       statusCode: 403,
     });
   });

--- a/packages/server/src/utils/auth.ts
+++ b/packages/server/src/utils/auth.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { config } from '../config.js';
 import { getDb, schema } from '../db/index.js';
 import type { FastifyRequest, FastifyReply } from 'fastify';
+import type { ErrorCode } from '@backspace/shared/src/errors';
 
 const SALT_ROUNDS = 12;
 
@@ -40,9 +41,12 @@ export function verifyJwt(token: string): JwtPayload {
  */
 export class AuthError extends Error {
   statusCode: number;
-  constructor(message: string, statusCode: number) {
+  /** Stable code for the client; the message stays the English log text. */
+  code: ErrorCode;
+  constructor(message: string, statusCode: number, code: ErrorCode = 'unauthorized') {
     super(message);
     this.statusCode = statusCode;
+    this.code = code;
   }
 }
 
@@ -76,7 +80,7 @@ export async function verifyJwtAndUser(token: string): Promise<{
   }).from(schema.users).where(eq(schema.users.id, payload.userId)).get();
 
   if (!user || user.isDeleted === 1) {
-    throw new AuthError('This account has been deleted', 401);
+    throw new AuthError('This account has been deleted', 401, 'account_deleted');
   }
 
   // Reject tokens issued before the last password change (token revocation).
@@ -100,7 +104,7 @@ export async function authenticate(
 ): Promise<void> {
   const authHeader = request.headers.authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    reply.code(401).send({ error: 'Missing or invalid authorization header', statusCode: 401 });
+    reply.code(401).send({ error: 'Missing or invalid authorization header', code: 'unauthorized', statusCode: 401 });
     return;
   }
 
@@ -112,9 +116,9 @@ export async function authenticate(
     (request as FastifyRequest & { userId: string; username: string }).homeInstance = identity.homeInstance;
   } catch (err) {
     if (err instanceof AuthError) {
-      return reply.code(err.statusCode).send({ error: err.message, statusCode: err.statusCode });
+      return reply.code(err.statusCode).send({ error: err.message, code: err.code, statusCode: err.statusCode });
     }
-    return reply.code(401).send({ error: 'Invalid or expired token', statusCode: 401 });
+    return reply.code(401).send({ error: 'Invalid or expired token', code: 'unauthorized', statusCode: 401 });
   }
 }
 
@@ -125,7 +129,7 @@ export async function requireAdmin(
   const db = getDb();
   const caller = db.select().from(schema.users).where(eq(schema.users.id, request.userId)).get();
   if (!caller || caller.isAdmin !== 1) {
-    return reply.code(403).send({ error: 'Only instance admins can perform this action', statusCode: 403 });
+    return reply.code(403).send({ error: 'Only instance admins can perform this action', code: 'forbidden', statusCode: 403 });
   }
 }
 
@@ -136,6 +140,7 @@ export async function requireLocalUser(
   if (request.homeInstance) {
     return reply.code(403).send({
       error: 'Federated users must use their home instance for DM operations',
+      code: 'forbidden',
       statusCode: 403,
     });
   }

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -89,6 +89,18 @@ export class RateLimitError extends Error {
   }
 }
 
+/**
+ * Reply of the username availability check. `reason` is the server's
+ * English text; `code` and `details` let the client say it in the user's
+ * language.
+ */
+export interface CheckUsernameResponse {
+  available: boolean;
+  reason?: string;
+  code?: ErrorCode;
+  details?: ErrorDetails;
+}
+
 export class HttpError extends Error {
   readonly status: number;
   readonly body?: unknown;
@@ -129,7 +141,7 @@ export class BackspaceApiClient {
   readonly auth: {
     register: (data: RegisterRequest) => Promise<AuthResponse>;
     login: (data: LoginRequest) => Promise<AuthResponse>;
-    checkUsername: (username: string) => Promise<{ available: boolean; reason?: string }>;
+    checkUsername: (username: string) => Promise<CheckUsernameResponse>;
     checkInvite: (token: string) => Promise<CheckInviteResponse>;
     attachProof: (targetDomain: string) => Promise<AttachProofResponse>;
   };
@@ -419,7 +431,7 @@ export class BackspaceApiClient {
       login: (data: LoginRequest) =>
         request<AuthResponse>('POST', '/auth/login', data, false),
       checkUsername: (username: string) =>
-        request<{ available: boolean; reason?: string }>('GET', `/auth/check-username?username=${encodeURIComponent(username)}`, undefined, false),
+        request<CheckUsernameResponse>('GET', `/auth/check-username?username=${encodeURIComponent(username)}`, undefined, false),
       checkInvite: (token: string) =>
         request<CheckInviteResponse>('GET', `/auth/check-invite?token=${encodeURIComponent(token)}`, undefined, false),
       attachProof: (targetDomain: string) =>

--- a/packages/web/src/components/JoinPage.tsx
+++ b/packages/web/src/components/JoinPage.tsx
@@ -9,6 +9,7 @@ import { parseInviteInput, buildInstanceJoinUrl } from '../utils/inviteParser';
 import { Avatar } from './ui/Avatar';
 import type { InvitePreview } from '@backspace/shared';
 import { describeError } from '../i18n/errors';
+import { isAlreadyMemberError } from '../utils/joinErrors';
 
 type JoinPhase = 'preview' | 'connect' | 'fallback' | 'other-instance' | 'already-member';
 
@@ -109,8 +110,7 @@ export function JoinPage() {
         setPhase('connect');
         setError('');
       } else {
-        const msg = err instanceof Error ? err.message : '';
-        if (msg.toLowerCase().includes('already a member')) {
+        if (isAlreadyMemberError(err)) {
           setPhase('already-member');
           setError('');
         } else {
@@ -139,8 +139,7 @@ export function JoinPage() {
         setFallbackPassword('');
         setError('');
       } else {
-        const msg = err instanceof Error ? err.message : '';
-        if (msg.toLowerCase().includes('already a member')) {
+        if (isAlreadyMemberError(err)) {
           setPhase('already-member');
           setError('');
         } else {
@@ -163,8 +162,7 @@ export function JoinPage() {
       const space = await joinByCode(parsed.code, parsed.origin);
       navigate(`/channels/${space.id}`);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : '';
-      if (msg.toLowerCase().includes('already a member')) {
+      if (isAlreadyMemberError(err)) {
         setPhase('already-member');
         setError('');
       } else {

--- a/packages/web/src/components/auth/RegisterPage.tsx
+++ b/packages/web/src/components/auth/RegisterPage.tsx
@@ -7,7 +7,7 @@ import { ImageCropModal } from '../ui/ImageCropModal';
 import { AVATAR_GRADIENT_MAP } from '../../utils/gradients';
 import { AVATAR_COLORS } from '@backspace/shared';
 import type { AvatarColor, CheckInviteResponse, InstanceInfoResponse } from '@backspace/shared';
-import { api, RateLimitError } from '../../api/client';
+import { api, HttpError, RateLimitError } from '../../api/client';
 import { useTransferStore } from '../../stores/transferStore';
 import { waitForTransferAttachment } from '../../utils/waitForTransfer';
 import { SourceCodeLink } from '../ui/SourceCodeLink';
@@ -215,9 +215,13 @@ export function RegisterPage() {
         const result = await api.auth.checkUsername(trimmed);
         if (controller.signal.aborted) return;
 
-        if (result.reason) {
+        if (result.reason || result.code) {
           setUsernameStatus('invalid');
-          setUsernameStatusMessage(result.reason);
+          // Localize by code when the server sends one; the English reason is
+          // the fallback for an instance that predates the codes.
+          setUsernameStatusMessage(
+            describeError(new HttpError(200, result.reason ?? '', result, result.code, result.details)),
+          );
         } else if (result.available) {
           setUsernameStatus('available');
           setUsernameStatusMessage(t('auth:validation.usernameAvailable'));

--- a/packages/web/src/components/chat/SpaceInviteCard.test.tsx
+++ b/packages/web/src/components/chat/SpaceInviteCard.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { SpaceInviteCard } from './SpaceInviteCard';
+import { HttpError } from '../../api/client';
 
 const { mockJoinByCode, mockGetApiForOrigin, mockNavigate } = vi.hoisted(() => ({
   mockJoinByCode: vi.fn(),
@@ -14,7 +15,9 @@ vi.mock('../../stores/spaceStore', () => ({
   useSpaceStore: (selector: any) => selector({ joinByCode: mockJoinByCode }),
   getApiForOrigin: mockGetApiForOrigin,
 }));
-vi.mock('../../api/client', () => ({
+// Keep the real exports: HttpError is what the join-error helper inspects.
+vi.mock('../../api/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../api/client')>()),
   createApiClient: vi.fn(),
 }));
 vi.mock('react-router-dom', async () => ({
@@ -105,7 +108,9 @@ describe('SpaceInviteCard', () => {
     const userEvent = (await import('@testing-library/user-event')).default;
     const user = userEvent.setup();
 
-    mockJoinByCode.mockRejectedValueOnce(new Error('You are already a member of this space'));
+    mockJoinByCode.mockRejectedValueOnce(
+      new HttpError(409, 'You are already a member', { error: 'You are already a member', code: 'already_member', statusCode: 409 }, 'already_member'),
+    );
     mockGetApiForOrigin.mockReturnValue({
       spaces: { invitePreview: vi.fn().mockResolvedValue({ ...basePayload.snapshot, spaceId: 'S1' }) },
     });

--- a/packages/web/src/components/chat/SpaceInviteCard.tsx
+++ b/packages/web/src/components/chat/SpaceInviteCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { describeError } from '../../i18n/errors';
+import { isAlreadyMemberError } from '../../utils/joinErrors';
 import { Avatar } from '../ui/Avatar';
 import { getApiForOrigin } from '../../stores/spaceStore';
 import { useSpaceStore } from '../../stores/spaceStore';
@@ -76,15 +77,14 @@ export function SpaceInviteCard({ payload, senderName }: Props) {
       const space = await joinByCode(payload.inviteCode, payload.spaceInstanceOrigin || undefined);
       landOnSpace(space.id);
     } catch (err) {
-      const msg = (err as Error)?.message ?? '';
-      if (msg.toLowerCase().includes('already a member')) {
+      if (isAlreadyMemberError(err)) {
         // Already a member is a successful state — just navigate to the space.
         // Look up the space in the store by id; if not found (rare race), stay
         // silent rather than block the user with a noisy error.
         landOnSpace(payload.spaceId);
         return;
       }
-      setJoinError(msg ? describeError(err) : t('chat:invite.joinFailed'));
+      setJoinError(err instanceof Error ? describeError(err) : t('chat:invite.joinFailed'));
       setJoining(false);
     }
   };

--- a/packages/web/src/components/modals/InviteModal.test.tsx
+++ b/packages/web/src/components/modals/InviteModal.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../api/client', async (importOriginal) => ({
 }));
 
 import { InviteModal } from './InviteModal';
+import { HttpError } from '../../api/client';
 import { useUIStore } from '../../stores/uiStore';
 import { useSpaceStore } from '../../stores/spaceStore';
 import { useSocialStore } from '../../stores/socialStore';
@@ -275,7 +276,7 @@ describe('InviteModal', () => {
     // f1 succeeds, f2 fails with `not_a_friend`.
     mockSpaceInvite.mockImplementation(({ target }: any) => {
       if (target.userId === 'f1') return Promise.resolve({});
-      return Promise.reject(new Error('not_a_friend'));
+      return Promise.reject(new HttpError(400, 'Not a friend', { error: 'Not a friend', code: 'not_a_friend', statusCode: 400 }, 'not_a_friend'));
     });
 
     setUpStore({

--- a/packages/web/src/components/modals/InviteModal.tsx
+++ b/packages/web/src/components/modals/InviteModal.tsx
@@ -7,7 +7,7 @@ import { useUIStore } from '../../stores/uiStore';
 import { useSpaceStore } from '../../stores/spaceStore';
 import { useAuthStore } from '../../stores/authStore';
 import { useSocialStore } from '../../stores/socialStore';
-import { api } from '../../api/client';
+import { api, HttpError } from '../../api/client';
 import { isSelf, parseFederatedUsername } from '../../utils/identity';
 import { useCanonicalUserView } from '../../utils/userViewLookup';
 import { describeError } from '../../i18n/errors';
@@ -21,26 +21,29 @@ type SendStatus =
 type InviteT = TFunction<['spaces', 'common']>;
 
 /**
- * The invite relay answers with a bare reason in its `error` field. These
- * are not `ErrorCode`s yet, so the wording lives in the spaces catalog
- * until the server-side error-code pass reaches the DM routes.
+ * Row-sized copy for each way a space invite can fail. Keyed on the server's
+ * error code; the two message checks below cover a failed fetch and the
+ * client-side "upstream" marker, which never carry a code.
  */
 function reasonForError(error: unknown, t: InviteT): string {
-  if (error instanceof Error) {
-    const msg = error.message;
-    switch (msg) {
+  if (error instanceof HttpError) {
+    switch (error.code) {
       case 'invite_invalid': return t('spaces:invite.failure.inviteInvalid');
       case 'not_a_friend': return t('spaces:invite.failure.notAFriend');
       case 'user_not_found': return t('spaces:invite.failure.userNotFound');
       case 'already_member': return t('spaces:invite.failure.alreadyMember');
-      case 'upstream': return t('spaces:invite.failure.upstream');
       case 'cannot_invite_self': return t('spaces:invite.failure.cannotInviteSelf');
       case 'invalid_body': return t('spaces:invite.failure.invalidBody');
       case 'invalid_target': return t('spaces:invite.failure.invalidTarget');
       default:
         break;
     }
-    if (/network|fetch|failed to fetch/i.test(msg)) {
+  }
+  if (error instanceof Error) {
+    if (error.message === 'upstream') {
+      return t('spaces:invite.failure.upstream');
+    }
+    if (/network|fetch|failed to fetch/i.test(error.message)) {
       return t('spaces:invite.failure.unreachable');
     }
   }

--- a/packages/web/src/components/modals/spaceSettingsPanels/RolesPanel.tsx
+++ b/packages/web/src/components/modals/spaceSettingsPanels/RolesPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSpaceStore } from '../../../stores/spaceStore';
 import { useUIStore } from '../../../stores/uiStore';
-import { api } from '../../../api/client';
+import { api, HttpError } from '../../../api/client';
 import { PermissionBits, stringToPermissions, permissionsToString } from '../../../utils/permissions';
 import { usePermissionNames, type PermissionKey } from '../../ui/OverrideEntry';
 import { describeError } from '../../../i18n/errors';
@@ -265,10 +265,8 @@ function RoleEditView({ role, spaceId, isNew, onBack, onDeleted, onCopied }: Rol
       await loadSpaceDetail(spaceId);
       addToast(t('spaces:roles.saved'), 'success', 2000);
     } catch (err) {
-      // The server has no error code for a duplicate name yet; its English
-      // text is the only signal, so the name-field routing keys off it.
-      const serverText = err instanceof Error ? err.message : '';
-      if (serverText.includes('already exists')) {
+      // A duplicate name belongs on the name field, not in the save banner.
+      if (err instanceof HttpError && err.code === 'role_name_taken') {
         setNameError(t('spaces:roles.nameDuplicate'));
       } else {
         setSaveError(describeError(err));

--- a/packages/web/src/components/ui/ConfirmDialog.tsx
+++ b/packages/web/src/components/ui/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import ReactDOM from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import { usePortalContainer } from '../../hooks/usePortalContainer';
 
 interface ConfirmDialogProps {
@@ -20,11 +21,12 @@ export function ConfirmDialog({
   onConfirm,
   title,
   description,
-  confirmLabel = 'Confirm',
-  cancelLabel = 'Cancel',
+  confirmLabel,
+  cancelLabel,
   variant = 'danger',
   loading = false,
 }: ConfirmDialogProps) {
+  const { t } = useTranslation(['common']);
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape' && !loading) {
       e.stopPropagation();
@@ -64,14 +66,14 @@ export function ConfirmDialog({
               disabled={loading}
               className="flex-1 py-2.5 text-sm font-medium text-txt-secondary bg-interactive-hover hover:bg-interactive-selected rounded-lg transition-colors disabled:opacity-50"
             >
-              {cancelLabel}
+              {cancelLabel ?? t('common:actions.cancel')}
             </button>
             <button
               onClick={onConfirm}
               disabled={loading}
               className={`flex-1 py-2.5 ${confirmBg} text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50`}
             >
-              {loading ? 'Please wait...' : confirmLabel}
+              {loading ? t('common:states.pleaseWait') : (confirmLabel ?? t('common:actions.confirm'))}
             </button>
           </div>
         </div>

--- a/packages/web/src/hooks/useSpaceJoin.ts
+++ b/packages/web/src/hooks/useSpaceJoin.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useExploreStore, type TaggedExploreSpace } from '../stores/exploreStore';
 import type { SpaceWithChannelsAndMembers } from '@backspace/shared';
+import { describeError } from '../i18n/errors';
 
 export interface SpaceJoinControls {
   isJoined: boolean;
@@ -48,7 +49,7 @@ export function useSpaceJoin(space: TaggedExploreSpace): SpaceJoinControls {
     try {
       return await publicJoin(space);
     } catch (err) {
-      setJoinError(err instanceof Error ? err.message : 'Failed to join');
+      setJoinError(describeError(err));
       setJoining(false);
       return null;
     }
@@ -62,7 +63,7 @@ export function useSpaceJoin(space: TaggedExploreSpace): SpaceJoinControls {
       setLocalRequestSent(true);
       setShowRequestForm(false);
     } catch (err) {
-      setJoinError(err instanceof Error ? err.message : 'Failed to send request');
+      setJoinError(describeError(err));
     } finally {
       setJoining(false);
     }

--- a/packages/web/src/locales/de/common.json
+++ b/packages/web/src/locales/de/common.json
@@ -67,7 +67,8 @@
     "loadingSettings": "Einstellungen werden geladen…",
     "settingsSaved": "Einstellungen gespeichert",
     "saveFailed": "Speichern fehlgeschlagen",
-    "scanning": "Wird geprüft…"
+    "scanning": "Wird geprüft…",
+    "pleaseWait": "Bitte warten…"
   },
   "labels": {
     "username": "Benutzername",

--- a/packages/web/src/locales/en/common.json
+++ b/packages/web/src/locales/en/common.json
@@ -67,7 +67,8 @@
     "loadingSettings": "Loading settings…",
     "settingsSaved": "Settings saved",
     "saveFailed": "Failed to save",
-    "scanning": "Scanning…"
+    "scanning": "Scanning…",
+    "pleaseWait": "Please wait…"
   },
   "labels": {
     "username": "Username",

--- a/packages/web/src/locales/ru/common.json
+++ b/packages/web/src/locales/ru/common.json
@@ -67,7 +67,8 @@
     "loadingSettings": "Загрузка настроек…",
     "settingsSaved": "Настройки сохранены",
     "saveFailed": "Не удалось сохранить",
-    "scanning": "Сканирование…"
+    "scanning": "Сканирование…",
+    "pleaseWait": "Подождите…"
   },
   "labels": {
     "username": "Имя пользователя",

--- a/packages/web/src/stores/instanceStore.remoteCredential.test.ts
+++ b/packages/web/src/stores/instanceStore.remoteCredential.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { User } from '@backspace/shared';
 import type { BackspaceApiClient } from '../api/client';
+import { HttpError } from '../api/client';
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 // Obvious fakes only. HOME_PASSWORD is the value that must never leave the
@@ -26,7 +27,10 @@ const remoteRegister = vi.fn();
 const remoteLogin = vi.fn();
 const remoteInfo = vi.fn(async () => ({ name: 'Orbit' }));
 
-vi.mock('../api/client', () => ({
+// Keep the real exports: HttpError is what the store inspects on a failed
+// remote registration.
+vi.mock('../api/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/client')>()),
   api: {
     users: {
       verifyPassword: (password: string) => verifyPassword(password),
@@ -155,7 +159,9 @@ describe('connectToRemote never hands the home password to a remote instance', (
   });
 
   it('falls back to login with the issued secret when the account already exists', async () => {
-    remoteRegister.mockRejectedValue(new Error('Username already taken'));
+    remoteRegister.mockRejectedValue(
+      new HttpError(409, 'Username is already taken', { error: 'Username is already taken', code: 'username_taken', statusCode: 409 }, 'username_taken'),
+    );
     remoteLogin.mockResolvedValue(authResponse());
 
     await useInstanceStore.getState().connectToRemote(REMOTE, HOME_PASSWORD, 'Erin');
@@ -168,7 +174,9 @@ describe('connectToRemote never hands the home password to a remote instance', (
   });
 
   it('never retries a failed remote login with the home password', async () => {
-    remoteRegister.mockRejectedValue(new Error('Username already taken'));
+    remoteRegister.mockRejectedValue(
+      new HttpError(409, 'Username is already taken', { error: 'Username is already taken', code: 'username_taken', statusCode: 409 }, 'username_taken'),
+    );
     remoteLogin.mockRejectedValue(new Error('Invalid username or password'));
 
     await expect(

--- a/packages/web/src/stores/instanceStore.ts
+++ b/packages/web/src/stores/instanceStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import type { User, InstanceInfoResponse, ReplicatedInstance, AuthResponse, FederationRegistryEntry } from '@backspace/shared';
-import { BackspaceApiClient, createApiClient, api } from '../api/client';
+import { BackspaceApiClient, HttpError, createApiClient, api } from '../api/client';
 import { useAuthStore } from './authStore';
 import {
   setApiForOriginResolver,
@@ -435,11 +435,17 @@ export const useInstanceStore = create<InstanceState>((set, get) => ({
             homeUserId: trueHomeUserId,
           });
         } catch (err) {
-          const message = (err as Error).message;
-          if (message.includes('already taken') || message.includes('409') ||
-              message.includes('Registration is currently closed') || message.includes('403')) {
-            // Already registered or registration closed — fall through to login
-          } else {
+          // Already registered, or registration closed: fall through to login.
+          // The status fallback covers a remote instance on a version that
+          // sends no code yet.
+          const registeredOrClosed = err instanceof HttpError && (
+            err.code === 'username_taken' ||
+            err.code === 'registration_closed' ||
+            err.code === 'federated_registration_closed' ||
+            err.status === 409 ||
+            err.status === 403
+          );
+          if (!registeredOrClosed) {
             throw err;
           }
         }

--- a/packages/web/src/utils/joinErrors.ts
+++ b/packages/web/src/utils/joinErrors.ts
@@ -1,0 +1,14 @@
+import { HttpError } from '../api/client';
+
+/**
+ * Whether a failed join means the user is already in the space, which every
+ * caller treats as success. The current server sends the `already_member`
+ * code; a federated peer on an older version still sends only English text,
+ * so the text match stays as the fallback for remote joins.
+ */
+export function isAlreadyMemberError(err: unknown): boolean {
+  if (err instanceof HttpError && err.code) {
+    return err.code === 'already_member';
+  }
+  return err instanceof Error && err.message.toLowerCase().includes('already a member');
+}


### PR DESCRIPTION
The last loose ends after the sweeps and the server error-code pass.

- The web client no longer recognises server errors by matching English text. The join page and the invite card check the `already_member` code, the invite modal keys its explanations on the code, the roles panel checks `role_name_taken`, and the instance store checks `username_taken` and the two registration-closed codes. One text fallback remains, in the remote-join paths, for a federated peer running a version that predates the codes.
- The register page localizes the username availability reason through the code and details the server now sends.
- The space-invite endpoint in the DM routes uses the shared error shape, and the authenticate, admin and local-user hooks carry codes on their 401 and 403 bodies. English text is unchanged.
- The space-join hook and the confirm dialog, which no sweep owned, use the catalogs; the dialog gains a "Please wait" state string in the three languages.
- The localization spec says every route file is converted and describes the release gate as it stands; the plan file gets a status section for the morning.

Type check, the web suite and the server suite are clean. Five tests now reject with a typed error carrying a code instead of a plain message; no assertion on visible text changed.
