### PR TITLE
docs: make design proposals open discussions, not maintainer requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/design_proposal.yml
@@ -7,8 +7,10 @@ body:
       value: |
         For changes that other code will have to live with: a convention, a framework-level
         dependency, a schema or protocol change, the desktop preload bridge. See "Design before code"
-        in CONTRIBUTING.md. A few paragraphs is the normal size. A maintainer replies within a few
-        days; prototyping in the meantime is fine, polishing is premature.
+        in CONTRIBUTING.md. A few paragraphs is the normal size. This is an open thread: anyone who
+        has worked on the affected area is welcome to weigh in, and mentioning them helps. The
+        maintainer makes the final call, normally within a few days. Prototyping in the meantime is
+        fine, polishing is premature.
   - type: textarea
     id: problem
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,12 +36,14 @@ off a path the project may need later. For those, a short conversation before
 the code is the difference between a change that merges and one that gets
 reworked after it is finished. The point of this section is to protect your
 time, not to add a hurdle: the discussion is the same either way, and it is
-much cheaper before the implementation exists.
+much cheaper before the implementation exists. Backspace has one maintainer
+and the last call is his, but the discussion is not his alone: proposals are
+open threads, and other contributors' arguments shape the decision.
 
 A change is architectural, and needs a design proposal, if it does any of:
 
 - introduces a mechanism or convention that other code must comply with from
-  then on (a coordinate model, a new state layer, a required wrapper around a
+  then on (a global event bus, a new state layer, a required wrapper around a
   browser API, a naming or file-layout rule);
 - adds a framework-level dependency, a build tool, or a new runtime mode or
   platform layer (an ordinary library falls under the dependency rule below
@@ -62,10 +64,16 @@ How it works:
    A few paragraphs is the normal size. Prototyping to find out whether the
    idea works is fine and often helps the discussion; just do not polish
    before the approach is agreed, because it may change.
-2. A maintainer replies within a few days: with questions, with "approved to
-   implement", or, for the largest decisions, with a request to write it up as
-   an ADR in `docs/decisions/` so the reasoning outlives the pull request. A
-   proposal that sits unanswered for a week is a bug in the process; nudge it.
+2. The proposal is open for discussion by anyone. If you have worked on the
+   subsystems involved, weigh in; `git log` on the files a proposal would
+   touch shows who else has, and mentioning them is welcome. The maintainer
+   makes the final call, normally within a few days, and waits a little
+   longer while a discussion is active. The call is "approved to implement",
+   questions, or, for the largest decisions, a request to write it up as an
+   ADR in `docs/decisions/` so the reasoning outlives the pull request. A
+   proposal that several contributors have argued through usually gets a
+   faster decision than one nobody has looked at. One that sits with no
+   response at all for a week is a bug in the process; nudge it.
 3. Implement against the agreed design and link the proposal from the pull
    request.
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -60,7 +60,9 @@ against it. Name the primitives and where they live.
 ## Alternatives considered
 
 Each option that was seriously on the table, and what it would have broken
-or cost.
+or cost. Where another contributor argued for an option on the proposal,
+record their argument here and credit them; the losing case is part of the
+record, and the person who made it should see it kept.
 
 ## Consequences
 


### PR DESCRIPTION
## What this changes

#140 added the design proposal flow, and every step in it named the maintainer: a maintainer replies, a maintainer approves, a maintainer asks for an ADR. Nothing said that anyone else was expected in the thread. That makes the maintainer the center of all planning, which is the opposite of the goal.

- `CONTRIBUTING.md`: proposals are open threads; contributors who have worked on the affected subsystems are asked to weigh in, with `git log` on the touched files as the way to find them. The maintainer makes the final call, normally within a few days, and waits while a discussion is active. A proposal several contributors have argued through gets a faster decision than one nobody has looked at. The trigger example is swapped for a neutral one.
- Design proposal template: same framing in the intro.
- `docs/decisions/README.md`: the alternatives section records and credits other contributors' arguments, so the losing case stays on the record.

## Type of change

- [x] Documentation

## Checklist

- [x] `pnpm build`, `pnpm dev`, tests: no code touched
- [x] I ran the change myself (read every changed section as a contributor)
- [x] Not applicable: no `docs/systems/` change, no identity or API changes
- [x] I have read and agree to the CLA (maintainer)
