### PR TITLE
fix(ui): allow 50% scale while keeping phones in the mobile layout

### DIFF
--- a/docs/systems/design-system.md
+++ b/docs/systems/design-system.md
@@ -59,6 +59,13 @@ resize and scale changes using the same predicate as AppLayout: mobile below
 The narrow-viewport guard keeps 390–430px phones in MobileShell even at 50%,
 when their effective layout width is 780–860px. Wider windows retain the scaled
 768px breakpoint; 600px is the first width eligible for desktop at 50%.
+
+The guard also decides the outcome at 75%, not only at the new floor: it applies
+at any scale at or below 78.125%, so a 576–599px window renders MobileShell where
+the scaled breakpoint alone would have kept the desktop grid. That is intended.
+A physically narrow viewport is mobile regardless of scale; gating the guard on
+scale would reintroduce the scale-driven shell flip it exists to prevent.
+
 Use the `desktop:` Tailwind variant for app-shell responsiveness; raw media
 queries ignore root zoom. Auth pages without a JS layout branch may keep `md:`.
 When scale moves the appearance panel into MobileShell, route reconstruction

--- a/docs/systems/design-system.md
+++ b/docs/systems/design-system.md
@@ -28,11 +28,16 @@ A new presentation preference goes in Appearance, not in Account or in Desktop
 
 ## Interface scale
 
-Appearance settings include a device-local interface scale: 75–250% in 25% steps,
+Appearance settings include a device-local interface scale: 50–250% in 25% steps,
 default/reset 100%. `interfaceScaleStore` persists the percentage under
 `backspace-interface-scale`; unsupported stored values fall back to 100%.
 `main.tsx` applies it before mounting React, including auth pages and portals.
 English, German, and Russian labels live in the `settings` namespace.
+
+50% is an opt-in density setting, not a recommended reading size: common 10–11px
+labels render at only 5–5.5px. The former 75% floor kept those labels at
+7.5–8.25px; the lower floor accommodates users who want more content on screen,
+but going lower would further compromise legibility. Default/reset remains 100%.
 
 The web and Electron clients share root CSS `zoom`. This is independent of the
 browser's own zoom controls. CSS viewport units do **not** compensate for CSS
@@ -49,7 +54,11 @@ scale. The viewport-token test rejects raw viewport units and environment
 functions outside these definitions in production source.
 
 `initializeInterfaceScale` updates `html[data-viewport="mobile|desktop"]` on
-resize and scale changes using the same 768-layout-pixel threshold as AppLayout.
+resize and scale changes using the same predicate as AppLayout: mobile below
+768 layout pixels **or** below 600 unscaled viewport pixels (`window.innerWidth`).
+The narrow-viewport guard keeps 390–430px phones in MobileShell even at 50%,
+when their effective layout width is 780–860px. Wider windows retain the scaled
+768px breakpoint; 600px is the first width eligible for desktop at 50%.
 Use the `desktop:` Tailwind variant for app-shell responsiveness; raw media
 queries ignore root zoom. Auth pages without a JS layout branch may keep `md:`.
 When scale moves the appearance panel into MobileShell, route reconstruction

