### PR TITLE
fix(i18n): restore auth navigation links

### DIFF
--- a/docs/systems/localization.md
+++ b/docs/systems/localization.md
@@ -383,6 +383,10 @@ It fails on:
    `node scripts/check-i18n.mjs --write-pending` regenerates it from the
    current tree. A line that is a false positive carries
    `// i18n-check: allow-literal` on the line above.
+9. Translation markup that differs from English, or a paired HTML void tag
+   (such as `<link>...</link>`) used as a `Trans` component wrapper. Void tags
+   are parsed as empty HTML elements, so wrapper components use distinctive
+   names such as `<actionLink>...</actionLink>` instead.
 
 The check reports every finding at once, with file and line, so a sweep PR
 can be fixed in one pass.

--- a/packages/web/src/components/auth/AuthNavigationLinks.test.tsx
+++ b/packages/web/src/components/auth/AuthNavigationLinks.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { setLanguage } from '../../i18n';
+import { LoginPage } from './LoginPage';
+import { RegisterPage } from './RegisterPage';
+
+const authState = {
+  login: vi.fn(),
+  isLoading: false,
+  initSession: vi.fn(),
+};
+
+vi.mock('../../stores/authStore', () => ({
+  useAuthStore: (selector: (state: typeof authState) => unknown) => selector(authState),
+}));
+
+vi.mock('../../stores/transferStore', () => ({
+  useTransferStore: {
+    getState: () => ({ startUpload: vi.fn() }),
+  },
+}));
+
+vi.mock('../../api/client', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../api/client')>();
+  return {
+    ...original,
+    api: {
+      instance: {
+        // Keep instance metadata pending: neither navigation prompt depends on it,
+        // and avoiding a state update keeps these tests focused on link semantics.
+        info: vi.fn(() => new Promise(() => {})),
+      },
+      auth: {
+        checkInvite: vi.fn(),
+        checkUsername: vi.fn(),
+        register: vi.fn(),
+      },
+      users: {
+        update: vi.fn(),
+      },
+    },
+  };
+});
+
+describe('authentication navigation prompts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['en', 'Register'],
+    ['de', 'Registrieren'],
+    ['ru', 'Зарегистрироваться'],
+  ] as const)('navigates from login to registration in %s', async (language, linkLabel) => {
+    await setLanguage(language);
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/login?redirect=%2Fchannels%2F%40me']}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<div>Registration destination</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: linkLabel });
+    expect(link).toHaveAttribute('href', '/register?redirect=%2Fchannels%2F%40me');
+
+    await user.click(link);
+    expect(screen.getByText('Registration destination')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['en', 'Log In'],
+    ['de', 'Anmelden'],
+    ['ru', 'Войти'],
+  ] as const)('navigates from registration to login in %s', async (language, linkLabel) => {
+    await setLanguage(language);
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/register?redirect=%2Fchannels%2F%40me']}>
+        <Routes>
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/login" element={<div>Login destination</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: linkLabel });
+    expect(link).toHaveAttribute('href', '/login?redirect=%2Fchannels%2F%40me');
+
+    await user.click(link);
+    expect(screen.getByText('Login destination')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/auth/LoginPage.tsx
+++ b/packages/web/src/components/auth/LoginPage.tsx
@@ -143,7 +143,7 @@ export function LoginPage() {
               t={t}
               i18nKey="auth:login.registerPrompt"
               components={{
-                link: <Link to={`/register${redirect ? `?redirect=${encodeURIComponent(redirect)}` : ''}`} className="text-accent-primary hover:underline" />,
+                actionLink: <Link to={`/register${redirect ? `?redirect=${encodeURIComponent(redirect)}` : ''}`} className="text-accent-primary hover:underline" />,
               }}
             />
           </p>

--- a/packages/web/src/components/auth/RegisterPage.tsx
+++ b/packages/web/src/components/auth/RegisterPage.tsx
@@ -601,7 +601,7 @@ export function RegisterPage() {
                   t={t}
                   i18nKey="auth:register.loginPrompt"
                   components={{
-                    link: <Link to={`/login${redirect ? `?redirect=${encodeURIComponent(redirect)}` : ''}`} className="text-accent-primary hover:underline" />,
+                    actionLink: <Link to={`/login${redirect ? `?redirect=${encodeURIComponent(redirect)}` : ''}`} className="text-accent-primary hover:underline" />,
                   }}
                 />
               </p>

--- a/packages/web/src/i18n/check.test.ts
+++ b/packages/web/src/i18n/check.test.ts
@@ -11,6 +11,7 @@ import {
   checkDirectIntl,
   checkErrorCodes,
   checkLiteralStrings,
+  checkMarkup,
   listLiteralStringFiles,
   runAllChecks,
 } from '../../../../scripts/i18n/check.mjs';
@@ -274,6 +275,38 @@ describe('literal-string', () => {
       'packages/web/src/components/Q.tsx': 'const x = 1;',
     });
     expect(listLiteralStringFiles(root)).toEqual(['packages/web/src/components/P.tsx']);
+  });
+});
+
+describe('markup', () => {
+  it('reports a paired HTML void tag used as a Trans component wrapper', () => {
+    const root = makeRoot({
+      [locale('en', 'auth')]: { prompt: 'No account? <link>Register</link>' },
+      [locale('de', 'auth')]: { prompt: 'Kein Konto? <link>Registrieren</link>' },
+    });
+    const findings = checkMarkup(root) as Finding[];
+    expect(findings).toHaveLength(2);
+    expect(findings.every((f) => f.rule === 'markup')).toBe(true);
+    expect(findings.every((f) => f.message.includes('HTML void tag <link>'))).toBe(true);
+  });
+
+  it('reports markup that differs between languages', () => {
+    const root = makeRoot({
+      [locale('en', 'common')]: { greeting: 'Hello <strong>{{name}}</strong>' },
+      [locale('ru', 'common')]: { greeting: 'Привет, {{name}}' },
+    });
+    const findings = checkMarkup(root) as Finding[];
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ rule: 'markup', file: locale('ru', 'common') });
+    expect(findings[0]!.message).toContain('<strong>');
+  });
+
+  it('allows safe component wrappers and self-closing basic HTML tags', () => {
+    const root = makeRoot({
+      [locale('en', 'common')]: { prompt: 'First<br/>Then <actionLink>continue</actionLink> or <Link>leave</Link>' },
+      [locale('de', 'common')]: { prompt: 'Zuerst<br/>Dann <actionLink>weiter</actionLink> oder <Link>gehen</Link>' },
+    });
+    expect(checkMarkup(root)).toEqual([]);
   });
 });
 

