### PR TITLE
fix(telemetry): keep the instance id across an off-and-on cycle

### DIFF
--- a/docs/superpowers/specs/2026-09-06-instance-telemetry-design.md
+++ b/docs/superpowers/specs/2026-09-06-instance-telemetry-design.md
@@ -1,7 +1,7 @@
 # Instance telemetry ("Say hi to Jannis") design
 
 Date: 2026-09-06
-Status: approved in conversation, revised after review, implemented on branch feat/instance-telemetry, 2026-09-06
+Status: approved in conversation, revised after review, implemented on branch feat/instance-telemetry, 2026-09-06. Superseded in one point on 2026-09-08: the id is no longer cleared on off or re-minted on re-enable, see `docs/systems/telemetry.md` "Opt-in state".
 
 ## 1. Purpose
 

--- a/docs/systems/admin.md
+++ b/docs/systems/admin.md
@@ -365,9 +365,10 @@ opening it writes nothing.
 
 `routes/adminTelemetry.ts` is the only writer of the four `instance_settings`
 telemetry columns. `PATCH /api/settings/instance` does not touch them, so the id
-lifecycle has exactly one owner. Enabling mints a fresh UUID and stamps today as
-the last reported day, which is what makes the first ping go out tomorrow;
-disabling clears the id, so a later re-enable is a new anonymous instance.
+lifecycle has exactly one owner. The first enable mints a UUID that is kept for
+the life of the install; every enable stamps today as the last reported day,
+which is what makes the first ping go out tomorrow. Disabling keeps the id and
+clears the bookkeeping, so a later re-enable reports as the same instance.
 Saving "on" while it is already on changes nothing at all.
 
 The first admin to sign in on an instance that was never asked sees a one-time
@@ -606,12 +607,13 @@ Contents, top to bottom:
   note that the next attempt is tomorrow. Absent when there is none.
 - The telemetry id, masked to its first block (`3f6c9e2a…`). The full id is what
   ties an instance to its rows in the public archive, so the panel confirms
-  which one is in use without putting the whole value on screen. Absent while
-  the setting is off, because the server clears the id then.
+  which one is in use without putting the whole value on screen. Hidden while
+  the setting is off: the server keeps the id for a later re-enable, but an id
+  on screen next to "Off" would read as if something were still being sent.
 - The live payload, rendered by the shared `PayloadPreview` (`defaultOpen`
   here, folded away in the ask) straight from `GET /api/admin/telemetry/preview`
   with a Refresh button. It is refetched after every successful toggle, since
-  turning the setting on mints a new id and turning it off clears it.
+  the first switch-on mints the id the payload carries.
 - A link to `docs/systems/telemetry.md` on GitHub.
 
 Strings live in the `telemetry` namespace under `panel.*`. Registered as the

