### PR TITLE
feat(settings): move language and interface scale to an Appearance tab

### DIFF
--- a/docs/systems/design-system.md
+++ b/docs/systems/design-system.md
@@ -15,9 +15,20 @@ Font: DM Sans (primary) with system fallbacks
 - `prefers-reduced-transparency` → fall back to solid surfaces
 - NOT a Discord clone — Backspace has its own visual identity
 
+## Settings organization
+
+Settings tabs split on ownership. **Appearance** holds preferences that belong
+to this browser or app: language and interface scale today, themes and display
+density later. They are stored locally and they work on the login screen, before
+there is an account. **Account** holds what lives on the server and follows the
+user to any device or instance: profile, credentials, deletion. Avatar and
+banner colours look like appearance and are not, because other people see them.
+A new presentation preference goes in Appearance, not in Account or in Desktop
+(which is Electron-only and would hide it from the browser).
+
 ## Interface scale
 
-Account settings include a device-local interface scale: 75–250% in 25% steps,
+Appearance settings include a device-local interface scale: 75–250% in 25% steps,
 default/reset 100%. `interfaceScaleStore` persists the percentage under
 `backspace-interface-scale`; unsupported stored values fall back to 100%.
 `main.tsx` applies it before mounting React, including auth pages and portals.
@@ -41,8 +52,8 @@ functions outside these definitions in production source.
 resize and scale changes using the same 768-layout-pixel threshold as AppLayout.
 Use the `desktop:` Tailwind variant for app-shell responsiveness; raw media
 queries ignore root zoom. Auth pages without a JS layout branch may keep `md:`.
-When scale moves account settings into MobileShell, route reconstruction places
-the current channel below settings and remains idempotent in StrictMode.
+When scale moves the appearance panel into MobileShell, route reconstruction
+places the current channel below settings and remains idempotent in StrictMode.
 
 `ImageCropModal` cancels root zoom only on the cropper container with
 `zoom: calc(1 / var(--interface-scale, 1))`. react-easy-crop mixes visual DOM