--- a/packages/web/src/locales/de/auth.json
+++ b/packages/web/src/locales/de/auth.json
@@ -24,7 +24,7 @@
     },
     "submitting": "Anmeldung läuft…",
     "failed": "Anmeldung fehlgeschlagen",
-    "registerPrompt": "Noch kein Konto? <link>Registrieren</link>"
+    "registerPrompt": "Noch kein Konto? <actionLink>Registrieren</actionLink>"
   },
   "register": {
     "title": "Konto erstellen",
@@ -41,7 +41,7 @@
       "invalidLink": "Ungültiger Einladungslink. Bitte fordere einen neuen an.",
       "required": "Für die Registrierung auf dieser Instanz ist eine Einladung erforderlich."
     },
-    "loginPrompt": "Du hast schon ein Konto? <link>Anmelden</link>",
+    "loginPrompt": "Du hast schon ein Konto? <actionLink>Anmelden</actionLink>",
     "personalize": {
       "title": "Zeig, wer du bist",
       "subtitle": "Gestalte dein Profil oder überspringe das vorerst"

--- a/packages/web/src/locales/en/auth.json
+++ b/packages/web/src/locales/en/auth.json
@@ -24,7 +24,7 @@
     },
     "submitting": "Logging in…",
     "failed": "Login failed",