--- a/docs/systems/admin.md
+++ b/docs/systems/admin.md
@@ -349,7 +349,7 @@ GET /api/admin/telemetry/preview  → TelemetryPayload
 ```typescript
 interface TelemetryStatus {
   enabled: boolean | null;   // null = this instance was never asked
-  id: string | null;         // the random telemetry id, null while off
+  id: string | null;         // the random telemetry id, kept through off; null until the first enable
   lastDay: string | null;    // last UTC day successfully reported
   lastError: { day: string; status: number } | null;
 }

--- a/docs/systems/api.md
+++ b/docs/systems/api.md
@@ -308,10 +308,11 @@ home-origin only.
 `PUT` requires `enabled` to be a boolean and returns 400 `validation_failed` for
 anything else (`"yes"`, `1`, a missing field). It is the only writer of the four
 `instance_settings` telemetry columns; the general settings PATCH never touches
-them. Enabling mints a fresh `telemetry_id` and stamps today as the last
-reported day so the first ping goes out tomorrow; disabling clears the id.
-Enabling an instance that is already on changes nothing, so a repeated save
-never rotates the id.
+them. Enabling mints a `telemetry_id` if the instance never had one and stamps
+today as the last reported day so the first ping goes out tomorrow; disabling
+keeps the id and clears the last day and the last error, so a later re-enable
+reports under the same id. Enabling an instance that is already on changes
+nothing. The id is never rotated.
 
 `GET /preview` returns the exact payload a ping would carry right now, built by
 the same function the reporter uses. While reporting is off there is no id and

--- a/docs/systems/api.md
+++ b/docs/systems/api.md
@@ -315,9 +315,10 @@ reports under the same id. Enabling an instance that is already on changes
 nothing. The id is never rotated.
 
 `GET /preview` returns the exact payload a ping would carry right now, built by
-the same function the reporter uses. While reporting is off there is no id and
-none is minted to render a preview: `instance` is the literal string `preview`.
-The route writes nothing in either state.
+the same function the reporter uses. While reporting is off `instance` is the
+literal string `preview`: an instance that was never on has no id and none is
+minted to render a preview, and one that was on keeps its id but does not show
+it next to "Off". The route writes nothing in either state.
 
 See [telemetry.md](telemetry.md) for the field semantics, the rounding rule and
 what is never sent.

--- a/docs/systems/database.md
+++ b/docs/systems/database.md
@@ -389,7 +389,7 @@ The user INSERT, `usedCount` increment, and redemption row INSERT all run in a s
 | federationRelayTtlDays | integer NOT NULL | 30 | |
 | autoAcceptPeering | integer NOT NULL | 1 | When 0, `peer/accept` rejects unsolicited requests with 403 |
 | telemetryEnabled | integer | | Opt-in usage pings. null = never asked, 0 = off, 1 = on. |
-| telemetryId | text | | Random UUID, minted on every off-to-on transition and cleared on every transition to off. Never the federation `instanceId`. |
+| telemetryId | text | | Random UUID, minted on the first off-to-on transition and kept for the life of the install, through off. Never the federation `instanceId`. |
 | telemetryLastDay | text | | Last UTC day (`YYYY-MM-DD`) successfully reported. |
 | telemetryLastError | text | | JSON `{ day, status }` of the last failed attempt, null after a success. |
 | installedAt | integer | | First-boot timestamp (epoch ms). Backfilled by `ensureDefaults` from the oldest local non-deleted account, or `Date.now()` on a fresh DB, so it is non-null after boot and never overwritten. |

--- a/docs/systems/telemetry.md
+++ b/docs/systems/telemetry.md
@@ -146,9 +146,11 @@ of off-and-on cycles. This is what Home Assistant and Grafana do. Rotating it
 would make one instance look like two to the receiver, restart its
 two-days-in-thirty qualification, leave an orphaned short-lived row behind, and
 move its slot minute. Until 2026-09-08 switching off cleared the id and
-switching on minted a new one; an instance that toggled before then has one
-orphaned row per cycle in the receiver, which the eligibility rule ignores and
-the 90-day retention removes.
+switching on minted a new one, so an instance that toggled before then left
+the old id's rows behind in the receiver. An old id that was on for a single
+day never qualifies; one that was on for longer stays eligible for up to 30
+days after the switch and is counted twice in the network series for that
+window. The 90-day retention removes the rows either way.
 
 The on-to-on case matters too. Restamping the last day on a repeated save would
 skip that day's ping. A second click in the admin panel and a re-run of
@@ -222,15 +224,15 @@ backspace-server/<version>`, with a 10 second `AbortSignal.timeout`. Outcomes:
 | Result | What the instance does |
 |---|---|
 | 2xx | `telemetry_last_day = day`, the last error is cleared |
-| 410 | reporting is switched off and the id is cleared, with one info-level log line saying the service was retired |
+| 410 | reporting is switched off through the same transition as the admin panel (the id is kept), with one info-level log line saying the service was retired |
 | any other status | `telemetry_last_error = { day, status }`, a debug log line, retry tomorrow and never sooner |
 | a thrown request (network failure, timeout) | the same as any other status, recorded as status `0` |
 
 Neither the payload nor the receiver's answer is ever logged. The state is read
