### PR TITLE
chore: release 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backspace",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Open, self-hosted communication platform \u2014 text, voice, video, and federation",
   "license": "AGPL-3.0-only",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/desktop",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Backspace",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/shared",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/web",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/metrics/package.json
+++ b/scripts/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/metrics",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/pr-triage/package.json
+++ b/scripts/pr-triage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/pr-triage",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",

--- a/scripts/telemetry-receiver/package.json
+++ b/scripts/telemetry-receiver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backspace/telemetry-receiver",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "author": "Jannis Braun",


### PR DESCRIPTION
Version bump only. Tags `v1.2.2` after merge.