-    "registerPrompt": "Need an account? <link>Register</link>"
+    "registerPrompt": "Need an account? <actionLink>Register</actionLink>"
   },
   "register": {
     "title": "Create an account",
@@ -41,7 +41,7 @@
       "invalidLink": "Invalid invite link. Please request a new one.",
       "required": "An invite is required to register on this instance."
     },
-    "loginPrompt": "Already have an account? <link>Log In</link>",
+    "loginPrompt": "Already have an account? <actionLink>Log In</actionLink>",
     "personalize": {
       "title": "Make it yours",
       "subtitle": "Personalize your profile, or skip for now"

--- a/packages/web/src/locales/ru/auth.json
+++ b/packages/web/src/locales/ru/auth.json
@@ -24,7 +24,7 @@
     },
     "submitting": "Вход…",
     "failed": "Не удалось войти",
-    "registerPrompt": "Нет аккаунта? <link>Зарегистрироваться</link>"
+    "registerPrompt": "Нет аккаунта? <actionLink>Зарегистрироваться</actionLink>"
   },
   "register": {
     "title": "Создать аккаунт",
@@ -41,7 +41,7 @@
       "invalidLink": "Неверная ссылка-приглашение. Запросите новую.",
       "required": "Для регистрации на этом сервере требуется приглашение."
     },