--- a/docs/systems/mobile-ui.md
+++ b/docs/systems/mobile-ui.md
@@ -342,6 +342,7 @@ Event options: `touchstart` is `{ passive: true }`, `touchmove` is `{ passive: f
 | `friends` | `FriendsPage` (with `mobile` prop) | — |
 | `settings` | `MobileSettingsScreen` | — |
 | `settings-account` | `MobileSettingsScreen` | `initialPanel="account"` |
+| `settings-appearance` | `MobileSettingsScreen` | `initialPanel="appearance"` |
 | `settings-voice` | `MobileSettingsScreen` | `initialPanel="voice"` |
 | `settings-privacy` | `MobileSettingsScreen` | `initialPanel="privacy"` |
 | `settings-connections` | `MobileSettingsScreen` | `initialPanel="connections"` |

--- a/packages/web/src/components/layout/MobileSettingsScreen.tsx
+++ b/packages/web/src/components/layout/MobileSettingsScreen.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useUIStore } from '../../stores/uiStore';
 import { useAuthStore } from '../../stores/authStore';
 import { AccountPanel } from '../modals/settingsPanels/AccountPanel';
+import { AppearancePanel } from '../modals/settingsPanels/AppearancePanel';
 import { VoicePanel } from '../modals/settingsPanels/VoicePanel';
 import { ConnectionsPanel } from '../modals/settingsPanels/ConnectionsPanel';
 import { PrivacyPanel } from '../modals/settingsPanels/PrivacyPanel';
@@ -18,6 +19,7 @@ interface MobileSettingsScreenProps {
 
 type PanelTitleKey =
   | 'settings:nav.tabs.account'
+  | 'settings:nav.tabs.appearance'
   | 'settings:nav.tabs.voice'
   | 'settings:nav.tabs.privacy'
   | 'settings:nav.tabs.connections'
@@ -26,6 +28,7 @@ type PanelTitleKey =
 
 const panelConfig: Record<string, { titleKey: PanelTitleKey; component: React.ReactNode }> = {
   account: { titleKey: 'settings:nav.tabs.account', component: <AccountPanel /> },
+  appearance: { titleKey: 'settings:nav.tabs.appearance', component: <AppearancePanel /> },
   voice: { titleKey: 'settings:nav.tabs.voice', component: <VoicePanel /> },
   privacy: { titleKey: 'settings:nav.tabs.privacy', component: <PrivacyPanel /> },
   connections: { titleKey: 'settings:nav.tabs.connections', component: <ConnectionsPanel /> },
@@ -37,6 +40,11 @@ const sectionIcons: Record<string, React.ReactNode> = {
   account: (
     <svg className="w-5 h-5 text-txt-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+    </svg>
+  ),
+  appearance: (
+    <svg className="w-5 h-5 text-txt-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.439.44 1.151 0 1.59l-2.879 2.879M6.75 17.25h.008v.008H6.75v-.008z" />
     </svg>
   ),
   voice: (
@@ -100,6 +108,7 @@ export function MobileSettingsScreen({ initialPanel }: MobileSettingsScreenProps
   // mobile feature (no global hooks, no recording flow on touch keyboards).
   const sections = [
     { id: 'account', label: t('settings:nav.tabs.account') },
+    { id: 'appearance', label: t('settings:nav.tabs.appearance') },
     { id: 'voice', label: t('settings:nav.tabs.voice') },
     { id: 'privacy', label: t('settings:nav.tabs.privacy') },
     { id: 'connections', label: t('settings:nav.tabs.connections') },

--- a/packages/web/src/components/layout/MobileShell.tsx
+++ b/packages/web/src/components/layout/MobileShell.tsx
@@ -58,6 +58,7 @@ const screenMap: Record<string, (params?: Record<string, string>) => React.React
   'friends': () => <FriendsPage mobile />,
   'settings': () => <MobileSettingsScreen />,
   'settings-account': () => <MobileSettingsScreen initialPanel="account" />,
+  'settings-appearance': () => <MobileSettingsScreen initialPanel="appearance" />,
   'settings-voice': () => <MobileSettingsScreen initialPanel="voice" />,
   'settings-privacy': () => <MobileSettingsScreen initialPanel="privacy" />,
   'settings-connections': () => <MobileSettingsScreen initialPanel="connections" />,

--- a/packages/web/src/components/modals/UserSettings.tsx
+++ b/packages/web/src/components/modals/UserSettings.tsx
@@ -8,6 +8,7 @@ import type { InstanceInfoResponse } from '@backspace/shared';
 import { useUIStore } from '../../stores/uiStore';
 import { useAuthStore } from '../../stores/authStore';
 import { AccountPanel } from './settingsPanels/AccountPanel';
+import { AppearancePanel } from './settingsPanels/AppearancePanel';
 import { VoicePanel } from './settingsPanels/VoicePanel';
 import { PrivacyPanel } from './settingsPanels/PrivacyPanel';
 import { ConnectionsPanel } from './settingsPanels/ConnectionsPanel';
@@ -17,7 +18,7 @@ import { KeybindsPanel } from './settingsPanels/KeybindsPanel';
 import { isElectron } from '../../platform/platform';
 import { SettingsSectionsProvider, useSettingsSectionsContext } from './SettingsSectionsContext';
 
-type SettingsTab = 'account' | 'voice' | 'privacy' | 'connections' | 'keybinds' | 'desktop' | 'instance';
+type SettingsTab = 'account' | 'appearance' | 'voice' | 'privacy' | 'connections' | 'keybinds' | 'desktop' | 'instance';
 
 function SidebarSubLinks() {
   const ctx = useSettingsSectionsContext();
@@ -138,6 +139,7 @@ export function UserSettingsModal() {
           <div className="glass-bubble rounded-lg p-2 flex-1 flex flex-col">
             <div className="text-[10px] font-semibold text-txt-tertiary uppercase tracking-wider px-3 py-1">{t('settings:nav.userSettings')}</div>
             <button onClick={() => handleTabClick('account')} className={tabClass('account')}>{t('settings:nav.tabs.account')}</button>
+            <button onClick={() => handleTabClick('appearance')} className={tabClass('appearance')}>{t('settings:nav.tabs.appearance')}</button>
             <button onClick={() => handleTabClick('voice')} className={tabClass('voice')}>{t('settings:nav.tabs.voice')}</button>
             <button onClick={() => handleTabClick('privacy')} className={tabClass('privacy')}>{t('settings:nav.tabs.privacy')}</button>
 
@@ -195,6 +197,7 @@ export function UserSettingsModal() {
             <div className="glass-bubble rounded-lg p-2 space-y-0.5">
               <div className="text-[10px] font-semibold text-txt-tertiary uppercase tracking-wider px-3 py-1">{t('settings:nav.userSettings')}</div>
               <button onClick={() => handleTabClick('account')} className={tabClass('account')}>{t('settings:nav.tabs.account')}</button>
+              <button onClick={() => handleTabClick('appearance')} className={tabClass('appearance')}>{t('settings:nav.tabs.appearance')}</button>
               <button onClick={() => handleTabClick('voice')} className={tabClass('voice')}>{t('settings:nav.tabs.voice')}</button>
               <button onClick={() => handleTabClick('privacy')} className={tabClass('privacy')}>{t('settings:nav.tabs.privacy')}</button>
 
@@ -247,6 +250,7 @@ export function UserSettingsModal() {
                 </button>
               )}
               {tab === 'account' && <AccountPanel />}
+              {tab === 'appearance' && <AppearancePanel />}
               {tab === 'voice' && <VoicePanel />}
               {tab === 'privacy' && <PrivacyPanel />}
               {tab === 'connections' && <ConnectionsPanel />}

--- a/packages/web/src/components/modals/settingsPanels/AccountPanel.tsx
+++ b/packages/web/src/components/modals/settingsPanels/AccountPanel.tsx
@@ -14,8 +14,6 @@ import { getAvatarGradient, adjustColor, mutedGradient, AVATAR_GRADIENT_MAP, BAN
 import { AVATAR_COLORS } from '@backspace/shared';
 import type { User, UserStatus, AvatarColor } from '@backspace/shared';
 import { describeError } from '../../../i18n/errors';
-import { LanguageSection } from './LanguageSection';
-import { InterfaceScaleSection } from './InterfaceScaleSection';
 
 const BIO_MAX_LENGTH = 190;
 const PASSWORD_MIN_LENGTH = 8;
@@ -333,9 +331,6 @@ export function AccountPanel() {
           )}
         </div>
       )}
-      <LanguageSection />
-      <InterfaceScaleSection />
-
       {/* ── Profile Customization ── */}
       <div>
         <div className="text-[11px] font-semibold text-txt-tertiary uppercase tracking-wider mb-1.5">

--- a/packages/web/src/components/modals/settingsPanels/AppearancePanel.test.tsx
+++ b/packages/web/src/components/modals/settingsPanels/AppearancePanel.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { AppearancePanel } from './AppearancePanel';
+
+afterEach(cleanup);
+
+describe('AppearancePanel', () => {
+  // Both controls are stored per device and work on the login screen, which is
+  // why they live here rather than with the account-owned settings.
+  it('carries the language and interface scale controls', () => {
+    const { container } = render(<AppearancePanel />);
+    expect(container.querySelector('#language-select')).not.toBeNull();
+    expect(container.querySelector('#interface-scale')).not.toBeNull();
+  });
+});

--- a/packages/web/src/components/modals/settingsPanels/AppearancePanel.tsx
+++ b/packages/web/src/components/modals/settingsPanels/AppearancePanel.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next';
+import { LanguageSection } from './LanguageSection';
+import { InterfaceScaleSection } from './InterfaceScaleSection';
+
+/**
+ * Presentation preferences that belong to this browser or app rather than to
+ * the account: they are stored locally and they apply on the login screen,
+ * before there is an account at all.
+ */
+export function AppearancePanel() {
+  const { t } = useTranslation(['settings']);
+
+  return (
+    <div className="space-y-5">
+      <h2 className="text-lg font-semibold text-txt-primary mb-6">{t('settings:appearance.title')}</h2>
+      <LanguageSection />
+      <InterfaceScaleSection />
+    </div>
+  );
+}

--- a/packages/web/src/components/modals/settingsPanels/InterfaceScaleSection.tsx
+++ b/packages/web/src/components/modals/settingsPanels/InterfaceScaleSection.tsx
@@ -10,13 +10,13 @@ export function InterfaceScaleSection() {
     const wasMobile = useUIStore.getState().isMobile;
     setScale(value);
     const ui = useUIStore.getState();
-    // Keep settings reachable when scaling crosses the responsive breakpoint.
+    // Keep this panel reachable when scaling crosses the responsive breakpoint.
     if (ui.isMobile !== wasMobile) {
       if (ui.isMobile) {
         ui.closeModal();
-        ui.pushMobileScreen('settings-account');
+        ui.pushMobileScreen('settings-appearance');
       } else {
-        ui.openModal('userSettings', { tab: 'account' });
+        ui.openModal('userSettings', { tab: 'appearance' });
       }
     }
   };

--- a/packages/web/src/hooks/useMobileRouteSync.test.tsx
+++ b/packages/web/src/hooks/useMobileRouteSync.test.tsx
@@ -7,7 +7,7 @@ import { useMobileRouteSync } from './useMobileRouteSync';
 afterEach(() => { cleanup(); useUIStore.setState({ mobileStack: [] }); });
 const route = '/channels/space/channel';
 const chat = { screen: 'channel-chat', params: { spaceId: 'space', channelId: 'channel' } };
-const settings = { screen: 'settings-account' };
+const settings = { screen: 'settings-appearance' };
 
 describe('mobile route reconstruction', () => {
   it.each([false, true])('restores chat below settings and back returns to chat (StrictMode=%s)', strict => {

--- a/packages/web/src/hooks/useMobileRouteSync.ts
+++ b/packages/web/src/hooks/useMobileRouteSync.ts
@@ -11,9 +11,9 @@ export function useMobileRouteSync(pathname: string): void {
     const matchesRoute = (entry: (typeof stack)[number] | undefined) =>
       entry?.screen === 'channel-chat' && entry.params?.spaceId === params.spaceId
       && entry.params?.channelId === params.channelId;
-    if (stack.at(-1)?.screen === 'settings-account') {
-      // InterfaceScaleSection currently hands off only account settings when
-      // scale crosses into mobile; extend this if it hands off other screens.
+    if (stack.at(-1)?.screen === 'settings-appearance') {
+      // InterfaceScaleSection currently hands off only the appearance panel
+      // when scale crosses into mobile; extend this if it hands off others.
       // Read the stack on every effect run, including StrictMode replay. The
       // existing settings history entry already has the channel URL beneath it.
       if (!stack.some(matchesRoute)) {

--- a/packages/web/src/locales/de/settings.json
+++ b/packages/web/src/locales/de/settings.json
@@ -117,6 +117,7 @@
     "administration": "Verwaltung",
     "tabs": {
       "account": "Konto",
+      "appearance": "Darstellung",
       "voice": "Sprache & Video",
       "privacy": "Privatsphäre",
       "connections": "Verbindungen",
@@ -126,6 +127,9 @@
     },
     "logOut": "Abmelden",
     "backToMenu": "Zurück zum Einstellungsmenü"
+  },
+  "appearance": {
+    "title": "Darstellung"
   },
   "account": {
     "title": "Mein Konto",
@@ -138,9 +142,6 @@
       "reattaching": "Wird verknüpft…",
       "reattachFailed": "Verknüpfen fehlgeschlagen",
       "reattached": "Konto wieder mit {{username}} verknüpft"
-    },
-    "language": {
-      "sectionTitle": "Sprache"
     },
     "profile": {
       "sectionTitle": "Profil anpassen",

--- a/packages/web/src/locales/en/settings.json
+++ b/packages/web/src/locales/en/settings.json
@@ -117,6 +117,7 @@
     "administration": "Administration",
     "tabs": {
       "account": "Account",
+      "appearance": "Appearance",
       "voice": "Voice & Video",
       "privacy": "Privacy",
       "connections": "Connections",
@@ -126,6 +127,9 @@
     },
     "logOut": "Log Out",
     "backToMenu": "Back to settings menu"
+  },
+  "appearance": {
+    "title": "Appearance"
   },
   "account": {
     "title": "My Account",
@@ -138,9 +142,6 @@
       "reattaching": "Re-attaching…",
       "reattachFailed": "Re-attach failed",
       "reattached": "Account re-linked with {{username}}"
-    },
-    "language": {
-      "sectionTitle": "Language"
     },
     "profile": {
       "sectionTitle": "Profile Customization",

--- a/packages/web/src/locales/ru/settings.json
+++ b/packages/web/src/locales/ru/settings.json
@@ -117,6 +117,7 @@
     "administration": "Администрирование",
     "tabs": {
       "account": "Учётная запись",
+      "appearance": "Оформление",
       "voice": "Голос и видео",
       "privacy": "Конфиденциальность",
       "connections": "Подключения",
@@ -126,6 +127,9 @@
     },
     "logOut": "Выйти",
     "backToMenu": "Назад к меню настроек"
+  },
+  "appearance": {
+    "title": "Оформление"
   },
   "account": {
     "title": "Моя учётная запись",
@@ -138,9 +142,6 @@
       "reattaching": "Привязка…",
       "reattachFailed": "Не удалось привязать",
       "reattached": "Учётная запись снова связана с {{username}}"
-    },
-    "language": {
-      "sectionTitle": "Язык"
     },
     "profile": {
       "sectionTitle": "Оформление профиля",

--- a/packages/web/src/platform/interfaceScale.test.tsx
+++ b/packages/web/src/platform/interfaceScale.test.tsx
@@ -110,14 +110,14 @@ describe('interface scale', () => {
     expect(screen.getByRole('button')).toBeDisabled();
   });
 
-  it('keeps account settings open across the effective mobile breakpoint', () => {
+  it('keeps appearance settings open across the effective mobile breakpoint', () => {
     const resize = () => useUIStore.getState().setIsMobile(layoutPixels(window.innerWidth) < 768);
     window.addEventListener('resize', resize);
     const stop = initializeInterfaceScale();
     useUIStore.setState({ isMobile: false, activeModal: 'userSettings' });
     render(<InterfaceScaleSection />);
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '250' } });
-    expect(useUIStore.getState().mobileStack.at(-1)?.screen).toBe('settings-account');
+    expect(useUIStore.getState().mobileStack.at(-1)?.screen).toBe('settings-appearance');
     fireEvent.click(screen.getByRole('button'));
     expect(useUIStore.getState().activeModal).toBe('userSettings');
     stop();


### PR DESCRIPTION
Language and interface scale sat in Account, but neither is account data: both are stored per device and both apply on the login screen, before there is an account at all. Account now holds only what lives on the server and follows you to another device or instance.

## What changed

- New **Appearance** tab, placed after Account in the settings modal and in the mobile settings list, carrying the language picker and the interface scale.
- New `settings-appearance` mobile screen; `MobileSettingsScreen` gains the panel, its icon and its list entry.
- `InterfaceScaleSection`'s breakpoint hand-off and the `useMobileRouteSync` reconstruction that pairs with it both follow the panel to the new screen.
- `nav.tabs.appearance` and `appearance.title` in English, German and Russian. The unused `account.language` key is dropped.
- `design-system.md` gains the rule that decides which tab a new preference goes in; `mobile-ui.md` gains the screen-map row.

Avatar and banner colours stay in Account: they look like appearance but other people see them, and they federate. Sound effects stay in Voice, next to output volume.

## Verification

- Web suite: 97 files, 839 tests, all passing, including a new `AppearancePanel` test and the two updated hand-off tests.
- `tsc --noEmit` clean, i18n consistency check clean.