-again after the request resolves: an admin can switch reporting off, or off and
-on again, while a ping is in flight, and the bookkeeping fields belong to
-whichever id is current. A row that changed underneath the request keeps what
-the transition left it.
+again after the request resolves: an admin can switch reporting off while a
+ping is in flight, and a row that was switched off keeps what the transition
+left it. The id survives an off-and-on round trip, so a ping that comes back
+to a re-enabled row still belongs to it and its outcome is recorded.
 
 `TELEMETRY_ENDPOINT` overrides the receiver base URL, default
 `https://hello.backspacechat.com`. It exists for tests, for pointing an instance
@@ -261,10 +263,11 @@ instance is already on.
 
 `GET /preview` builds the real payload with the same `buildTelemetryPayload` the
 reporter uses, so the modal and the settings panel can never show a document
-different from the one that would be sent. While reporting is off there is no
-id, and minting one to render a preview would opt the instance in by opening a
-dialog: the literal string `preview` stands in as `instance` instead. The route
-writes nothing in either state.
+different from the one that would be sent. While reporting is off the literal
+string `preview` stands in as `instance`: an instance that was never on has no
+id, and minting one to render a preview would opt it in by opening a dialog; an
+instance that was on keeps its id but does not show it next to "Off". The
+route writes nothing in either state.
 
 The panel lives in Instance settings under "Say hi to Jannis", with the toggle,
 the last reported day, the last error if there is one, the masked id and the

--- a/docs/systems/telemetry.md
+++ b/docs/systems/telemetry.md
@@ -137,19 +137,25 @@ Transitions, all through `setTelemetryEnabled(sqlite, enabled, today)`:
 
 | From | To | What happens |
 |---|---|---|
-| `null` or off | on | a fresh `crypto.randomUUID()` is minted, `telemetry_last_day` is set to today, the last error is cleared |
+| `null` or off | on | a `crypto.randomUUID()` is minted if the row has no id yet, `telemetry_last_day` is set to today, the last error is cleared |
 | on | on | nothing at all |
-| any | off | the id, the last day and the last error are cleared |
+| any | off | the last day and the last error are cleared; the id is kept |
 
-The on-to-on case matters. Rotating the id on a repeated save would make one
-instance look like two to the receiver and reset its two-days-in-thirty
-qualification, and restamping the last day would skip that day's ping. A second
-click in the admin panel and a re-run of `install.sh` with `TELEMETRY=on` both
-take that path and both change nothing.
+The id is minted once and kept for the life of the install, through any number
+of off-and-on cycles. This is what Home Assistant and Grafana do. Rotating it
+would make one instance look like two to the receiver, restart its
+two-days-in-thirty qualification, leave an orphaned short-lived row behind, and
+move its slot minute. Until 2026-09-08 switching off cleared the id and
+switching on minted a new one; an instance that toggled before then has one
+orphaned row per cycle in the receiver, which the eligibility rule ignores and
+the 90-day retention removes.
+
+The on-to-on case matters too. Restamping the last day on a repeated save would
+skip that day's ping. A second click in the admin panel and a re-run of
+`install.sh` with `TELEMETRY=on` both take that path and both change nothing.
 
 Setting the last day to today on the way in is what makes the first ping go out
-tomorrow rather than within the minute. Turning off and on again mints a new id,
-so as far as the receiver can tell that is a new anonymous instance.
+tomorrow rather than within the minute.
 
 **Backup restore is a known limit.** A database restored onto two machines
 carries the same `telemetry_id`. The receiver upserts both onto one row per day,

--- a/install.sh
+++ b/install.sh
@@ -773,12 +773,12 @@ fi
 # TELEMETRY unset writes nothing to the database and leaves that ask intact.
 #
 # The transition mirrors setTelemetryEnabled() in