--- a/docs/systems/desktop.md
+++ b/docs/systems/desktop.md
@@ -85,8 +85,8 @@ Instance URL management functions: `loadInstanceUrl()`, `saveInstanceUrl()`, `cl
 
 ### Interface Scale
 
-The account settings' interface-scale control is shared with the web client
-(75–250%, saved locally). It uses root CSS zoom; the native title bar is not
+The Appearance settings' interface-scale control is shared with the web client
+(50–250%, saved locally). It uses root CSS zoom; the native title bar is not
 scaled. `--titlebar-inset` is the single 33 px reservation (32 px drag region
 plus 1 px divider), divided by interface scale. `App`, `SpaceSidebar` and
 `ImagePreview` share it so fixed overlays and normal layout continue matching

--- a/docs/systems/mobile-ui.md
+++ b/docs/systems/mobile-ui.md
@@ -40,21 +40,23 @@ const checkMobile = () => setIsMobile(isMobileViewport());
 
 | Breakpoint | Value | Layout |
 |------------|-------|--------|
-| Desktop | `>= 768` layout px | AppLayout three-column grid (sidebar + chat + member list) |
-| Mobile | `< 768` layout px | MobileShell (tab bar + screen stack) |
+| Desktop | `>= 768` layout px **and** `innerWidth >= 600` | AppLayout three-column grid (sidebar + chat + member list) |
+| Mobile | `< 768` layout px **or** `innerWidth < 600` | MobileShell (tab bar + screen stack) |
 
 `AppLayout` conditionally renders `<MobileShell />` when `isMobile === true`. Modals render globally in both modes.
 
-### One breakpoint, in layout pixels
+### One shared predicate, with a narrow-viewport guard
 
-The threshold is **layout** pixels, not `window.innerWidth`. The interface-scale
+The main threshold is in **layout** pixels. The interface-scale
 setting applies CSS `zoom` to the root element, so `innerWidth` reports visual
 pixels while CSS lengths are layout pixels; at 200% a 1280 px window is a 640 px
 layout viewport and belongs in MobileShell. `isMobileViewport()` in
 `platform/interfaceScale.ts` divides by the scale factor, and layout code that
 needs the breakpoint should call it rather than compare `innerWidth` itself.
-(`PictureInPicture` inlines the same `layoutPixels(innerWidth) < 768` test
-because it already measures a layout viewport; `platform/clientKind.ts`
+It also keeps `window.innerWidth < 600` mobile regardless of scale: at 50%, a
+390px phone has 780 layout pixels but must not switch into the desktop shell.
+(`PictureInPicture` uses `layoutPixels(innerWidth) < 768` for its own obstacle
+geometry, not for choosing the app shell; `platform/clientKind.ts`
 deliberately keeps raw `innerWidth`, since telemetry classifies the physical
 device rather than the scaled layout.)
 

--- a/packages/web/src/components/voice/PictureInPicture.tsx
+++ b/packages/web/src/components/voice/PictureInPicture.tsx
@@ -1,4 +1,4 @@
-import { layoutRect, layoutPixels } from '../../platform/interfaceScale';
+import { layoutRect, layoutPixels, MOBILE_LAYOUT_BREAKPOINT } from '../../platform/interfaceScale';
 import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useVoiceStore } from '../../stores/voiceStore';
@@ -43,7 +43,7 @@ function getPipBounds(pipX: number): {
   const minY = PIP_MARGIN;
   let maxY = vh - PIP_HEIGHT - PIP_MARGIN;
 
-  if (vw < 768) return { minX, maxX, minY, maxY };
+  if (vw < MOBILE_LAYOUT_BREAKPOINT) return { minX, maxX, minY, maxY };
 
   const obstacles = document.querySelectorAll<HTMLElement>('[data-pip-obstacle]');
   for (const el of obstacles) {

--- a/packages/web/src/platform/interfaceScale.test.tsx
+++ b/packages/web/src/platform/interfaceScale.test.tsx
@@ -19,7 +19,11 @@ afterEach(() => {
 });
 
 describe('interface scale', () => {
-  it.each([[700, 75, 'desktop'], [1366, 200, 'mobile'], [768, 100, 'desktop']])(
+  it.each([
+    [390, 50, 'mobile'], [430, 50, 'mobile'], [599, 50, 'mobile'],
+    [600, 50, 'desktop'], [600, 100, 'mobile'],
+    [700, 75, 'desktop'], [1366, 200, 'mobile'], [768, 100, 'desktop'],
+  ])(
     'shares the JS/CSS breakpoint at width %i and scale %i', (width, scale, expected) => {
       vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(Number(width));
       useInterfaceScaleStore.getState().setScale(Number(scale));
@@ -69,7 +73,7 @@ describe('interface scale', () => {
     expect(useInterfaceScaleStore.getState().scale).toBe(scale);
   });
 
-  it.each([0, -1, 74, 99, 251, Infinity, NaN, '200', null])('rejects invalid stored value %s', value => {
+  it.each([0, -1, 49, 51, 67, 74, 99, 251, Infinity, NaN, '50', '200', null])('rejects invalid stored value %s', value => {
     expect(normalizeInterfaceScale(value)).toBe(100);
   });
 
@@ -100,7 +104,8 @@ describe('interface scale', () => {
     expect(pos.top * 2.5 + 250).toBeLessThanOrEqual(window.innerHeight);
   });
 
-  it('offers all eight scales and resets immediately', () => {
+  it('offers all nine scales and resets immediately', () => {
+    expect(INTERFACE_SCALES).toEqual([50, 75, 100, 125, 150, 175, 200, 225, 250]);
     render(<InterfaceScaleSection />);
     expect(screen.getAllByRole('option').map(option => option.getAttribute('value'))).toEqual(INTERFACE_SCALES.map(String));
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '250' } });
@@ -111,7 +116,7 @@ describe('interface scale', () => {
   });
 
   it('keeps appearance settings open across the effective mobile breakpoint', () => {
-    const resize = () => useUIStore.getState().setIsMobile(layoutPixels(window.innerWidth) < 768);
+    const resize = () => useUIStore.getState().setIsMobile(isMobileViewport());
     window.addEventListener('resize', resize);
     const stop = initializeInterfaceScale();
     useUIStore.setState({ isMobile: false, activeModal: 'userSettings' });
@@ -120,6 +125,27 @@ describe('interface scale', () => {
     expect(useUIStore.getState().mobileStack.at(-1)?.screen).toBe('settings-appearance');
     fireEvent.click(screen.getByRole('button'));
     expect(useUIStore.getState().activeModal).toBe('userSettings');
+    stop();
+    window.removeEventListener('resize', resize);
+  });
+
+  it.each([390, 430])('keeps phone appearance settings mobile when halving scale and resetting (%ipx)', width => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(width);
+    const resize = () => useUIStore.getState().setIsMobile(isMobileViewport());
+    window.addEventListener('resize', resize);
+    const stop = initializeInterfaceScale();
+    useUIStore.getState().pushMobileScreen('settings-appearance');
+    render(<InterfaceScaleSection />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '50' } });
+    expect(useInterfaceScaleStore.getState().scale).toBe(50);
+    expect(document.documentElement.dataset.viewport).toBe('mobile');
+    expect(useUIStore.getState().isMobile).toBe(true);
+    expect(useUIStore.getState().activeModal).toBeNull();
+    expect(useUIStore.getState().mobileStack.at(-1)?.screen).toBe('settings-appearance');
+    fireEvent.click(screen.getByRole('button'));
+    expect(useInterfaceScaleStore.getState().scale).toBe(100);
+    expect(document.documentElement.dataset.viewport).toBe('mobile');
+    expect(useUIStore.getState().mobileStack.at(-1)?.screen).toBe('settings-appearance');
     stop();
     window.removeEventListener('resize', resize);
   });

--- a/packages/web/src/platform/interfaceScale.test.tsx
+++ b/packages/web/src/platform/interfaceScale.test.tsx
@@ -6,7 +6,22 @@ import { computeFloatingPosition, pointAnchor } from '../hooks/useFloatingPositi
 import { InterfaceScaleSection } from '../components/modals/settingsPanels/InterfaceScaleSection';
 import { useUIStore } from '../stores/uiStore';
 
+const teardowns: Array<() => void> = [];
+
+/** Registers cleanup up front, so a failing assertion cannot leak listeners into later tests. */
+function startInterfaceScale(): () => void {
+  const stop = initializeInterfaceScale();
+  teardowns.push(stop);
+  return stop;
+}
+
+function onResize(handler: () => void): void {
+  window.addEventListener('resize', handler);
+  teardowns.push(() => window.removeEventListener('resize', handler));
+}
+
 afterEach(() => {
+  for (const teardown of teardowns.splice(0).reverse()) teardown();
   cleanup();
   useInterfaceScaleStore.getState().setScale(100);
   document.documentElement.style.removeProperty('zoom');
@@ -27,15 +42,14 @@ describe('interface scale', () => {
     'shares the JS/CSS breakpoint at width %i and scale %i', (width, scale, expected) => {
       vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(Number(width));
       useInterfaceScaleStore.getState().setScale(Number(scale));
-      const stop = initializeInterfaceScale();
+      startInterfaceScale();
       expect(document.documentElement.dataset.viewport).toBe(expected);
       expect(isMobileViewport()).toBe(expected === 'mobile');
-      stop();
     },
   );
   it('updates the viewport marker on window resize and removes the listener on cleanup', () => {
     const width = vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(900);
-    const stop = initializeInterfaceScale();
+    const stop = startInterfaceScale();
     width.mockReturnValue(600);
     window.dispatchEvent(new Event('resize'));
     expect(document.documentElement.dataset.viewport).toBe('mobile');
@@ -53,15 +67,13 @@ describe('interface scale', () => {
   it.each(INTERFACE_SCALES)('shares the unscaled native titlebar inset at %i%%', scale => {
     window.backspace = {} as BackspaceElectronAPI;
     useInterfaceScaleStore.getState().setScale(scale);
-    const stop = initializeInterfaceScale();
+    startInterfaceScale();
     expect(document.documentElement.style.getPropertyValue('--titlebar-inset')).toBe('calc(33px / var(--interface-scale))');
     expect(document.documentElement.style.getPropertyValue('--interface-scale')).toBe(String(scale / 100));
-    stop();
   });
   it('reserves no titlebar inset in the browser', () => {
-    const stop = initializeInterfaceScale();
+    startInterfaceScale();
     expect(document.documentElement.style.getPropertyValue('--titlebar-inset')).toBe('0px');
-    stop();
   });
   it.each(INTERFACE_SCALES)('persists and restores %i%%', async scale => {
     useInterfaceScaleStore.getState().setScale(scale);
@@ -80,8 +92,8 @@ describe('interface scale', () => {
   it('applies persisted scale before rendering, notifies layout hooks, and unsubscribes', () => {
     useInterfaceScaleStore.getState().setScale(175);
     const resize = vi.fn();
-    window.addEventListener('resize', resize);
-    const stop = initializeInterfaceScale();
+    onResize(resize);
+    const stop = startInterfaceScale();
     expect(document.documentElement.style.zoom).toBe('1.75');
     useInterfaceScaleStore.getState().setScale(250);
     expect(document.documentElement.style.getPropertyValue('--interface-scale')).toBe('2.5');
@@ -90,7 +102,6 @@ describe('interface scale', () => {
     stop();
     useInterfaceScaleStore.getState().setScale(100);
     expect(resize).toHaveBeenCalledTimes(2);
-    window.removeEventListener('resize', resize);
   });
 
   it('fits a zoomed floating surface inside the viewport using layout coordinates', () => {
@@ -117,23 +128,21 @@ describe('interface scale', () => {
 
   it('keeps appearance settings open across the effective mobile breakpoint', () => {
     const resize = () => useUIStore.getState().setIsMobile(isMobileViewport());
-    window.addEventListener('resize', resize);
-    const stop = initializeInterfaceScale();
+    onResize(resize);
+    startInterfaceScale();
     useUIStore.setState({ isMobile: false, activeModal: 'userSettings' });
     render(<InterfaceScaleSection />);
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '250' } });
     expect(useUIStore.getState().mobileStack.at(-1)?.screen).toBe('settings-appearance');
     fireEvent.click(screen.getByRole('button'));
     expect(useUIStore.getState().activeModal).toBe('userSettings');
-    stop();
-    window.removeEventListener('resize', resize);
   });
 
   it.each([390, 430])('keeps phone appearance settings mobile when halving scale and resetting (%ipx)', width => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(width);
     const resize = () => useUIStore.getState().setIsMobile(isMobileViewport());
-    window.addEventListener('resize', resize);
-    const stop = initializeInterfaceScale();
+    onResize(resize);
+    startInterfaceScale();
     useUIStore.getState().pushMobileScreen('settings-appearance');
     render(<InterfaceScaleSection />);
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '50' } });
@@ -146,7 +155,5 @@ describe('interface scale', () => {
     expect(useInterfaceScaleStore.getState().scale).toBe(100);
     expect(document.documentElement.dataset.viewport).toBe('mobile');
     expect(useUIStore.getState().mobileStack.at(-1)?.screen).toBe('settings-appearance');
-    stop();
-    window.removeEventListener('resize', resize);
   });
 });

--- a/packages/web/src/platform/interfaceScale.test.tsx
+++ b/packages/web/src/platform/interfaceScale.test.tsx
@@ -37,6 +37,7 @@ describe('interface scale', () => {
   it.each([
     [390, 50, 'mobile'], [430, 50, 'mobile'], [599, 50, 'mobile'],
     [600, 50, 'desktop'], [600, 100, 'mobile'],
+    [575, 75, 'mobile'], [576, 75, 'mobile'], [599, 75, 'mobile'], [600, 75, 'desktop'],
     [700, 75, 'desktop'], [1366, 200, 'mobile'], [768, 100, 'desktop'],
   ])(
     'shares the JS/CSS breakpoint at width %i and scale %i', (width, scale, expected) => {

--- a/packages/web/src/platform/interfaceScale.ts
+++ b/packages/web/src/platform/interfaceScale.ts
@@ -11,9 +11,16 @@ export function visualPixels(value: number): number {
   return value * (useInterfaceScaleStore.getState().scale / 100);
 }
 
+/** Below this many layout pixels the app shell is MobileShell, not AppLayout. */
+export const MOBILE_LAYOUT_BREAKPOINT = 768;
+
+/** Physically narrow viewports stay mobile at any scale. Phones are 390-430px. */
+export const NARROW_VIEWPORT_BREAKPOINT = 600;
+
 export function isMobileViewport(): boolean {
   // Zooming out must not turn a physically narrow phone into the desktop shell.
-  return window.innerWidth < 600 || layoutPixels(window.innerWidth) < 768;
+  return window.innerWidth < NARROW_VIEWPORT_BREAKPOINT
+    || layoutPixels(window.innerWidth) < MOBILE_LAYOUT_BREAKPOINT;
 }
 
 export function layoutRect<T extends { top: number; right: number; bottom: number; left: number; width: number; height: number }>(rect: T) {

--- a/packages/web/src/platform/interfaceScale.ts
+++ b/packages/web/src/platform/interfaceScale.ts
@@ -12,7 +12,8 @@ export function visualPixels(value: number): number {
 }
 
 export function isMobileViewport(): boolean {
-  return layoutPixels(window.innerWidth) < 768;
+  // Zooming out must not turn a physically narrow phone into the desktop shell.
+  return window.innerWidth < 600 || layoutPixels(window.innerWidth) < 768;
 }
 
 export function layoutRect<T extends { top: number; right: number; bottom: number; left: number; width: number; height: number }>(rect: T) {

--- a/packages/web/src/stores/interfaceScaleStore.ts
+++ b/packages/web/src/stores/interfaceScaleStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export const INTERFACE_SCALES = [75, 100, 125, 150, 175, 200, 225, 250] as const;
+export const INTERFACE_SCALES = [50, 75, 100, 125, 150, 175, 200, 225, 250] as const;
 
 export function normalizeInterfaceScale(value: unknown): number {
   return typeof value === 'number' && INTERFACE_SCALES.some(scale => scale === value) ? value : 100;


### PR DESCRIPTION
## What this changes

Implements option 1 from #159: offer **50–250% in 25% steps** and keep physically narrow viewports in MobileShell.

- Add 50% to the existing validated/persisted scale list. Default and reset stay at 100%.
- Use `window.innerWidth < 600 || layoutPixels(window.innerWidth) < 768` in the shared JS/CSS viewport predicate. At 50%, 390/430px phones stay mobile; 599px stays mobile and 600px can use desktop.
- Extend tests for the phone and boundary cases, the ninth dropdown option, persistence/coordinates/native-titlebar coverage, invalid values, and keeping phone Appearance settings reachable when selecting 50% and resetting.
- Document the new range, the narrow-viewport guard and the legibility trade-off (10–11px labels become 5–5.5px at 50%) in both design-system and mobile UI specs.

Closes #159

## Release note

Interface scale now supports 50–250%. Windows narrower than 600 CSS viewport pixels always use the mobile layout. This also changes existing 75% users at widths 576–599px from the desktop shell to MobileShell, closing the sidebar and member list. Changing scale cannot restore the desktop shell below 600px; widen the window to at least 600px (at 75%) to use it again. Default and Reset remain 100%.

## Review follow-up

Preserved the maintainer's follow-up commit `14448f93`: corrected the Electron spec to Appearance / 50–250%, documented the 75% band, shared the breakpoint constants with PiP, and registered test cleanup in `afterEach`. Added explicit JS/CSS predicate regressions for 575/576/599/600px at 75%. Re-ran `pnpm build` successfully and the complete web suite: **98 files, 858 tests passed**. The original browser evidence below remains applicable; this follow-up adds boundary tests without changing rendering behavior.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor or cleanup
- [x] Documentation
- [ ] Other

## Checklist

- [x] `pnpm build` succeeds (shared types, server, and web all build)
- [x] `pnpm dev` starts the server and web client without errors
- [x] Tests pass where applicable (`pnpm test`) — complete affected web package, 98 files / 858 tests after review
- [x] I ran the change myself, and attached evidence (screenshot, recording, or terminal output) if it affects packaging, installation, or the UI — Orca browser interaction, rendered screenshots and terminal results below
- [x] I updated the relevant `docs/systems/` spec
- [x] If this is an architectural change, it links the approved design proposal — N/A: existing predicate/store only; follows the maintainer's preferred option in #159, no new dependency or mechanism
- [x] I reviewed the full diff after the last commit (with an agent, if one wrote it) and fixed what I found
- [x] This change resolves the correct federated identity where applicable — N/A: device-local scale only, no identity/API/federation changes
- [x] CLA requirement satisfied — `cla-assistant` passed for the existing contributor signature; no new signature was posted

## Notes for reviewers

Validated on Windows, Node 24.15.0, repository-pinned pnpm 10.34.3 through Corepack. Orca's embedded Chromium browser is now working and the UI checks are complete. This is browser viewport testing, not a claim of testing on a physical phone or in the packaged Electron app.

The server used an isolated disposable SQLite database/uploads directory and loopback binding, not a production account. Optional ffmpeg/ffprobe were unavailable; Vite reported its existing config-loader/chunk warnings. Neither blocked startup/build.

Original implementation terminal evidence (updated follow-up results above):

```text
pnpm build
  @backspace/shared: tsc OK
  @backspace/server: tsc OK
  @backspace/web: i18n check: no findings; tsc OK; Vite/PWA build OK

