### PR TITLE
fix(desktop): keep image controls below title bar

### DIFF
--- a/packages/web/src/components/chat/ImagePreview.test.tsx
+++ b/packages/web/src/components/chat/ImagePreview.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useUIStore } from '../../stores/uiStore';
+import { isElectron } from '../../platform/platform';
+import { ImagePreview } from './ImagePreview';
+
+vi.mock('../../platform/platform', () => ({
+  isElectron: vi.fn(),
+}));
+
+vi.mock('../../utils/imageActions', () => ({
+  saveImage: vi.fn(),
+  copyImageToClipboard: vi.fn(),
+}));
+
+describe('ImagePreview', () => {
+  beforeEach(() => {
+    vi.mocked(isElectron).mockReturnValue(false);
+    useUIStore.setState({
+      activeModal: 'imagePreview',
+      imagePreviewUrl: '/test-image.png',
+    });
+  });
+
+  afterEach(() => {
+    useUIStore.getState().closeImagePreview();
+  });
+
+  it('covers the complete browser viewport', () => {
+    const { container } = render(<ImagePreview />);
+
+    expect(container.firstElementChild).toHaveClass('top-0');
+    expect(container.firstElementChild).not.toHaveClass('top-[33px]');
+  });
+
+  it('stays below the native window controls in Electron', () => {
+    vi.mocked(isElectron).mockReturnValue(true);
+
+    const { container } = render(<ImagePreview />);
+
+    expect(container.firstElementChild).toHaveClass('top-[33px]');
+    expect(container.firstElementChild).not.toHaveClass('top-0');
+  });
+});

--- a/packages/web/src/components/chat/ImagePreview.tsx
+++ b/packages/web/src/components/chat/ImagePreview.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUIStore } from '../../stores/uiStore';
 import { saveImage, copyImageToClipboard } from '../../utils/imageActions';
+import { isElectron } from '../../platform/platform';
 
 export function ImagePreview() {
   const { t } = useTranslation(['chat', 'common']);
@@ -11,9 +12,13 @@ export function ImagePreview() {
 
   if (activeModal !== 'imagePreview' || !imageUrl) return null;
 
+  // Fixed positioning escapes App's 32px title bar and 1px divider. Keep the
+  // preview below that native-control area without changing browser layout.
+  const topInsetClass = isElectron() ? 'top-[33px]' : 'top-0';
+
   return (
     <div
-      className="fixed inset-0 z-[200] flex items-center justify-center bg-surface-overlay animate-fade-in cursor-pointer"
+      className={`fixed inset-x-0 bottom-0 z-[200] flex items-center justify-center bg-surface-overlay animate-fade-in cursor-pointer ${topInsetClass}`}
       onClick={closeImagePreview}
     >
       {/* Toolbar: download, copy, close */}


### PR DESCRIPTION
## What this changes

Keeps the full-screen image preview and its save, copy, and close controls below Electron's native title-bar controls.

`ImagePreview` used `fixed inset-0`. Fixed positioning is relative to the window viewport, so it escaped the 32 px title bar plus 1 px divider reserved by `App` and placed its `top-4 right-4` toolbar underneath the Windows minimize/maximize/close buttons.

The preview now uses explicit viewport edges and applies the existing 33 px desktop inset only when `isElectron()` is true. Browser/PWA rendering remains full-viewport and unchanged.

Regression coverage verifies both layouts:

- browser: `top-0`;
- Electron: `top-[33px]`.

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm build` succeeds (shared types, server, and web all build)
- [x] `pnpm dev` starts the server and web client without errors
- [x] Tests pass where applicable (`pnpm test`)
- [x] I ran the change myself, and attached evidence (screenshot, recording, or terminal output) if it affects packaging, installation, or the UI
- [x] I updated the relevant `docs/systems/` spec if this changed schema, API routes, WebSocket events, the federation protocol, permissions, or the design system (not applicable: no documented contract or design-system token changes)
- [x] This change resolves the correct federated identity where it compares IDs, checks permissions, or talks to remote servers (not applicable: presentation-only change)
- [x] I have read and agree to the [CLA](../CLA.md) — ticking this box is not the signature. After opening this PR, post a separate comment containing exactly:
      `I have read the CLA Document and I hereby sign the CLA`

## Notes for reviewers

Validated on Windows 11:

- full web suite: 81 test files / 684 tests passed;
- focused `ImagePreview` regression suite: 2 tests passed;
- workspace typecheck and i18n consistency check passed;
- production builds for shared, server, and web passed;
- server and web development processes both reached their ready state.

The supplied screenshot demonstrates the previous overlap. The layout assertions pin the corrected Electron and browser geometry so the collision cannot silently return.