-# packages/server/src/telemetry/state.ts: turning on mints a fresh id and stamps
-# today (UTC) as the last reported day so the first ping goes out tomorrow;
-# turning on an instance that is already on changes nothing, because rotating
-# the id would make one instance look like two to the receiver and restamping
-# the day would skip that day's ping; turning off clears the id, the last day
-# and the last error. Nothing here can fail the install.
+# packages/server/src/telemetry/state.ts: turning on mints an id if the
+# instance never had one and stamps today (UTC) as the last reported day so
+# the first ping goes out tomorrow; turning on an instance that is already on
+# changes nothing, because restamping the day would skip that day's ping;
+# turning off keeps the id for a later re-enable and clears the last day and
+# the last error. Nothing here can fail the install.
 if [[ -n "${TELEMETRY:-}" ]]; then
   if [[ "$TELEMETRY" != "on" && "$TELEMETRY" != "off" ]]; then
     error "TELEMETRY must be 'on' or 'off' (got '${TELEMETRY}'). Leaving the usage ping unset."
@@ -797,10 +797,10 @@ if [[ -n "${TELEMETRY:-}" ]]; then
       const today = new Date().toISOString().slice(0, 10);
       let result;
       if (process.env.BS_TELEMETRY === "on") {
-        const changes = db.prepare("UPDATE instance_settings SET telemetry_enabled = 1, telemetry_id = ?, telemetry_last_day = ?, telemetry_last_error = NULL, updated_at = ? WHERE id = 1 AND (telemetry_enabled IS NULL OR telemetry_enabled = 0)").run(crypto.randomUUID(), today, now).changes;
+        const changes = db.prepare("UPDATE instance_settings SET telemetry_enabled = 1, telemetry_id = COALESCE(telemetry_id, ?), telemetry_last_day = ?, telemetry_last_error = NULL, updated_at = ? WHERE id = 1 AND (telemetry_enabled IS NULL OR telemetry_enabled = 0)").run(crypto.randomUUID(), today, now).changes;
         result = changes === 1 ? "on, the first ping goes out tomorrow" : "already on, left as it is";
       } else {
-        db.prepare("UPDATE instance_settings SET telemetry_enabled = 0, telemetry_id = NULL, telemetry_last_day = NULL, telemetry_last_error = NULL, updated_at = ? WHERE id = 1").run(now);
+        db.prepare("UPDATE instance_settings SET telemetry_enabled = 0, telemetry_last_day = NULL, telemetry_last_error = NULL, updated_at = ? WHERE id = 1").run(now);
         result = "off, nothing is sent";
       }
       db.close();

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -335,7 +335,7 @@ export const instanceSettings = sqliteTable('instance_settings', {
   autoAcceptPeering: integer('auto_accept_peering').notNull().default(1),
   /** null = never asked, 0 = off, 1 = on. */
   telemetryEnabled: integer('telemetry_enabled'),
-  /** Random UUID, minted on every off-to-on transition, cleared on off. Never the federation instance_id. */
+  /** Random UUID, minted on the first off-to-on transition and kept through off. Never the federation instance_id. */
   telemetryId: text('telemetry_id'),
   /** Last UTC day successfully reported. */
   telemetryLastDay: text('telemetry_last_day'),

--- a/packages/server/src/routes/adminTelemetry.test.ts
+++ b/packages/server/src/routes/adminTelemetry.test.ts
@@ -159,4 +159,12 @@ describe('admin telemetry routes', () => {
     expect(res.statusCode).toBe(200);
     expect((res.json() as { instance: string }).instance).toBe(id);
   });
+
+  it('previews under the placeholder again once switched off, although the id is kept', async () => {
+    await app.inject({ method: 'PUT', url: '/api/admin/telemetry', headers: AUTH, payload: { enabled: true } });
+    await app.inject({ method: 'PUT', url: '/api/admin/telemetry', headers: AUTH, payload: { enabled: false } });
+    expect(stateRow().telemetry_id).not.toBeNull();
+    const res = await app.inject({ method: 'GET', url: '/api/admin/telemetry/preview', headers: AUTH });
+    expect((res.json() as { instance: string }).instance).toBe('preview');
+  });
 });

--- a/packages/server/src/routes/adminTelemetry.test.ts
+++ b/packages/server/src/routes/adminTelemetry.test.ts
@@ -116,14 +116,18 @@ describe('admin telemetry routes', () => {
     expect(stateRow().telemetry_id).toBe(body.id);
   });
 