pnpm --filter @backspace/web exec vitest run src/platform/interfaceScale.test.tsx
  Test Files 1 passed (1)
  Tests 56 passed (56)

pnpm --filter @backspace/web test
  Test Files 98 passed (98)
  Tests 854 passed (854)

pnpm dev
  VITE v8.2.2 ready
  Local: http://localhost:5173/
  Backspace server running at http://127.0.0.1:3005
```

## Browser verification and screenshots

- Desktop (1555px): selected 50% through Appearance; the desktop shell stays active.
- Narrow viewports (390px and 430px): selected 50% and used Reset to 100% through the actual settings controls; Appearance remains accessible and the shell stays mobile.
- Reload: 50% persists; after restoring the narrow viewport, the mobile shell is active and Appearance can be reopened with 50% selected. Orca resets its viewport override on navigation, so the override was reapplied after reload.
- Captures below are unedited rendered-app screenshots using a disposable local account. Explicit viewport sizing avoids the duplicate-image capture observed with Orca's device emulation. No application change was needed for that capture issue.
- All GitHub checks passed for the original implementation, including Node 20/24 build and tests, container build, security scans and CLA. See the checks tab for the latest follow-up commit.

50% deliberately remains tiny; the guard prevents an unwanted layout switch, it does not make 5px text readable.

Screenshots are stored in a separate evidence-only branch of the contributor fork, not in this PR's source diff.

### Desktop, 50%

![Desktop Appearance at 50%](https://raw.githubusercontent.com/st7105/backspace/evidence/interface-scale-pr-161/desktop-50.png)

### 390px viewport, 50%

![Mobile Appearance at 390px and 50%](https://raw.githubusercontent.com/st7105/backspace/evidence/interface-scale-pr-161/mobile-390-50.png)

### 430px viewport, 50%

![Mobile Appearance at 430px and 50%](https://raw.githubusercontent.com/st7105/backspace/evidence/interface-scale-pr-161/mobile-430-50.png)