-    "loginPrompt": "Уже есть аккаунт? <link>Войти</link>",
+    "loginPrompt": "Уже есть аккаунт? <actionLink>Войти</actionLink>",
     "personalize": {
       "title": "Настройте под себя",
       "subtitle": "Оформите профиль или пропустите этот шаг"

--- a/scripts/i18n/check.mjs
+++ b/scripts/i18n/check.mjs
@@ -518,6 +518,94 @@ export function listLiteralStringFiles(root) {
 }
 
 // ---------------------------------------------------------------------------
+// Rule 9: markup
+// ---------------------------------------------------------------------------
+
+// html-parse-stringify (used by react-i18next's Trans component) parses these
+// as HTML void elements. They cannot be used as wrappers for React components:
+// `<link>text</link>`, for example, renders an empty <link> and leaves `text`
+// outside the component supplied to Trans.
+const HTML_VOID_TAGS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta',
+  'param', 'source', 'track', 'wbr',
+]);
+const MARKUP_TAG_RE = /<\/?([A-Za-z][\w-]*)\b[^>]*>/g;
+
+function markupTagsOf(value) {
+  const tags = new Set();
+  for (const match of String(value).matchAll(MARKUP_TAG_RE)) tags.add(match[1]);
+  return tags;
+}
+
+function pairedVoidTagsOf(value) {
+  const text = String(value);
+  const opening = new Set();
+  const closing = new Set();
+  for (const match of text.matchAll(MARKUP_TAG_RE)) {
+    const full = match[0];
+    // html-parse-stringify deliberately keeps this lookup case-sensitive, so
+    // `<Link>` is a valid component name while lowercase `<link>` is void.
+    const tag = match[1];
+    if (!HTML_VOID_TAGS.has(tag)) continue;
+    if (full.startsWith('</')) closing.add(tag);
+    else if (!full.endsWith('/>')) opening.add(tag);
+  }
+  return new Set([...opening].filter((tag) => closing.has(tag)));
+}
+
+export function checkMarkup(root) {
+  const loaded = loadCatalogs(root);
+  const findings = [];
+  const source = loaded.catalogs[SOURCE_LANGUAGE] ?? {};
+
+  // Validate every catalog, including English: unsafe markup in the source is
+  // just as capable of breaking a Trans component as a translator's change.
+  for (const lng of loaded.languages) {
+    for (const [ns, flat] of Object.entries(loaded.catalogs[lng] ?? {})) {
+      for (const [key, value] of Object.entries(flat)) {
+        for (const tag of pairedVoidTagsOf(value)) {
+          findings.push({
+            rule: 'markup',
+            file: fileFor(loaded, lng, ns),
+            message: `key "${key}" uses HTML void tag <${tag}> as a wrapper; use a non-HTML Trans component name`,
+          });
+        }
+      }
+    }
+  }
+
+  // As with interpolation placeholders, markup is part of a translation's
+  // contract. Compare the union across plural forms because CLDR categories
+  // differ between languages.
+  for (const lng of loaded.languages) {
+    if (lng === SOURCE_LANGUAGE) continue;
+    for (const ns of loaded.namespaces) {
+      const target = loaded.catalogs[lng]?.[ns];
+      if (!target) continue;
+      const sourceFamilies = families(source[ns]);
+      const targetFamilies = families(target);
+      for (const [base, sourceForms] of sourceFamilies) {
+        const targetForms = targetFamilies.get(base);
+        if (!targetForms) continue;
+        const expected = new Set();
+        for (const value of sourceForms.values()) for (const tag of markupTagsOf(value)) expected.add(tag);
+        const actual = new Set();
+        for (const value of targetForms.values()) for (const tag of markupTagsOf(value)) actual.add(tag);
+        if (!sameSet(expected, actual)) {
+          findings.push({
+            rule: 'markup',
+            file: fileFor(loaded, lng, ns),
+            message: `key "${base}" uses <${[...actual].join('>, <')}> in ${lng} but <${[...expected].join('>, <')}> in ${SOURCE_LANGUAGE}`,
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
 // All together
 // ---------------------------------------------------------------------------
 
@@ -530,6 +618,7 @@ export const RULES = [
   'direct-intl',
   'error-code-missing',
   'literal-string',
+  'markup',
 ];
 
 export function runAllChecks(root, options = {}) {
@@ -542,6 +631,7 @@ export function runAllChecks(root, options = {}) {
     ...checkDirectIntl(root),
     ...checkErrorCodes(root),
     ...checkLiteralStrings(root, options),
+    ...checkMarkup(root),
   ];
 }
 


### PR DESCRIPTION
## What this changes

Restores the translated navigation links below the login and registration forms.

`react-i18next` parses lowercase `<link>` as the HTML void element, so the React Router component was rendered empty and its translated label became plain, non-interactive text. The auth localization introduced in #98 exposed that collision.

This change:

- renames the translation component placeholder to `<actionLink>` in `en`, `de`, and `ru`;
- adds navigation regression tests for both auth pages in all three shipped languages, including `redirect` preservation;
- audits translation markup and adds an i18n rule that rejects paired HTML void tags and tag drift between languages;
- documents the new consistency rule.

Regression from #98.

## Type of change

- [x] Bug fix


- [x] Documentation


## Checklist

- [x] `pnpm build` succeeds (shared types, server, and web all build)
- [x] `pnpm dev` starts the server and web client without errors
- [x] Tests pass where applicable (`pnpm test`)
- [x] I ran the change myself, and attached evidence (screenshot, recording, or terminal output) if it affects packaging, installation, or the UI
- [x] I updated the relevant `docs/systems/` spec if this changed schema, API routes, WebSocket events, the federation protocol, permissions, or the design system
- [x] This change resolves the correct federated identity where it compares IDs, checks permissions, or talks to remote servers (not applicable: no identity or federation logic is changed)
- [x] I have read and agree to the [CLA](../CLA.md) — ticking this box is not the signature. After opening this PR, post a separate comment containing exactly:
      `I have read the CLA Document and I hereby sign the CLA`

## Notes for reviewers

Validation performed on Windows 11:

- full web suite: 76 files / 665 tests passed;
- focused auth + i18n checks: 2 files / 30 tests passed;
- `pnpm typecheck`: passed;
- `pnpm check:i18n`: no findings;
- production builds for shared, server, and web: passed;
- manual Orca browser verification in Russian: both links render as focusable anchors with accent styling and `pointer-events: auto`, and navigate between `/login` and `/register`.

The repository-wide test command also reaches unrelated, pre-existing Windows/environment failures in metrics (POSIX chmod expectation and vendored-file checkout checksum) and server integration tests (child instances cannot start in this environment). No failing test covers files changed here; the complete web suite passes.

