### PR TITLE
fix(notifications): open the conversation on click

### DIFF
--- a/docs/systems/desktop.md
+++ b/docs/systems/desktop.md
@@ -608,6 +608,18 @@ Executed before each release. See `docs/superpowers/specs/2026-05-03-electron-re
 - `silent: false` (plays system sound)
 - Click handler: defaults to show + focus the main window; an optional `onClick` parameter overrides this (used by the update-ready notification to call `autoUpdater.quitAndInstall()` directly)
 
+Chat notifications carry optional `{ channelId, spaceId, userId }` context through
+`showNotification(title, body, options?)`. Clicking restores a minimized window,
+shows it, and sends `notification-click` back to the originating renderer only
+while its home origin still matches. `onNotificationClick` returns an unsubscribe
+function; the web client feature-detects it for compatibility with older shells.
+`NotificationController` validates the signed-in home user and current channel
+membership before navigating to `/channels/<spaceId or @me>/<channelId>`.
+The space comes from `channelToSpaceMap`, including remote spaces; existing
+channel-origin routing selects the API instance. Browser notifications use the
+same navigation handler and close on click. Mobile navigation also brings the
+chat screen to the top when the URL already points at that chat.
+
 Badge count: `set-badge-count` IPC calls `app.setBadgeCount()` (macOS dock badge, Windows taskbar overlay).
 
 **Win32 attribution:** `app.setAppUserModelId('com.backspace.desktop')` set early in startup so notifications attribute to "Backspace" in Windows Action Center.
@@ -679,7 +691,8 @@ All handlers registered in `main.ts:registerIpcHandlers()`.
 
 | Channel | Direction | Payload | Action |
 |---------|-----------|---------|--------|
-| `show-notification` | R->M | `{ title, body }` | Show native notification |
+| `show-notification` | R->M | `{ title, body, options?: { channelId?, spaceId?, userId? } }` | Show native notification with optional chat target |
+| `notification-click` | M->R | `{ channelId?, spaceId?, userId? }` | Open the notification's chat in the originating session |
 | `set-badge-count` | R->M | `number` | Set dock/taskbar badge |
 | `minimize-window` | R->M | — | Minimize window |
 | `maximize-window` | R->M | — | Toggle maximize/unmaximize |

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -534,8 +534,20 @@ function showNotification(title: string, body: string, onClick?: () => void): vo
 // ─── IPC Handlers ───────────────────────────────────────────────────────────
 
 function registerIpcHandlers(): void {
-  ipcMain.on('show-notification', (_event, data: { title: string; body: string }) => {
-    showNotification(data.title, data.body);
+  ipcMain.on('show-notification', (event, data: { title: string; body: string; options?: { channelId?: string; spaceId?: string; userId?: string } }) => {
+    if (event.sender !== mainWindow?.webContents) return;
+    const sender = event.sender;
+    const origin = new URL(sender.getURL()).origin;
+    showNotification(data.title, data.body, () => {
+      if (!mainWindow || mainWindow.isDestroyed() || sender.isDestroyed()) return;
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.show();
+      mainWindow.focus();
+      // A toast from a previous home instance must not open IDs on the new one.
+      if (sender === mainWindow.webContents && new URL(sender.getURL()).origin === origin && data.options) {
+        sender.send('notification-click', data.options);
+      }
+    });
   });
 
   ipcMain.on('set-badge-count', (_event, count: number) => {

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -15,8 +15,13 @@ contextBridge.exposeInMainWorld('backspace', {
   },
 
   // Notifications & badge
-  showNotification: (title: string, body: string) => {
-    ipcRenderer.send('show-notification', { title, body });
+  showNotification: (title: string, body: string, options?: { channelId?: string; spaceId?: string; userId?: string }) => {
+    ipcRenderer.send('show-notification', { title, body, options });
+  },
+  onNotificationClick: (callback: (options: { channelId?: string; spaceId?: string; userId?: string }) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, options: { channelId?: string; spaceId?: string; userId?: string }) => callback(options);
+    ipcRenderer.on('notification-click', handler);
+    return () => { ipcRenderer.removeListener('notification-click', handler); };
   },
   setBadgeCount: (count: number) => {
     ipcRenderer.send('set-badge-count', count);

--- a/packages/web/src/components/NotificationController.test.tsx
+++ b/packages/web/src/components/NotificationController.test.tsx
@@ -1,0 +1,128 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import type { DmChannel, MessageWithUser, User } from '@backspace/shared';
+import { NotificationController } from './NotificationController';
+import { sendNotification } from '../platform/notifications';
+import { useAuthStore } from '../stores/authStore';
+import { useSpaceStore } from '../stores/spaceStore';
+import { useChatStore } from '../stores/chatStore';
+import { useUIStore } from '../stores/uiStore';
+
+vi.mock('../audio/AudioManager', () => ({ AudioManager: { getInstance: () => ({}) } }));
+
+class BrowserNotification {
+  static permission = 'granted';
+  static instances: BrowserNotification[] = [];
+  onclick?: () => void;
+  close = vi.fn();
+  constructor(public title: string) { BrowserNotification.instances.push(this); }
+}
+
+function Location() {
+  return <output data-testid="route">{useLocation().pathname}</output>;
+}
+
+function mount() {
+  return render(<MemoryRouter initialEntries={['/channels/other/old']}>
+    <NotificationController /><Location />
+  </MemoryRouter>);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('Notification', BrowserNotification);
+  BrowserNotification.instances = [];
+  vi.spyOn(window, 'focus').mockImplementation(() => {});
+  vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+  useAuthStore.setState({ user: { id: 'me' } as User });
+  useSpaceStore.setState({
+    channelToSpaceMap: new Map([['remote-chat', 'remote-space']]),
+    channelOriginMap: new Map([['remote-chat', 'https://remote.example']]),
+    dmChannels: [{ id: 'dm' } as DmChannel],
+  });
+  useChatStore.setState({ realtimeMessageEvents: [] });
+  useUIStore.setState({ isMobile: false, mobileStack: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  delete window.backspace;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('notification clicks', () => {
+  it.each([
+    ['dm', undefined, '/channels/@me/dm'],
+    ['remote-chat', 'remote-space', '/channels/remote-space/remote-chat'],
+  ])('opens %s through the router and closes the browser notification', (channelId, spaceId, route) => {
+    const view = mount();
+    sendNotification('Message', 'Hello', { channelId, spaceId, userId: 'me' });
+    const notification = BrowserNotification.instances[0]!;
+    act(() => notification.onclick?.());
+    expect(view.getByTestId('route')).toHaveTextContent(route);
+    expect(window.focus).toHaveBeenCalled();
+    expect(notification.close).toHaveBeenCalledOnce();
+  });
+
+  it('routes an Electron click and removes its IPC listener on unmount', () => {
+    const off = vi.fn();
+    let click: ((options: { channelId: string; userId: string }) => void) | undefined;
+    window.backspace = {
+      onNotificationClick: vi.fn(callback => { click = callback; return off; }),
+      onWindowFocusChange: vi.fn(), showNotification: vi.fn(), setBadgeCount: vi.fn(),
+    } as unknown as NonNullable<Window['backspace']>;
+    const view = mount();
+    sendNotification('Message', 'Hello', { channelId: 'dm', userId: 'me' });
+    expect(window.backspace.showNotification).toHaveBeenCalledWith('Message', 'Hello', { channelId: 'dm', userId: 'me' });
+    act(() => click?.({ channelId: 'dm', userId: 'me' }));
+    expect(view.getByTestId('route')).toHaveTextContent('/channels/@me/dm');
+    view.unmount();
+    expect(off.mock.calls.length).toBe(vi.mocked(window.backspace.onNotificationClick!).mock.calls.length);
+  });
+
+  it('supports an older Electron bridge without the click API', () => {
+    window.backspace = { onWindowFocusChange: vi.fn() } as unknown as NonNullable<Window['backspace']>;
+    expect(() => mount().unmount()).not.toThrow();
+  });
+
+  it.each([
+    { channelId: 'deleted', userId: 'me' },
+    { channelId: 'dm', userId: 'previous-account' },
+    { channelId: 'remote-chat', spaceId: 'wrong-space', userId: 'me' },
+  ])('ignores stale context %j', options => {
+    const view = mount();
+    sendNotification('Message', 'Hello', options);
+    act(() => BrowserNotification.instances[0]!.onclick?.());
+    expect(view.getByTestId('route')).toHaveTextContent('/channels/other/old');
+  });
+
+  it('brings the mobile chat back above settings without duplicate chat entries', () => {
+    useUIStore.setState({ isMobile: true, mobileStack: [{ screen: 'settings' }] });
+    mount();
+    sendNotification('Message', 'Hello', { channelId: 'dm', userId: 'me' });
+    act(() => BrowserNotification.instances[0]!.onclick?.());
+    act(() => BrowserNotification.instances[0]!.onclick?.());
+    expect(useUIStore.getState().mobileStack).toEqual([
+      { screen: 'settings' }, { screen: 'channel-chat', params: { channelId: 'dm', spaceId: '@me' } },
+    ]);
+  });
+
+  it('keeps notifying once the 50-event buffer is full, retaining the remote space', () => {
+    const oldEvents = Array.from({ length: 50 }, (_, i) => ({
+      channelId: 'remote-chat', message: { id: String(i) } as MessageWithUser,
+    }));
+    useChatStore.setState({ realtimeMessageEvents: oldEvents });
+    const view = mount();
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => useChatStore.setState({ realtimeMessageEvents: [...oldEvents.slice(1), {
+      channelId: 'remote-chat',
+      message: { id: 'new', channelId: 'remote-chat', userId: 'other', content: 'Hello' } as MessageWithUser,
+    }] }));
+    expect(BrowserNotification.instances).toHaveLength(1);
+    act(() => BrowserNotification.instances[0]!.onclick?.());
+    expect(view.getByTestId('route')).toHaveTextContent('/channels/remote-space/remote-chat');
+  });
+});

--- a/packages/web/src/components/NotificationController.tsx
+++ b/packages/web/src/components/NotificationController.tsx
@@ -1,18 +1,38 @@
 import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useChatStore } from '../stores/chatStore';
 import { useVoiceStore } from '../stores/voiceStore';
 import { useAuthStore } from '../stores/authStore';
 import { isElectron } from '../platform/platform';
-import { sendNotification, updateBadgeCount } from '../platform/notifications';
+import { onNotificationClick, sendNotification, updateBadgeCount } from '../platform/notifications';
+import { useSpaceStore, getMyUserIdForOrigin } from '../stores/spaceStore';
+import { useUIStore } from '../stores/uiStore';
 
 /**
  * Headless component that bridges store events to native OS notifications and badge counts.
  * Renders nothing — lives alongside SoundController in AppLayout.
  */
 export function NotificationController() {
+  const navigate = useNavigate();
   const currentUser = useAuthStore((s) => s.user);
   const isInitialMount = useRef(true);
   const windowFocused = useRef(true);
+
+  useEffect(() => onNotificationClick(({ channelId, spaceId, userId }) => {
+    if (!channelId || !userId || userId !== useAuthStore.getState().user?.id) return;
+    const spaces = useSpaceStore.getState();
+    const targetSpace = spaces.channelToSpaceMap.get(channelId);
+    if (targetSpace !== spaceId || (!targetSpace && !spaces.dmChannels.some(dm => dm.id === channelId))) return;
+    const resolvedSpace = targetSpace || '@me';
+    const ui = useUIStore.getState();
+    if (ui.isMobile) {
+      const top = ui.mobileStack.at(-1);
+      if (top?.screen !== 'channel-chat' || top.params?.channelId !== channelId) {
+        ui.pushMobileScreen('channel-chat', { channelId, spaceId: resolvedSpace });
+      }
+    }
+    navigate(`/channels/${targetSpace ? encodeURIComponent(targetSpace) : '@me'}/${encodeURIComponent(channelId)}`);
+  }), [navigate]);
 
   // Track window focus state
   useEffect(() => {
@@ -53,16 +73,20 @@ export function NotificationController() {
       if (isInitialMount.current) return;
       if (windowFocused.current) return;
 
-      if (state.realtimeMessageEvents.length > prevState.realtimeMessageEvents.length) {
-        const newEvents = state.realtimeMessageEvents.slice(prevState.realtimeMessageEvents.length);
+      if (state.realtimeMessageEvents !== prevState.realtimeMessageEvents) {
+        // The store keeps only 50 events; its length stops growing after that.
+        const newEvents = state.realtimeMessageEvents.filter(event => !prevState.realtimeMessageEvents.includes(event));
         for (const { message } of newEvents) {
-          if (message.userId !== currentUser?.id) {
+          const { channelToSpaceMap, channelOriginMap } = useSpaceStore.getState();
+          if (message.userId !== getMyUserIdForOrigin(channelOriginMap.get(message.channelId) ?? '')) {
             const displayName = message.user?.displayName || message.user?.username || 'Someone';
             const body = message.content
               ? message.content.replace(/[*_~`>#\-\[\]]/g, '').slice(0, 100)
               : 'Sent an attachment';
             sendNotification(displayName, body, {
               channelId: message.channelId,
+              spaceId: channelToSpaceMap.get(message.channelId),
+              userId: currentUser?.id,
             });
             break; // one notification per batch
           }
