### PR TITLE
feat(chat): edit last message with ArrowUp

### DIFF
--- a/packages/web/src/components/chat/Message.tsx
+++ b/packages/web/src/components/chat/Message.tsx
@@ -124,22 +124,38 @@ function getImageEmbedSourceUrl(content: string | null, embeds: Embed[]): string
 export function Message({ message, isCompact, isFirstInGroup, previousMessageId }: MessageProps) {
   const { t } = useTranslation(['chat', 'common']);
   const fmt = useFormatters();
-  const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(message.content ?? '');
   const [isHovered, setIsHovered] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [showReactionPicker, setShowReactionPicker] = useState(false);
   const confirmDeleteTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const editTextareaRef = useRef<HTMLTextAreaElement>(null);
   const reactionPickerBtnRef = useRef<HTMLButtonElement>(null);
   const reactionPickerRef = useRef<HTMLDivElement>(null);
   const currentUser = useAuthStore((s) => s.user);
   const editMessage = useChatStore((s) => s.editMessage);
+  const editingMessageId = useChatStore((s) => s.editingMessageId);
+  const setEditingMessage = useChatStore((s) => s.setEditingMessage);
   const deleteMessage = useChatStore((s) => s.deleteMessage);
   const members = useSpaceStore((s) => s.members);
   const openUserProfile = useUIStore((s) => s.openUserProfile);
 
   const pending = isPendingMessage(message) ? message.__pending : null;
   const showInteractions = !pending;
+  const isEditing = !pending && editingMessageId === message.id;
+
+  useEffect(() => {
+    if (!isEditing) return;
+    const content = message.content ?? '';
+    setEditContent(content);
+    const frame = requestAnimationFrame(() => {
+      const textarea = editTextareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(content.length, content.length);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isEditing, message.content]);
 
   const transfersForRow = useTransferStore((s) => s.transfers);
   const inMemoryFiles = useTransferStore((s) => s.hasInMemoryFile);
@@ -163,6 +179,14 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
     ? message.channelId || message.dmChannelId || ''
     : message.channelId || (message as MessageWithUser & { dmChannelId?: string }).dmChannelId || '';
   const isAuthor = isSelf(message.user, currentUser);
+  const startEditing = () => {
+    setEditContent(message.content ?? '');
+    setEditingMessage(message.id);
+  };
+  const stopEditing = () => {
+    setEditContent(message.content ?? '');
+    setEditingMessage(null);
+  };
   const channelPermissions = useSpaceStore((s) => s.channelPermissions);
   const myChPerms = channelPermissions.get(message.channelId);
   const isDmMessage = isPendingMessage(message)
@@ -330,10 +354,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
       canSendMessages,
       canManageMessages,
       onReply: () => setReplyTo(message),
-      onEdit: () => {
-        setEditContent(message.content ?? '');
-        setIsEditing(true);
-      },
+      onEdit: startEditing,
       onDelete: () => deleteMessage(message.id, channelKey),
       onReaction: (emoji: string) => toggleReaction(emoji),
       onOpenEmojiPicker: () => {
@@ -353,12 +374,11 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
       e.preventDefault();
       if (editContent.trim()) {
         await editMessage(message.id, editContent.trim(), channelKey);
-        setIsEditing(false);
+        setEditingMessage(null);
       }
     }
     if (e.key === 'Escape') {
-      setIsEditing(false);
-      setEditContent(message.content ?? '');
+      stopEditing();
     }
   };
 
@@ -475,6 +495,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
         {isEditing ? (
           <div className="mt-1 w-full">
             <textarea
+              ref={editTextareaRef}
               value={editContent}
               onChange={(e) => setEditContent(e.target.value)}
               onKeyDown={handleEditSubmit}
@@ -487,13 +508,13 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
                 t={t}
                 i18nKey="chat:message.edit.hint"
                 components={{ // i18n-check: allow-literal (the next line is an object key after a JSX element, not text)
-                  cancel: <button onClick={() => setIsEditing(false)} className="text-txt-link hover:underline" />,
+                  cancel: <button onClick={stopEditing} className="text-txt-link hover:underline" />,
                   save: (
                     <button
                       onClick={() => {
                         if (editContent.trim()) {
                           editMessage(message.id, editContent.trim(), channelKey);
-                          setIsEditing(false);
+                          setEditingMessage(null);
                         }
                       }}
                       className="text-txt-link hover:underline"
@@ -711,10 +732,7 @@ export function Message({ message, isCompact, isFirstInGroup, previousMessageId 
           </button>
           {isAuthor && (
             <button
-              onClick={() => {
-                setEditContent(message.content ?? '');
-                setIsEditing(true);
-              }}
+              onClick={startEditing}
               className="px-2 h-full text-txt-tertiary hover:text-txt-primary hover:bg-interactive-hover transition-all flex items-center justify-center"
               title={t('common:actions.edit')}
             >

--- a/packages/web/src/components/chat/MessageInput.test.tsx
+++ b/packages/web/src/components/chat/MessageInput.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MessageWithUser, User } from '@backspace/shared';
+import { useAuthStore } from '../../stores/authStore';
+import { useChatStore } from '../../stores/chatStore';
+import { useComposerStore } from '../../stores/composerStore';
+import { useSpaceStore } from '../../stores/spaceStore';
+import { Message } from './Message';
+import { MessageInput } from './MessageInput';
+
+vi.mock('../../hooks/useWebSocket', () => ({ wsSend: vi.fn() }));
+vi.mock('../../audio/AudioManager', () => ({
+  AudioManager: {
+    getInstance: vi.fn().mockReturnValue({
+      setOutputDevice: vi.fn(),
+      setVolume: vi.fn(),
+    }),
+  },
+}));
+
+const me: User = {
+  id: 'me',
+  username: 'alice',
+  displayName: 'Alice',
+  avatar: null,
+  banner: null,
+  accentColor: null,
+  avatarColor: null,
+  bio: null,
+  status: 'online',
+  customStatus: null,
+  isAdmin: false,
+  createdAt: 1,
+  homeInstance: null,
+  homeUserId: null,
+  replicatedInstances: [],
+};
+
+const ownMessage: MessageWithUser = {
+  id: 'message-1',
+  channelId: 'dm-1',
+  userId: me.id,
+  replyToId: null,
+  content: 'last message',
+  editedAt: null,
+  createdAt: 1,
+  user: me,
+  attachments: [],
+  embeds: [],
+  reactions: [],
+};
+
+beforeEach(() => {
+  window.history.replaceState({}, '', '/channels/@me/dm-1');
+  useAuthStore.setState({ user: me });
+  useSpaceStore.setState({ dmChannels: [] });
+  useComposerStore.setState({ states: new Map() });
+  useChatStore.setState({
+    messages: new Map([['dm-1', [ownMessage]]]),
+    replyTo: null,
+    editingMessageId: null,
+  });
+});
+
+afterEach(() => {
+  useChatStore.getState().clearAllMessages();
+  useComposerStore.setState({ states: new Map() });
+  useAuthStore.setState({ user: null });
+  window.history.replaceState({}, '', '/');
+});
+
+describe('MessageInput edit shortcut', () => {
+  it('opens the last own message when ArrowUp is pressed in an empty composer', async () => {
+    render(
+      <>
+        <Message message={ownMessage} isCompact={false} isFirstInGroup previousMessageId={null} />
+        <MessageInput channelId="dm-1" channelName="@Bob" />
+      </>,
+    );
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowUp' });
+
+    expect(useChatStore.getState().editingMessageId).toBe('message-1');
+    const editor = screen.getByDisplayValue('last message') as HTMLTextAreaElement;
+    await waitFor(() => {
+      expect(editor).toHaveFocus();
+      expect(editor.selectionStart).toBe('last message'.length);
+      expect(editor.selectionEnd).toBe('last message'.length);
+    });
+  });
+
+  it('preserves a non-empty draft instead of starting message editing', () => {
+    useComposerStore.getState().setDraft('dm-1', 'unfinished draft');
+    render(<MessageInput channelId="dm-1" channelName="@Bob" />);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowUp' });
+
+    expect(useChatStore.getState().editingMessageId).toBeNull();
+    expect(useComposerStore.getState().get('dm-1').draftText).toBe('unfinished draft');
+  });
+
+  it('preserves an active reply instead of starting message editing', () => {
+    useComposerStore.getState().setReplyTo('dm-1', {
+      id: 'reply-target',
+      userId: 'other',
+      content: 'original message',
+    });
+    render(<MessageInput channelId="dm-1" channelName="@Bob" />);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'ArrowUp' });
+
+    expect(useChatStore.getState().editingMessageId).toBeNull();
+    expect(useComposerStore.getState().get('dm-1').replyTo?.id).toBe('reply-target');
+  });
+});

--- a/packages/web/src/components/chat/MessageInput.tsx
+++ b/packages/web/src/components/chat/MessageInput.tsx
@@ -88,7 +88,6 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
   const previewUrlsRef = useRef<Map<string, string>>(new Map());
 
   const sendMessage = useChatStore((s) => s.sendMessage);
-  const channelMessages = useChatStore((s) => s.messages.get(channelId));
   const chatReplyTo = useChatStore((s) => s.replyTo);
   const chatSetReplyTo = useChatStore((s) => s.setReplyTo);
   const editingMessageId = useChatStore((s) => s.editingMessageId);
@@ -453,7 +452,10 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
       && !composerState.replyTo;
 
     if (isPlainArrowUp && composerIsEmpty && !editingMessageId) {
-      const message = findLastOwnEditableMessage(channelMessages ?? [], currentUser);
+      // Read the list on demand: subscribing to it would re-render the composer
+      // on every incoming message, and the shortcut only needs it at keypress time.
+      const channelMessages = useChatStore.getState().messages.get(channelId) ?? [];
+      const message = findLastOwnEditableMessage(channelMessages, currentUser);
       if (message) {
         e.preventDefault();
         setActivePopover(null);

--- a/packages/web/src/components/chat/MessageInput.tsx
+++ b/packages/web/src/components/chat/MessageInput.tsx
@@ -16,6 +16,8 @@ import { useTransferStore, type Transfer } from '../../stores/transferStore';
 import { usePendingMessageStore } from '../../stores/pendingMessageStore';
 import { putHandle, supportsFsHandles, supportsDnDHandles } from '../../utils/idbHandles';
 import { useVisualViewportInset } from '../../hooks/useVisualViewportInset';
+import { useAuthStore } from '../../stores/authStore';
+import { findLastOwnEditableMessage } from './messageEditing';
 
 interface MessageInputProps {
   channelId: string;
@@ -86,8 +88,12 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
   const previewUrlsRef = useRef<Map<string, string>>(new Map());
 
   const sendMessage = useChatStore((s) => s.sendMessage);
+  const channelMessages = useChatStore((s) => s.messages.get(channelId));
   const chatReplyTo = useChatStore((s) => s.replyTo);
   const chatSetReplyTo = useChatStore((s) => s.setReplyTo);
+  const editingMessageId = useChatStore((s) => s.editingMessageId);
+  const setEditingMessage = useChatStore((s) => s.setEditingMessage);
+  const currentUser = useAuthStore((s) => s.user);
   const members = useSpaceStore((s) => s.members);
 
   const addToast = useUIStore((s) => s.addToast);
@@ -129,6 +135,11 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
       textareaRef.current?.focus();
     }
   }, [chatReplyTo]);
+
+  // Return focus to the composer after inline editing is saved or cancelled.
+  useEffect(() => {
+    if (!editingMessageId) textareaRef.current?.focus();
+  }, [editingMessageId]);
 
   // Close popover on channel change
   useEffect(() => {
@@ -426,6 +437,27 @@ export function MessageInput({ channelId, channelName, placeholder }: MessageInp
       if (e.key === 'Escape') {
         e.preventDefault();
         setMentionState(null);
+        return;
+      }
+    }
+
+    const isPlainArrowUp = e.key === 'ArrowUp'
+      && !e.altKey
+      && !e.ctrlKey
+      && !e.metaKey
+      && !e.shiftKey
+      && !e.nativeEvent.isComposing;
+    const composerIsEmpty = draftText.length === 0
+      && composerState.stagedTransferIds.length === 0
+      && !chatReplyTo
+      && !composerState.replyTo;
+
+    if (isPlainArrowUp && composerIsEmpty && !editingMessageId) {
+      const message = findLastOwnEditableMessage(channelMessages ?? [], currentUser);
+      if (message) {
+        e.preventDefault();
+        setActivePopover(null);
+        setEditingMessage(message.id);
         return;
       }
     }

--- a/packages/web/src/components/chat/messageEditing.test.ts
+++ b/packages/web/src/components/chat/messageEditing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageWithUser, User } from '@backspace/shared';
+import { findLastOwnEditableMessage } from './messageEditing';
+
+const me: User = {
+  id: 'me',
+  username: 'alice',
+  displayName: 'Alice',
+  avatar: null,
+  banner: null,
+  accentColor: null,
+  avatarColor: null,
+  bio: null,
+  status: 'online',
+  customStatus: null,
+  isAdmin: false,
+  createdAt: 1,
+  homeInstance: null,
+  homeUserId: null,
+  replicatedInstances: [],
+};
+
+const other: User = { ...me, id: 'other', username: 'bob', displayName: 'Bob' };
+
+function message(id: string, user: User, content: string | null, type: 'user' | 'system' = 'user'): MessageWithUser {
+  return {
+    id,
+    channelId: 'channel',
+    userId: user.id,
+    replyToId: null,
+    content,
+    type,
+    editedAt: null,
+    createdAt: Number(id.replace(/\D/g, '')) || 1,
+    user,
+    attachments: [],
+    embeds: [],
+    reactions: [],
+  };
+}
+
+describe('findLastOwnEditableMessage', () => {
+  it('returns the newest own text message', () => {
+    const messages = [
+      message('1', me, 'older'),
+      message('2', other, 'someone else'),
+      message('3', me, 'newest'),
+    ];
+
+    expect(findLastOwnEditableMessage(messages, me)?.id).toBe('3');
+  });
+
+  it('skips system and attachment-only messages', () => {
+    const messages = [
+      message('1', me, 'editable'),
+      message('2', me, null),
+      message('3', me, '{"event":"member_added"}', 'system'),
+    ];
+
+    expect(findLastOwnEditableMessage(messages, me)?.id).toBe('1');
+  });
+
+  it('does not fall back to an older message while the newest own message is pending', () => {
+    const messages = [
+      message('1', me, 'older'),
+      message('temp_2', me, 'sending'),
+    ];
+
+    expect(findLastOwnEditableMessage(messages, me)).toBeNull();
+  });
+});

--- a/packages/web/src/components/chat/messageEditing.ts
+++ b/packages/web/src/components/chat/messageEditing.ts
@@ -1,0 +1,24 @@
+import type { MessageWithUser, User } from '@backspace/shared';
+import { isSelf } from '../../utils/identity';
+
+/**
+ * Finds the newest text message the current user can open in the inline editor.
+ * System messages and attachment-only messages are skipped. If the newest own
+ * message is still optimistic, wait for the server copy instead of unexpectedly
+ * opening an older message.
+ */
+export function findLastOwnEditableMessage(
+  messages: readonly MessageWithUser[],
+  currentUser: User | null,
+): MessageWithUser | null {
+  if (!currentUser) return null;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || message.type === 'system' || !isSelf(message.user, currentUser)) continue;
+    if (message.id.startsWith('temp_')) return null;
+    if (message.content?.trim()) return message;
+  }
+
+  return null;
+}

--- a/packages/web/src/stores/chatStore.ts
+++ b/packages/web/src/stores/chatStore.ts
@@ -47,6 +47,7 @@ interface ChatState {
   isLoading: boolean;
   loadError: string | null;
   replyTo: MessageWithUser | null;
+  editingMessageId: string | null;
   readStates: Map<string, string>;
   unreadChannels: Set<string>;
   realtimeMessageEvents: RealtimeMessageEvent[];
@@ -55,6 +56,7 @@ interface ChatState {
   setCurrentChannel: (channelId: string | null) => void;
   saveScrollPosition: (channelId: string, messageId: string) => void;
   setReplyTo: (message: MessageWithUser | null) => void;
+  setEditingMessage: (messageId: string | null) => void;
   loadMessages: (channelId: string, force?: boolean) => Promise<void>;
   clearAllMessages: () => void;
   loadMoreMessages: (channelId: string) => Promise<boolean>;
@@ -104,6 +106,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isLoading: false,
   loadError: null,
   replyTo: null,
+  editingMessageId: null,
   readStates: new Map(),
   unreadChannels: new Set(),
   realtimeMessageEvents: [],
@@ -150,6 +153,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       return {
         currentChannelId: channelId,
+        editingMessageId: state.currentChannelId === channelId ? state.editingMessageId : null,
         channelAccessTimes: newAccessTimes,
         messages: newMessages,
         hasMore: newHasMore,
@@ -158,6 +162,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     });
   },
   setReplyTo: (message) => set({ replyTo: message }),
+  setEditingMessage: (messageId) => set({ editingMessageId: messageId }),
 
   clearAllMessages: () => set({
     messages: new Map(),
@@ -170,6 +175,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     scrollPositions: new Map(),
     currentChannelId: null,
     replyTo: null,
+    editingMessageId: null,
   }),
 
   loadMessages: async (channelId: string, force?: boolean) => {
@@ -517,7 +523,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const current = newMessages.get(channelId);
       if (!current) return state;
       newMessages.set(channelId, current.filter(m => m.id !== messageId));
-      return { messages: newMessages };
+      return {
+        messages: newMessages,
+        editingMessageId: state.editingMessageId === messageId ? null : state.editingMessageId,
+      };
     });
   },
 


### PR DESCRIPTION
## What this changes

Pressing plain `ArrowUp` in an empty message composer now opens the most recent editable message authored by the current user, matching the familiar Telegram/Discord workflow.

The shortcut is deliberately conservative:

- it only runs when the composer is completely empty;
- drafts, staged attachments, and active replies are preserved;
- modified shortcuts such as `Ctrl+ArrowUp` and `Shift+ArrowUp` retain their normal behavior;
- mention-list keyboard navigation keeps priority;
- system, attachment-only, and other users' messages are skipped;
- if the newest own message is still an optimistic pending message, nothing older is opened unexpectedly;
- federated copies of the current user are recognized through the existing `isSelf` identity resolver.

The inline editor is now coordinated through `chatStore`, so keyboard, toolbar, and context-menu entry points share one editing state and cannot open multiple editors. Focus moves to the editor with the caret at the end, then returns to the composer after save or cancel. Changing channels or deleting the edited message clears the editing state.

No matching issue or pull request was found. This is a small, self-contained keyboard UX change, so it is submitted directly under the repository's small-fix guidance.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Production builds succeed for `@backspace/shared`, `@backspace/server`, and `@backspace/web`
- [ ] `pnpm dev` starts the server and web client without errors
- [x] Tests pass where applicable (`@backspace/web`: 77 files / 666 tests)
- [x] The changed interaction was exercised in a browser-DOM integration test; there is no visual design change, and a still screenshot cannot demonstrate the key press
- [x] No system documentation update is needed; this changes existing composer behavior only
- [x] Federated self-identities are resolved through the existing `isSelf` helper rather than assuming a single user ID
- [x] I have read and agree to the CLA; my existing signature applies to this contribution

## Test coverage

Added integration and unit coverage for:

- `ArrowUp` opening the newest own message and rendering the inline editor;
- editor focus and caret placement at the end of the message;
- preserving non-empty drafts and active replies;
- choosing the newest own message while ignoring messages from other users;
- skipping system and attachment-only messages;
- refusing to fall back to an older message while the newest own message is pending.

Validation performed:

- `pnpm --filter @backspace/web test` — 77 files / 666 tests passed
- `pnpm --filter @backspace/web build` — passed
- workspace typechecks — passed
- server e2e typecheck — passed
- `pnpm check:i18n` — no findings