### PR TITLE
chore: release 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backspace",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Open, self-hosted communication platform \u2014 text, voice, video, and federation",
   "license": "AGPL-3.0-only",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/desktop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backspace",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/shared",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/web",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/metrics",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",


### PR DESCRIPTION
Version bump only. The container image for 1.1.0 failed to build (fixed in #119); this tag rebuilds it. No other changes.