-  it('clears the id when switched off', async () => {
-    await app.inject({ method: 'PUT', url: '/api/admin/telemetry', headers: AUTH, payload: { enabled: true } });
+  it('keeps the id when switched off and reuses it when switched on again', async () => {
+    const on = await app.inject({ method: 'PUT', url: '/api/admin/telemetry', headers: AUTH, payload: { enabled: true } });
+    const id = (on.json() as { id: string }).id;
     const res = await app.inject({
       method: 'PUT', url: '/api/admin/telemetry', headers: AUTH, payload: { enabled: false },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ enabled: false, id: null, lastDay: null, lastError: null });
-    expect(stateRow()).toMatchObject({ telemetry_enabled: 0, telemetry_id: null });
+    expect(res.json()).toEqual({ enabled: false, id, lastDay: null, lastError: null });
+    expect(stateRow()).toMatchObject({ telemetry_enabled: 0, telemetry_id: id, telemetry_last_day: null });
+
+    const back = await app.inject({ method: 'PUT', url: '/api/admin/telemetry', headers: AUTH, payload: { enabled: true } });
+    expect(back.json()).toMatchObject({ enabled: true, id });
   });
 
   it('rejects a body without a boolean', async () => {

--- a/packages/server/src/routes/adminTelemetry.ts
+++ b/packages/server/src/routes/adminTelemetry.ts
@@ -45,9 +45,11 @@ export async function adminTelemetryRoutes(app: FastifyInstance): Promise<void> 
   // right now, built by the same function the reporter uses so the modal and
   // the settings panel can never show something the reporter would not send.
   //
-  // While reporting is off there is no id, and minting one here would opt the
-  // instance in by opening a preview. The literal "preview" stands in instead;
-  // nothing is written either way.
+  // While reporting is off the literal "preview" stands in for the id. An
+  // instance that has never been on has no id, and minting one here would opt
+  // it in by opening a preview; an instance that was on keeps its id for a
+  // later re-enable, but showing it next to "Off" would read as if something
+  // were still being sent. Nothing is written either way.
   app.get(
     '/api/admin/telemetry/preview',
     { preHandler: [authenticate, requireAdmin] },
@@ -55,7 +57,8 @@ export async function adminTelemetryRoutes(app: FastifyInstance): Promise<void> 
       const sqlite = getRawDb();
       const state = readTelemetryState(sqlite);
       const today = utcDay(new Date());
-      return buildTelemetryPayload(sqlite, payloadContextFromConfig(config, today, state.id ?? 'preview'));
+      const instance = state.enabled === true && state.id !== null ? state.id : 'preview';
+      return buildTelemetryPayload(sqlite, payloadContextFromConfig(config, today, instance));
     },
   );
 }

--- a/packages/server/src/telemetry/reporter.test.ts
+++ b/packages/server/src/telemetry/reporter.test.ts
@@ -101,7 +101,7 @@ describe('reporterTick', () => {
   it('turns itself off on 410', async () => {
     setTelemetryEnabled(db, true, '2026-09-06');
     expect(await reporterTick(deps('2026-09-08T23:59:59Z', 410))).toBe('retired');
-    expect(readTelemetryState(db)).toMatchObject({ enabled: false, id: null });
+    expect(readTelemetryState(db)).toMatchObject({ enabled: false, lastDay: null, lastError: null });
     expect(log.info).toHaveBeenCalledTimes(1);
   });
 
@@ -134,18 +134,26 @@ describe('reporterTick', () => {
       return new Response(null, { status: 204 });
     });
     expect(await reporterTick(d)).toBe('skipped');
-    expect(readTelemetryState(db)).toEqual({ enabled: false, id: null, lastDay: null, lastError: null });
+    expect(readTelemetryState(db)).toMatchObject({ enabled: false, lastDay: null, lastError: null });
+    expect(readTelemetryState(db).id).not.toBeNull();
   });
 
-  it('records nothing when telemetry is re-enabled under a new id while the ping is in flight', async () => {
-    setTelemetryEnabled(db, true, '2026-09-06');
+  it('records the outcome when telemetry is switched off and on again while the ping is in flight', async () => {
+    // The id survives the round trip, so the row the ping came from is still
+    // the current row and its bookkeeping applies.
+    const id = setTelemetryEnabled(db, true, '2026-09-06').id;
     const d = deps('2026-09-08T23:59:59Z');
     (d.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
       setTelemetryEnabled(db, false, '2026-09-08');
       setTelemetryEnabled(db, true, '2026-09-08');
       return new Response(null, { status: 503 });
     });
-    expect(await reporterTick(d)).toBe('skipped');
-    expect(readTelemetryState(db)).toMatchObject({ enabled: true, lastDay: '2026-09-08', lastError: null });
+    expect(await reporterTick(d)).toBe('failed');
+    expect(readTelemetryState(db)).toMatchObject({
+      enabled: true,
+      id,
+      lastDay: '2026-09-08',
+      lastError: { day: '2026-09-08', status: 503 },
+    });
   });
 });

--- a/packages/server/src/telemetry/reporter.ts
+++ b/packages/server/src/telemetry/reporter.ts
@@ -45,7 +45,12 @@ function pingUrl(endpoint: string): string {
  * admin can switch reporting off while a ping is in flight, and a row that
  * was switched off keeps what the transition left it. The id survives an
  * off-and-on round trip, so a ping that comes back to a re-enabled row still
- * belongs to it and is recorded.
+ * belongs to it and is recorded; the id comparison below only fires for a
+ * database edited or restored by hand. If that round trip crosses midnight
+ * the success overwrites the re-enable's stamp with the ping's own day, so one
+ * ping goes out at the next slot rather than the one after. Do not "fix" that
+ * by comparing the last day: it would skip a day for an instance that was on
+ * the whole time bar a second.
  *
  * Neither the payload nor the receiver's answer is ever logged.
  */

--- a/packages/server/src/telemetry/reporter.ts
+++ b/packages/server/src/telemetry/reporter.ts
@@ -42,9 +42,10 @@ function pingUrl(endpoint: string): string {
  * made the request.
  *
  * The state is read at the start and again after the request resolves: an
- * admin can switch reporting off, or off and on again, while a ping is in
- * flight, and the bookkeeping fields belong to whichever id is current. A row
- * that changed underneath the request keeps what the transition left it.
+ * admin can switch reporting off while a ping is in flight, and a row that
+ * was switched off keeps what the transition left it. The id survives an
+ * off-and-on round trip, so a ping that comes back to a re-enabled row still
+ * belongs to it and is recorded.
  *
  * Neither the payload nor the receiver's answer is ever logged.
  */

--- a/packages/server/src/telemetry/state.test.ts
+++ b/packages/server/src/telemetry/state.test.ts
@@ -43,11 +43,20 @@ describe('telemetry state', () => {
     expect(s.lastError).toBeNull();
   });
 
-  it('clears the id on disable and mints a new one on re-enable', () => {
+  it('keeps the id across disable and re-enable', () => {
     const first = setTelemetryEnabled(db, true, '2026-09-06').id;
-    expect(setTelemetryEnabled(db, false, '2026-09-06')).toMatchObject({ enabled: false, id: null });
-    const second = setTelemetryEnabled(db, true, '2026-09-07').id;
-    expect(second).not.toBe(first);
+    expect(setTelemetryEnabled(db, false, '2026-09-06')).toMatchObject({ enabled: false, id: first });
+    const second = setTelemetryEnabled(db, true, '2026-09-07');
+    expect(second.id).toBe(first);
+    expect(second.lastDay).toBe('2026-09-07');
+  });
+
+  it('mints an id only when there is none', () => {
+    db.prepare('UPDATE instance_settings SET telemetry_enabled = 0, telemetry_id = NULL WHERE id = 1').run();
+    const first = setTelemetryEnabled(db, true, '2026-09-06').id;
+    expect(first).toMatch(/^[0-9a-f-]{36}$/);
+    expect(setTelemetryEnabled(db, false, '2026-09-06').id).toBe(first);
+    expect(setTelemetryEnabled(db, true, '2026-09-07').id).toBe(first);
   });
 
   it('keeps the id and last day when enable is called while already enabled', () => {
@@ -67,9 +76,10 @@ describe('telemetry state', () => {
   it('clears the last day and the last error on disable', () => {
     setTelemetryEnabled(db, true, '2026-09-06');
     recordTelemetryFailure(db, '2026-09-07', 503);
+    const id = readTelemetryState(db).id;
     expect(setTelemetryEnabled(db, false, '2026-09-07')).toEqual({
       enabled: false,
-      id: null,
+      id,
       lastDay: null,
       lastError: null,
     });

--- a/packages/server/src/telemetry/state.ts
+++ b/packages/server/src/telemetry/state.ts
@@ -38,16 +38,19 @@ export function readTelemetryState(sqlite: Database.Database): TelemetryStatus {
 }
 
 /**
- * The single on/off transition. An off-to-on transition mints a fresh id and
- * stamps today as the last reported day so the first ping goes out tomorrow at
- * the slot, never within the minute. Turning off clears the id: a later
- * re-enable is a new anonymous instance as far as the receiver can tell.
+ * The single on/off transition. The id is minted once, the first time the
+ * instance is switched on, and kept for the life of the install: switching off
+ * stops the pings and clears the bookkeeping, switching on again reuses the
+ * same id. A stable id is what Home Assistant and Grafana do, and it keeps a
+ * re-enabled instance from looking like a new one to the receiver, restarting
+ * its two-days-in-thirty qualification and moving its slot minute.
  *
- * Enabling an instance that is already on changes nothing. Rotating the id
- * there would make one instance look like two to the receiver and reset its
- * two-days-in-thirty qualification, and restamping the last day would skip
- * that day's ping. A repeated admin save and a re-run of install.sh with
- * TELEMETRY=on both take this path.
+ * Switching on stamps today as the last reported day so the first ping goes
+ * out tomorrow at the slot, never within the minute.
+ *
+ * Enabling an instance that is already on changes nothing. Restamping the
+ * last day there would skip that day's ping. A repeated admin save and a
+ * re-run of install.sh with TELEMETRY=on both take this path.
  */
 export function setTelemetryEnabled(
   sqlite: Database.Database,
@@ -58,11 +61,11 @@ export function setTelemetryEnabled(
   if (enabled && current.enabled === true) return current;
   if (enabled) {
     sqlite.prepare(
-      'UPDATE instance_settings SET telemetry_enabled = 1, telemetry_id = ?, telemetry_last_day = ?, telemetry_last_error = NULL, updated_at = ? WHERE id = 1',
+      'UPDATE instance_settings SET telemetry_enabled = 1, telemetry_id = COALESCE(telemetry_id, ?), telemetry_last_day = ?, telemetry_last_error = NULL, updated_at = ? WHERE id = 1',
     ).run(crypto.randomUUID(), today, Date.now());
   } else {
     sqlite.prepare(
-      'UPDATE instance_settings SET telemetry_enabled = 0, telemetry_id = NULL, telemetry_last_day = NULL, telemetry_last_error = NULL, updated_at = ? WHERE id = 1',
+      'UPDATE instance_settings SET telemetry_enabled = 0, telemetry_last_day = NULL, telemetry_last_error = NULL, updated_at = ? WHERE id = 1',
     ).run(Date.now());
   }
   return readTelemetryState(sqlite);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1494,6 +1494,6 @@ export interface TelemetryStatus {
   enabled: boolean | null;
   lastDay: string | null;
   lastError: { day: string; status: number } | null;
-  /** The random telemetry id, or null while off. */
+  /** The random telemetry id, minted on the first enable and kept through off; null until then. */
   id: string | null;
 }

--- a/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.test.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.test.tsx
@@ -34,6 +34,7 @@ describe('TelemetryPanel', () => {
     render(<TelemetryPanel />);
     expect(await screen.findByText('Off')).toBeInTheDocument();
     expect(screen.queryByText(/3f6c9e2a/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/"instance": "preview"/)).toBeInTheDocument();
   });
 
   it('toggles through the API', async () => {

--- a/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.test.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.test.tsx
@@ -29,6 +29,13 @@ describe('TelemetryPanel', () => {
     expect(screen.getByText(/Last hello sent on/)).toBeInTheDocument();
   });
 
+  it('hides the id while off even though the server keeps it', async () => {
+    vi.spyOn(api.admin.telemetry, 'get').mockResolvedValue({ ...off, id: on.id });
+    render(<TelemetryPanel />);
+    expect(await screen.findByText('Off')).toBeInTheDocument();
+    expect(screen.queryByText(/3f6c9e2a/)).not.toBeInTheDocument();
+  });
+
   it('toggles through the API', async () => {
     vi.spyOn(api.admin.telemetry, 'get').mockResolvedValue(off);
     const set = vi.spyOn(api.admin.telemetry, 'set').mockResolvedValue(on);

--- a/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.tsx
@@ -103,8 +103,8 @@ export function TelemetryPanel() {
     setSaving(true);
     try {
       await setTelemetryEnabled(next);
-      // The first switch-on mints the id, so the payload on screen would
-      // otherwise still show the placeholder for an instance that now has one.
+      // The preview carries the real id while on and the placeholder while
+      // off, so the payload on screen would otherwise name the wrong one.
       await loadPreview();
     } catch (err) {
       // The store only keeps what the server returned, so the switch stays

--- a/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.tsx
+++ b/packages/web/src/components/modals/instanceSettingsPanels/TelemetryPanel.tsx
@@ -103,8 +103,8 @@ export function TelemetryPanel() {
     setSaving(true);
     try {
       await setTelemetryEnabled(next);
-      // Turning it on mints a new id and turning it off clears it, so the
-      // payload on screen would otherwise name an id that no longer applies.
+      // The first switch-on mints the id, so the payload on screen would
+      // otherwise still show the placeholder for an instance that now has one.
       await loadPreview();
     } catch (err) {
       // The store only keeps what the server returned, so the switch stays
@@ -193,7 +193,7 @@ export function TelemetryPanel() {
             })}
           </div>
         )}
-        {telemetry.id !== null && (
+        {telemetry.enabled === true && telemetry.id !== null && (
           <div className="text-xs text-txt-tertiary">
             {t('telemetry:panel.status.id', { id: maskId(telemetry.id) })}
           </div>


### PR DESCRIPTION
## What

Telemetry's instance id is now minted once, on the first enable, and kept for the life of the install. Switching reporting off clears the last reported day and the last error but keeps the id. Switching it on again reports under the same id.

Before this, off cleared the id and on minted a new one, so a re-enabled instance looked like a new install to the receiver: a fresh two-days-in-thirty clock, an orphaned row under the old id, and a moved slot minute. That is exactly what happened on zwiss on 2026-09-07 and why D1 holds two ids for one server.

## Why a stable id

Every comparable project keeps one: Home Assistant (uuid4 on first send, never cleared on disable), Grafana (random id stored once in the kv store), Nextcloud (reuses the core instanceid), Synapse (sends the server name itself), GitLab (uuid plus hostname). A random id with no link to the domain is anonymous enough on its own.

## Changes

- `telemetry/state.ts`: `COALESCE(telemetry_id, ?)` on enable, no id clear on disable. The reporter's in-flight guard still catches a plain switch-off; an off-and-on round trip now keeps the row current, so the ping's outcome is recorded.
- `install.sh`: the unattended `TELEMETRY=on|off` path mirrors the same SQL.
- Admin panel: the masked id is shown only while reporting is on, so an id next to "Off" does not read as if something were still being sent.
- Docs: telemetry.md transition table and rationale, api.md, admin.md.

## Tests

Server: state, reporter and admin route suites updated for the new transitions (53 tests). Web: panel suite gains an off-with-id case (11 tests). Both typecheck clean.

## Receiver

No change needed. Rows already written under the old ids on zwiss stay as an orphan; single-day instances never qualify for a published figure and rows age out after 90 days.