### PR TITLE
feat(telemetry): carry the ask's scene into the settings panel

### DIFF
--- a/docs/systems/telemetry.md
+++ b/docs/systems/telemetry.md
@@ -264,6 +264,15 @@ The panel lives in Instance settings under "Say hi to Jannis", with the toggle,
 the last reported day, the last error if there is one, the masked id and the
 live preview. See [admin.md](admin.md).
 
+It also carries the ask's own artwork, banded above the switch so the picture
+and the control read as one object. The panel's three states are the scene's
+three moods: `happy` (beam lit) while reporting is on, `farewell` (the pilot's
+arm lowered) while it is off, and `idle` (still waving) before the first
+answer. Switching the hello off plays the beam back into the porthole rather
+than cutting it, which is a transition the modal never needed: it is answered
+once and closed, so before this the beam only ever arrived. Under
+`prefers-reduced-motion` the same change is a 200 ms cross-fade.
+
 ---
 
 ## 7. The ask

--- a/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.test.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.test.tsx
@@ -7,6 +7,12 @@ import { api } from '../../../api/client';
 
 const off = { enabled: false, id: null, lastDay: null, lastError: null };
 const on = { enabled: true, id: '3f6c9e2a-1b2c-4d5e-8f90-1234567890ab', lastDay: '2026-09-06', lastError: null };
