### PR TITLE
docs: point the update-indicator plan at a spec that exists

### DIFF
--- a/docs/superpowers/plans/2026-09-08-instance-update-indicator.md
+++ b/docs/superpowers/plans/2026-09-08-instance-update-indicator.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** React 18, Zustand 5, TypeScript strict, Tailwind 3, i18next, Vitest + @testing-library/react.
 
-**Spec:** `/private/tmp/claude-501/-Users-jbraun-backspace-public/5422ded3-2069-4358-84fb-0611dafbef36/scratchpad/update-badge-design.md` (revised after code review). Copy it into the worktree if the scratchpad is gone; the plan restates every decision it depends on.
+**Spec:** none separate. The design was settled in review on the pull request that carried this work (#166) and folded into this document, which restates every decision it depends on. Unlike the other plans here, there is no `docs/superpowers/specs/` file to read alongside it.
 
 ## Global Constraints
 


### PR DESCRIPTION
The Spec line in `2026-09-08-instance-update-indicator.md` named a path inside a session scratchpad. It is meaningless to anyone reading the repo, and it carried a session id into public history.

Every other plan in that directory points at a committed `docs/superpowers/specs/` file. This work never had one: the design was settled in review on #166 and folded into the plan, which restates every decision it depends on. The line now says that rather than naming a directory nobody else can open.

Docs only, no code touched.

Two other plans carry the same kind of dead scratchpad path (`2026-09-03-plan-f-evidence-dast-docs.md` and `2026-09-04-localization-foundation.md`). Left alone here rather than widening a one-line fix; happy to do them separately.