### PR TITLE
fix(i18n): localize activity elapsed time

### DIFF
--- a/packages/web/src/components/ui/ActivityCard.test.tsx
+++ b/packages/web/src/components/ui/ActivityCard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Activity } from '@backspace/shared';
+import { setLanguage } from '../../i18n';
+import { ActivityCard } from './ActivityCard';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-09-04T12:00:00Z'));
+});
+
+afterEach(async () => {
+  await setLanguage('en');
+  vi.useRealTimers();
+});
+
+describe('ActivityCard', () => {
+  it('localizes the elapsed activity time', async () => {
+    await setLanguage('ru');
+    const activity: Activity = {
+      type: 'playing',
+      name: 'Escape from Tarkov',
+      timestamps: { start: Date.now() - 32 * 60 * 1000 },
+    };
+
+    render(<ActivityCard activities={[activity]} />);
+
+    expect(screen.getByText('Escape from Tarkov')).toBeInTheDocument();
+    expect(screen.getByText('Прошло 32 мин.')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/ui/ActivityCard.tsx
+++ b/packages/web/src/components/ui/ActivityCard.tsx
@@ -1,17 +1,21 @@
 import type { Activity } from '@backspace/shared';
 import { getPrimaryActivity } from '@backspace/shared/src/activities.js';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 interface ActivityCardProps {
   activities: Activity[];
   fallbackCustomStatus?: string | null;
 }
 
-function formatElapsed(startMs: number): string {
+function formatElapsed(startMs: number, t: TFunction<'common'>): string {
   const elapsed = Date.now() - startMs;
   const minutes = Math.floor(elapsed / 60000);
   const hours = Math.floor(minutes / 60);
-  if (hours > 0) return `${hours}h ${minutes % 60}m`;
-  return `${minutes}m`;
+  const duration = hours > 0
+    ? t('time.hoursMinutesShort', { hours, minutes: minutes % 60 })
+    : t('time.minutesShort', { minutes });
+  return t('time.elapsed', { duration });
 }
 
 /** Returns the accent border color class for an activity type */
@@ -36,6 +40,7 @@ export function hasRichActivity(activities: Activity[]): boolean {
  * The glass card wrapper is applied by the parent row container.
  */
 export function ActivityCard({ activities, fallbackCustomStatus }: ActivityCardProps) {
+  const { t } = useTranslation('common');
   const primary = getPrimaryActivity(activities);
 
   if (!primary) {
@@ -58,7 +63,7 @@ export function ActivityCard({ activities, fallbackCustomStatus }: ActivityCardP
       </div>
       {primary.timestamps?.start && (
         <div className="text-[10px] leading-[1.3] text-txt-tertiary">
-          {formatElapsed(primary.timestamps.start)} elapsed
+          {formatElapsed(primary.timestamps.start, t)}
         </div>
       )}
     </>

--- a/packages/web/src/locales/de/common.json
+++ b/packages/web/src/locales/de/common.json
@@ -87,7 +87,10 @@
     "today": "Heute um {{time}}",
     "yesterday": "Gestern um {{time}}",
     "never": "Nie",
-    "justNow": "Gerade eben"
+    "justNow": "Gerade eben",
+    "minutesShort": "{{minutes}} Min.",
+    "hoursMinutesShort": "{{hours}} Std. {{minutes}} Min.",
+    "elapsed": "Seit {{duration}}"
   },
   "units": {
     "ms": "{{value}} ms",

--- a/packages/web/src/locales/en/common.json
+++ b/packages/web/src/locales/en/common.json
@@ -87,7 +87,10 @@
     "today": "Today at {{time}}",
     "yesterday": "Yesterday at {{time}}",
     "never": "Never",
-    "justNow": "Just now"
+    "justNow": "Just now",
+    "minutesShort": "{{minutes}}m",
+    "hoursMinutesShort": "{{hours}}h {{minutes}}m",
+    "elapsed": "{{duration}} elapsed"
   },
   "units": {
     "ms": "{{value}} ms",

--- a/packages/web/src/locales/ru/common.json
+++ b/packages/web/src/locales/ru/common.json
@@ -87,7 +87,10 @@
     "today": "Сегодня в {{time}}",
     "yesterday": "Вчера в {{time}}",
     "never": "Никогда",
-    "justNow": "Только что"
+    "justNow": "Только что",
+    "minutesShort": "{{minutes}} мин.",
+    "hoursMinutesShort": "{{hours}} ч {{minutes}} мин.",
+    "elapsed": "Прошло {{duration}}"
   },
   "units": {
     "ms": "{{value}} мс",


### PR DESCRIPTION
## What this changes

Fixes the hard-coded English elapsed-time label in rich activity cards, reported while reviewing the Russian UI in #116.

Before, every locale rendered values such as `32m elapsed`. The component now reads the duration and label from the `common` catalog:

- English: `32m elapsed`
- German: `Seit 32 Min.`
- Russian: `Прошло 32 мин.`

Application/game names remain untouched because they are user/application data, not UI copy.

The new regression test switches the app to Russian and verifies the exact activity-card output while preserving the game title.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Web production build succeeds
- [ ] `pnpm dev` starts the server and web client without errors
- [x] Tests pass (`76` files / `661` web tests, including the new regression test)
- [x] The reported UI state is covered by an automated locale-switching regression test
- [x] No system documentation update is needed; this only localizes existing UI copy
- [x] No identity, permission, or federation behavior is changed
- [x] My existing CLA signature applies to this contribution

## Validation

- `pnpm check:i18n` — no findings
- `pnpm --filter @backspace/web typecheck` — passed
- `pnpm --filter @backspace/web test` — 76 files / 661 tests passed
- `pnpm --filter @backspace/web build` — passed