+const never = { enabled: null, id: null, lastDay: null, lastError: null };
+
+/** The mood the scene stands in, which is this panel's state as a picture. */
+function moodOf(container: HTMLElement): string | null {
+  return container.querySelector('svg[data-mood]')?.getAttribute('data-mood') ?? null;
+}
 
 beforeEach(() => {
   useSettingsStore.setState({ telemetry: null, telemetryPreview: null });
@@ -55,11 +61,12 @@ describe('TelemetryPanel', () => {
   it('keeps the toggle on the server state when saving fails', async () => {
     vi.spyOn(api.admin.telemetry, 'get').mockResolvedValue(off);
     vi.spyOn(api.admin.telemetry, 'set').mockRejectedValue(new Error('Nope'));
-    render(<TelemetryPanel />);
+    const { container } = render(<TelemetryPanel />);
     await screen.findByText('Off');
     await userEvent.click(screen.getByRole('switch'));
     await waitFor(() => expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false'));
     expect(screen.getByText('Off')).toBeInTheDocument();
+    expect(moodOf(container), 'the scene lit up for a save the server refused').toBe('farewell');
   });
 
   it('refetches the preview on demand', async () => {
@@ -71,6 +78,41 @@ describe('TelemetryPanel', () => {
     const onMount = preview.mock.calls.length;
     await userEvent.click(screen.getByRole('button', { name: 'Refresh' }));
     await waitFor(() => expect(preview.mock.calls.length).toBe(onMount + 1));
+  });
+
+  it('says the state twice, once in words and once in the scene', async () => {
+    const get = vi.spyOn(api.admin.telemetry, 'get').mockResolvedValue(on);
+
+    const lit = render(<TelemetryPanel />);
+    await screen.findByText('On');
+    expect(moodOf(lit.container)).toBe('happy');
+    lit.unmount();
+
+    useSettingsStore.setState({ telemetry: null, telemetryPreview: null });
+    get.mockResolvedValue(off);
+    const dark = render(<TelemetryPanel />);
+    await screen.findByText('Off');
+    expect(moodOf(dark.container)).toBe('farewell');
+    dark.unmount();
+
+    useSettingsStore.setState({ telemetry: null, telemetryPreview: null });
+    get.mockResolvedValue(never);
+    const waiting = render(<TelemetryPanel />);
+    await screen.findByText('Never asked');
+    expect(moodOf(waiting.container)).toBe('idle');
+  });
+
+  it('lights the beam when the switch goes on', async () => {
+    vi.spyOn(api.admin.telemetry, 'get').mockResolvedValue(off);
+    vi.spyOn(api.admin.telemetry, 'set').mockResolvedValue(on);
+    const { container } = render(<TelemetryPanel />);
+    await screen.findByText('Off');
+    expect(moodOf(container)).toBe('farewell');
+
+    await userEvent.click(screen.getByRole('switch'));
+
+    await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
+    expect(moodOf(container)).toBe('happy');
   });
 
   it('links to the document that says what is sent', async () => {

--- a/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.tsx
@@ -6,6 +6,7 @@ import { useFormatters, type Formatters } from '../../../i18n/formatters';
 import { describeError } from '../../../i18n/errors';
 import { Toggle } from '../../ui/Toggle';
 import { PayloadPreview } from '../../telemetry/PayloadPreview';
+import { HelloScene, type SceneMood } from '../../telemetry/scene/HelloScene';
 
 /** What the ping contains and why, in the repository the instance runs. */
 const DOC_URL = 'https://github.com/TheZwiss/backspace/blob/main/docs/systems/telemetry.md';
@@ -30,6 +31,21 @@ function formatDay(day: string, f: Formatters): string {
 function maskId(id: string): string {
   const [first] = id.split('-');
   return `${first ?? id}…`;
+}
+
+/**
+ * The panel's three states are the scene's three moods, so the artwork from
+ * the ask carries straight over instead of being spent once and thrown away.
+ *
+ * `happy` is the beam lit, `farewell` is the pilot's arm lowered, and `idle`
+ * is the pilot still waving because nobody has answered yet. That last one is
+ * only reachable before the first answer: once an admin has said either word,
+ * `enabled` is never null again.
+ */
+function moodFor(enabled: boolean | null): SceneMood {
+  if (enabled === true) return 'happy';
+  if (enabled === false) return 'farewell';
+  return 'idle';
 }
 
 /**
@@ -137,9 +153,22 @@ export function TelemetryPanel() {
         <div className="text-xs text-txt-tertiary mt-1">{t('telemetry:panel.intro')}</div>
       </div>
 
-      {/* The switch, with the server's state under it */}
-      <div className="rounded-lg bg-white/[0.02] p-3.5">
-        <div className="flex items-center justify-between gap-4">
+      {/*
+        The scene and the switch are one object rather than two stacked ones.
+        Flipping the switch changes the picture immediately above it, which is
+        what makes the beam retracting read as a consequence of the click; the
+        same artwork sitting elsewhere on the panel would just be decoration.
+
+        5:2 with `slice`: the composition is 3:2, so a banner this wide crops
+        the void away at top and bottom and keeps the whole ship. The scene is
+        aria-hidden and carries no text, so nothing here is the only copy of
+        anything - statusLabel below still says the state in words.
+      */}
+      <div className="rounded-lg bg-white/[0.02] overflow-hidden">
+        <div className="aspect-[5/2] bg-surface-base">
+          <HelloScene mood={moodFor(telemetry.enabled)} preserveAspectRatio="xMidYMid slice" />
+        </div>
+        <div className="flex items-center justify-between gap-4 p-3.5">
           <div>
             <div className="text-sm font-medium text-txt-primary">{t('telemetry:panel.toggle')}</div>
             <div className="text-xs text-txt-tertiary mt-0.5">{statusLabel}</div>

--- a/packages/web/src/components/telemetry/scene/HelloScene.test.tsx
+++ b/packages/web/src/components/telemetry/scene/HelloScene.test.tsx
@@ -101,6 +101,53 @@ describe('HelloScene', () => {
     expect(animate).not.toHaveBeenCalled();
   });
 
+  // Leaving happy is the transition the modal never made: it is answered once
+  // and closed. What these assert is that a track exists at all - without one
+  // the beam is not faded, it is cancelled, and cancelling a forwards-filled
+  // animation drops the element onto its base value in a single frame.
+  it('draws the beam back into the porthole when the scene leaves happy', () => {
+    const { rerender } = render(<HelloScene mood="happy" />);
+    animate.mockClear();
+    rerender(<HelloScene mood="farewell" />);
+
+    const tracks = animate.mock.calls.map(([frames]) => frames as Keyframe[]);
+    const beam = tracks.find((f) => f[0]?.transform === 'scaleX(1)' && f.at(-1)?.transform === 'scaleX(0)');
+    expect(beam, 'nothing takes the beam from full width back to the porthole').toBeDefined();
+
+    // A track that starts dark would blink the cabin off and on before dimming
+    // it, because a delayed or dark-first track sits at the base value first.
+    const cabin = tracks.filter((f) => f[0]?.opacity === 1 && f.at(-1)?.opacity === 0);
+    expect(cabin.length, 'the lit window does not fade down from lit').toBeGreaterThan(0);
+  });
+
+  it('keeps the farewell wave when it leaves happy, alongside the retract', () => {
+    const { rerender } = render(<HelloScene mood="happy" />);
+    animate.mockClear();
+    rerender(<HelloScene mood="farewell" />);
+
+    const tracks = animate.mock.calls.map(([frames]) => frames as Keyframe[]);
+    const arm = tracks.find((f) => String(f.at(-1)?.transform).startsWith('rotate('));
+    expect(arm, 'the arm never lowers, so the retract replaced the farewell').toBeDefined();
+  });
+
+  it('fades the beam out under reduced motion rather than collapsing it', () => {
+    installMatchMedia(true);
+    const { rerender } = render(<HelloScene mood="happy" />);
+    animate.mockClear();
+    rerender(<HelloScene mood="farewell" />);
+
+    const tracks = animate.mock.calls.map(([frames]) => frames as Keyframe[]);
+    const beam = tracks.find((f) => f.length > 0 && f.every((k) => k.transform === 'scaleX(1)'));
+    expect(beam, 'the beam collapses to no width before its opacity can fade').toBeDefined();
+    expect(beam?.at(-1)?.opacity).toBe(0);
+  });
+
+  it('leaves the aspect ratio to the SVG default until a caller asks for one', () => {
+    expect(renderScene('idle').getAttribute('preserveAspectRatio')).toBeNull();
+    const { container } = render(<HelloScene mood="idle" preserveAspectRatio="xMidYMid slice" />);
+    expect(container.querySelector('svg')?.getAttribute('preserveAspectRatio')).toBe('xMidYMid slice');
+  });
+
   it('uses only palette colours, nothing pure black or white', () => {
     const svg = renderScene('happy');
     const markup = svg.outerHTML;

--- a/packages/web/src/components/telemetry/scene/HelloScene.tsx
+++ b/packages/web/src/components/telemetry/scene/HelloScene.tsx
@@ -10,6 +10,15 @@ export type SceneMood = 'idle' | 'happy' | 'farewell';
 export interface HelloSceneProps {
   mood: SceneMood;
   className?: string;
+  /**
+   * How the 3:2 composition sits in a container shaped differently. Left
+   * unset, the SVG default (`xMidYMid meet`) letterboxes, which is what the
+   * modal's own 3:2 slot wants. A banner wider than 3:2 passes
+   * `xMidYMid slice` so the void crops away instead of the ship shrinking into
+   * empty space; the ship spans y 106-246 of the 320-high viewBox, so any
+   * container down to 5:2 keeps all of it.
+   */
+  preserveAspectRatio?: string;
 }
 
 // Ids for gradients, filters, masks and clips, unique per mounted scene.
@@ -69,7 +78,7 @@ const STYLE = `
 .hs-root[data-mood=farewell] .hs-rest{opacity:1}
 }`;
 
-export function HelloScene({ mood, className }: HelloSceneProps) {
+export function HelloScene({ mood, className, preserveAspectRatio }: HelloSceneProps) {
   const ids = makeIds(useId().replace(/[^a-zA-Z0-9]/g, ''));
   const svgRef = useRef<SVGSVGElement>(null);
   useSceneAnimation(svgRef, mood);
@@ -78,6 +87,7 @@ export function HelloScene({ mood, className }: HelloSceneProps) {
     <svg
       ref={svgRef}
       viewBox="0 0 480 320"
+      preserveAspectRatio={preserveAspectRatio}
       width="100%"
       height="100%"
       aria-hidden="true"

--- a/packages/web/src/components/telemetry/scene/useSceneAnimation.ts
+++ b/packages/web/src/components/telemetry/scene/useSceneAnimation.ts
@@ -9,6 +9,10 @@ const EASING = {
 
 const CROSS_FADE_MS = 200;
 const BEAM_OPACITY = 0.6;
+// Slower than the 900 ms arrival: light withdrawing reads as deliberate, light
+// arriving reads as eager. The cabin settles a little after the beam is home.
+const RETRACT_MS = 620;
+const SETTLE_MS = 680;
 
 // The arm's current rotation in degrees, read from its computed transform so
 // the choreography starts where the ambient wave left it instead of snapping.
@@ -106,10 +110,72 @@ export function useSceneAnimation(svgRef: React.RefObject<SVGSVGElement | null>,
       );
     }
 
+    /**
+     * The way back out of `happy`. The modal never needed one: it is answered
+     * once and closed, so the beam only ever arrives. A settings panel
+     * switches the hello off as often as on, and that is the transition an
+     * admin actually watches, so the light is drawn back into the porthole
+     * rather than cut.
+     *
+     * Nothing here fills forwards, and nothing needs to: every track ends on
+     * the value the stylesheet already holds for a scene that is not happy, so
+     * each element is handed back exactly where CSS picks it up.
+     *
+     * The cabin holds its brightness through the first third rather than
+     * taking a `delay`. A delayed track sits at its underlying value until it
+     * starts, and that value is the dark one, so a delay would blink the
+     * window off and on again before dimming it.
+     */
+    function retract(): void {
+      play(
+        part('ray'),
+        [
+          { transform: 'scaleX(1)', opacity: BEAM_OPACITY },
+          { opacity: BEAM_OPACITY, offset: 0.45 },
+          { transform: 'scaleX(0)', opacity: 0 },
+        ],
+        { duration: RETRACT_MS, easing: EASING.gentle },
+      );
+      play(
+        part('lit'),
+        [
+          { opacity: 1, offset: 0 },
+          { opacity: 1, offset: 0.38 },
+          { opacity: 0, offset: 1 },
+        ],
+        { duration: SETTLE_MS, easing: EASING.gentle },
+      );
+      play(
+        part('glow'),
+        [
+          { opacity: 0.85, transform: 'scale(1.2)', offset: 0 },
+          { opacity: 0.85, transform: 'scale(1.2)', offset: 0.38 },
+          { opacity: 0.4, transform: 'scale(1)', offset: 1 },
+        ],
+        { duration: SETTLE_MS, easing: EASING.gentle },
+      );
+    }
+
     // Reduced motion: the stylesheet already shows the still frame for this
     // mood; the parts that changed fade to it over 200 ms.
-    function crossFade(): void {
+    function crossFade(leavingHappy: boolean): void {
       const fade = { duration: CROSS_FADE_MS, easing: EASING.gentle };
+      if (leavingHappy) {
+        // The beam's width is pinned across both frames. The still frame for
+        // any scene that is not happy puts the ray at scaleX(0), so letting
+        // the transform track its own way there would collapse the beam to
+        // nothing in the first frame and leave the opacity nothing to fade.
+        play(
+          part('ray'),
+          [
+            { transform: 'scaleX(1)', opacity: BEAM_OPACITY },
+            { transform: 'scaleX(1)', opacity: 0 },
+          ],
+          fade,
+        );
+        play(part('lit'), [{ opacity: 1 }, { opacity: 0 }], fade);
+        play(part('glow'), [{ opacity: 0.85 }, { opacity: 0.4 }], fade);
+      }
       if (mood === 'happy') {
         play(part('lit'), [{ opacity: 0 }, { opacity: 1 }], fade);
         play(part('ray'), [{ opacity: 0 }, { opacity: BEAM_OPACITY }], fade);
@@ -120,12 +186,17 @@ export function useSceneAnimation(svgRef: React.RefObject<SVGSVGElement | null>,
       }
     }
 
+    // Leaving `happy` is its own step rather than an alternative to the new
+    // mood's choreography: switching the hello off plays the beam home AND
+    // lowers the pilot's arm, and the two touch different parts of the scene.
+    const leavingHappy = previous === 'happy' && mood !== 'happy';
+
     if (mq?.matches) {
-      if (previous !== null && previous !== mood) crossFade();
-    } else if (mood === 'happy') {
-      happy();
-    } else if (mood === 'farewell') {
-      farewell();
+      if (previous !== null && previous !== mood) crossFade(leavingHappy);
+    } else {
+      if (leavingHappy) retract();
+      if (mood === 'happy') happy();
+      else if (mood === 'farewell') farewell();
     }
 
     function onMotionChange(event: MediaQueryListEvent): void {


### PR DESCRIPTION
The scene drawn for the one-time ask was never seen again. The settings panel showed a switch and a status line, so the artwork cost a first impression and bought nothing after it.

The panel's three states are already the scene's three moods, so nothing new is drawn: `happy` while reporting is on, `farewell` while it is off, `idle` before the first answer. The scene is banded directly above the switch inside one card rather than placed elsewhere on the panel, so flipping the switch changes the picture immediately over it. The same artwork further down the page would read as decoration.

**Leaving `happy` had no choreography at all**, because the modal never made that transition: it is answered once and closed, so the beam only ever arrived. A settings panel switches the hello off as often as on, and without a way back the beam was not fading, it was being cancelled — and cancelling a forwards-filled animation drops the element onto its CSS base in a single frame. The beam is now drawn back into the porthole over 620ms and the cabin settles after it over 680ms.

The cabin's hold is written into the keyframes rather than taken as a `delay`. A delayed track sits at its underlying value until it starts, and that value is the dark one, so a delay would have blinked the window off and on again before dimming it.

Under `prefers-reduced-motion` the same change is a 200ms cross-fade, with the ray's width pinned across both frames: the still frame for any scene that is not happy puts the ray at `scaleX(0)`, so letting the transform find its own way there would collapse the beam before the opacity had anything to fade.

`HelloScene` takes a `preserveAspectRatio` so the 3:2 composition can crop into a banner instead of letterboxing into empty space. It is unset by default, so the modal renders byte-identically; the panel passes `xMidYMid slice` for a 5:2 band. The ship spans y 106-246 of the 320-high viewBox, so any container down to 5:2 keeps all of it, which was checked in a browser rather than derived.

`docs/systems/telemetry.md` §6 enumerated what the panel holds and would otherwise now be wrong.

780 tests across 94 files, typecheck and the i18n check clean. Each new test was watched failing with its own code removed: the retract, the reduced-motion fade and the mood mapping each break exactly the test that claims to cover them.

Known behaviour, deliberate: opening the panel replays the mood's choreography, so telemetry-off greets you with the pilot's full goodbye wave each time. Parking the arm at rest without the wave needs a resting pose the scene does not have yet, and that is a bigger change than this one.