@@ -90,7 +114,10 @@ export function NotificationController() {
 
     const unsubscribe = useVoiceStore.subscribe((state) => {
       if (state.incomingCall && !prevIncoming && !windowFocused.current) {
-        sendNotification('Incoming Call', `${state.incomingCall.callerName} is calling you`);
+        sendNotification('Incoming Call', `${state.incomingCall.callerName} is calling you`, {
+          channelId: state.incomingCall.dmChannelId ?? undefined,
+          userId: useAuthStore.getState().user?.id,
+        });
       }
       prevIncoming = state.incomingCall;
     });

--- a/packages/web/src/platform/electron.d.ts
+++ b/packages/web/src/platform/electron.d.ts
@@ -81,7 +81,8 @@ interface BackspaceElectronAPI {
   close: () => void;
 
   // Notifications & badge
-  showNotification: (title: string, body: string) => void;
+  showNotification: (title: string, body: string, options?: import('./notifications').NotificationOptions) => void;
+  onNotificationClick?: (callback: (options: import('./notifications').NotificationOptions) => void) => () => void;
   setBadgeCount: (count: number) => void;
 
   // Auto-update, legacy per-event channels.

--- a/packages/web/src/platform/notifications.ts
+++ b/packages/web/src/platform/notifications.ts
@@ -1,28 +1,33 @@
 import { isElectron } from './platform';
-import { useUIStore } from '../stores/uiStore';
 
-interface NotificationOptions {
+export interface NotificationOptions {
   channelId?: string;
   spaceId?: string;
+  userId?: string;
+}
+
+const clicks = new EventTarget();
+
+/** One subscription per mounted controller, including older desktop bridges. */
+export function onNotificationClick(callback: (options: NotificationOptions) => void): () => void {
+  const handler = (event: Event) => callback((event as CustomEvent<NotificationOptions>).detail);
+  clicks.addEventListener('click', handler);
+  const unsubscribe = window.backspace?.onNotificationClick?.(callback);
+  return () => {
+    clicks.removeEventListener('click', handler);
+    unsubscribe?.();
+  };
 }
 
 export function sendNotification(title: string, body: string, options?: NotificationOptions): void {
   if (isElectron()) {
-    window.backspace!.showNotification(title, body);
+    window.backspace!.showNotification(title, body, options);
   } else if ('Notification' in window && Notification.permission === 'granted') {
     const notification = new Notification(title, { body, icon: '/icons/icon-192.png' });
     notification.onclick = () => {
       window.focus();
-      const { channelId, spaceId } = options ?? {};
-      if (channelId) {
-        const isMobile = useUIStore.getState().isMobile;
-        if (isMobile) {
-          useUIStore.getState().pushMobileScreen('channel-chat', {
-            channelId,
-            spaceId: spaceId || '@me',
-          });
-        }
-      }
+      notification.close();
+      if (options) clicks.dispatchEvent(new CustomEvent('click', { detail: options }));
     };
   }
 }


### PR DESCRIPTION
## What this changes

Clicking a message notification now opens its DM or space channel and restores the desktop window if it was minimized. Previously Electron discarded the channel context and only focused the window; the browser handler only pushed a mobile screen.

The notification carries its channel, space, and signed-in home user through an optional, backwards-compatible IPC payload. One shared controller handles browser and Electron clicks, checks that the account and channel still match, and navigates through React Router. Remote spaces use the existing channel-to-space and channel-origin maps. Incoming DM-call notifications also open their conversation, without automatically answering the call.

Also fixes the capped realtime-event buffer check: notification delivery continues after its 50 entries stop increasing in length. Self-message suppression resolves the user's identity on the channel's instance.

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm build` succeeds (shared, server, and web production builds passed)
- [x] `pnpm dev` starts the server and web client without errors
- [x] Tests pass where applicable (`pnpm test`): web and desktop suites passed
- [x] I ran the change myself, and attached evidence (screenshot, recording, or terminal output) if it affects packaging, installation, or the UI
- [x] I updated the relevant `docs/systems/` spec if this changed schema, API routes, WebSocket events, the federation protocol, permissions, or the design system (desktop IPC and notification behavior documented)
- [x] This change resolves the correct federated identity where it compares IDs, checks permissions, or talks to remote servers (per-origin self ID; existing remote channel routing)
- [x] I have read and agree to the [CLA](../CLA.md) — a separate signature comment follows

## Notes for reviewers

Validation on Windows 11:

- Web: 81 files, 691 tests passed, including 9 notification regressions.
- Desktop: 9 files, 149 tests passed; desktop TypeScript compilation passed.
- Workspace typechecks, i18n checks, and production builds passed.
- Server started on port 3005 and Vite on 5173.

Ran the compiled desktop main process and real preload in Electron 40.10.6 against a local fixture mounting the production `NotificationController`. Native notifications were shown; the harness emitted `click` on the actual Electron Notification object and verified the route and window restoration. This validates the production IPC path, but is not a manual click in Windows Action Center. The fixture used synthetic IDs and no real accounts or messages.

```text
PASS native notification -> main -> preload -> controller -> /channels/@me/dm; minimized window restored
PASS native notification -> main -> preload -> controller -> /channels/remote-space/remote-chat; minimized window restored
PASS Electron 40.10.6 on Windows; screenshot saved
```

Regression coverage also checks stale accounts/deleted channels, an older desktop bridge without the new subscription API, listener cleanup, mobile stack behavior, and delivery after the realtime buffer reaches capacity.

Desktop chat navigation requires both the updated shell and web client; an older shell remains usable and retains its existing focus-only behavior. This does not add service-worker push or cold-start notification activation.
