### PR TITLE
feat(design): material tier, primary call to action, modal and toast chrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Full spec: `docs/systems/design-system.md`
 
 No resting border — sunken `surface-input` background provides differentiation.
 
-**Glass material:** `backdrop-filter: blur(20px) saturate(120%)`, `rgba(20,20,26,0.52)`, border `rgba(255,255,255,0.07)`. Modal backdrops: `bg-black/50`.
+**Glass material:** `backdrop-filter: blur(20px) saturate(120%)`, `rgba(20,20,26,0.52)`, border `rgba(255,255,255,0.07)`. Modal backdrops: `.modal-scrim` (a vignette, not flat black). Floating chrome and the primary button use the material tier (`.mat-*`, `.cta-primary`, `.toast-lit`); see design-system.md "Material Tier".
 
 ---
 

--- a/docs/superpowers/specs/2026-09-09-ui-soul-pass-scene-bible.md
+++ b/docs/superpowers/specs/2026-09-09-ui-soul-pass-scene-bible.md
@@ -1,0 +1,304 @@
+# UI soul pass: scene bible
+
+Status: rows approved 2026-09-09. Batch 0 (rows 0, 4, 5, 9, 11) is built; scene batches follow.
+
+This is the document that lets many independent agents produce one product.
+It is not a token list; Aether Drift already has tokens. It says what each
+surface depicts, what light every layer obeys, how much may move, and which
+of two treatments a surface gets. The reference for the bar is
+`packages/web/src/components/telemetry/answers/HiButton.tsx` and
+`SilenceButton.tsx`, with their co-located CSS.
+
+## 1. The world
+
+Backspace already has a world. It was built for the telemetry ask and it is
+good: a small crewed craft with a warm cabin light, holding station in a
+quiet, warm-dark space; a pilot who waves; a plotted course to a new world;
+and, on the far side, a derelict plate that stopped transmitting. The app's
+own name is a spacecraft's habitable volume.
+
+Every scene in this pass is a place on that same journey. The rule for
+choosing a subject is the one that made the two buttons work: **the scene
+depicts what the surface is for.** The empty voice channel is a rendezvous point with nobody moored yet, and
+pressing Join is the departure. Add friend is a hail going out to one specific person. The login
+card is the airlock you come home through. Never "put space behind it". A
+nebula pasted on everything becomes wallpaper in a week.
+
+What is *not* in this world: characters that emote at the user, confetti,
+purple corporate glow, anything that reads as a "landing page hero".
+
+## 2. Nori
+
+There is already a mascot. `Mascot.tsx` draws a mint blob with two eyes and
+a blush in four moods (idle, sleeping, excited, lonely), animated by a
+622-line Web Animations hook, and English copy names it: "No pending
+requests, Nori is napping." It appears on five empty states today (friends
+online/all/pending/activity, the DM list) and twice on mobile.
+
+Nori and the ship are currently two different visual languages. The blob is
+lit by a flat radial gradient with near-black eyes; the ship is lit by one
+key light and shades toward its own hue. One of these has to give, and it is
+the blob's *rendering*, not the character.
+
+**Proposal: Nori is the crew.** Same silhouette, same moods, same hook, but
+redrawn under the scene's light rule (section 4): key light from upper
+left, shade toward lavender, eyes in `pilot` not `#0d0d12`, a proper contact
+shadow instead of a grey ellipse. Nori then sits inside scenes as the
+someone who is there when no one else is: at the window when nobody is
+online, asleep at the console when there are no pending requests, at the
+hailing desk when there are no friends yet. The porthole pilot in the
+telemetry scene stays a silhouette; the two are not the same drawing at the
+same scale and do not need to be.
+
+**Decided 2026-09-09: Nori stays**, on the condition that the redraw and the
+animations fit the world. The animation hook finds parts by attribute only
+(`data-mascot`, `data-eye`, `data-side`, the sleep z's, the particles), so a
+redraw that keeps those attributes keeps every mood working. "Fit" means
+three things, and they are row 12's brief:
+
+- **Light.** Highlight and shadow placed where the shared key light puts
+  them, upper left; the body shades toward lavender on the lower right, not
+  toward a darker mint; the grey ellipse becomes a cast shadow that stays
+  under the body while it breathes.
+- **Eyes.** The near-black eyes become the palette's `pilot`, with the
+  catchlight moved to the upper left to agree with the key.
+- **Motion.** The idle breath runs at 3.8 seconds today, under the six-second
+  floor; it slows to the floor, and the wiggle and look-around periods are
+  checked against the budget. No new animation is added; timings are the
+  only thing in the hook that changes.
+
+## 3. Palette
+
+One palette, extending `packages/web/src/components/telemetry/scene/palette.ts`.
+Every value is derived from an Aether Drift token in `globals.css`; nothing
+here is pure black or white. The existing eleven entries stay as they are.
+New entries, with the token they come from:
+
+| Key | From | Role |
+|---|---|---|
+| `deck` | `--bg-channel` warmed one step | Interior floor and bulkheads of any room scene |
+| `bulkhead` | `--bg-elevated` | The lit face of interior structure |
+| `console` | `--accent-sky` at low alpha | Standby lights on instruments, the colour of "ready" |
+| `seat` | `hullShade` (lavender toward primary) | Anything turned away from the key inside a room |
+| `signal` | `--accent-mint` | An outgoing or live signal, a plotted course, a friend who is here |
+| `hail` | `--accent-peach` toward `--accent-coral` | An incoming call, someone wanting attention |
+| `warn` | `--accent-rose` at the derelict's saturation | A beacon that has gone dark, an invalid invite |
+| `dust` | `--sil-rime` (from SilenceButton) | Frost, motes, the cold end of the range |
+
+`SilenceButton` currently defines its cold palette as private custom
+properties. Batch 0 lifts them into this file so the derelict vocabulary is
+reusable (dead beacons, expired connections) without a second definition.
+
+## 4. The light rule
+
+**One key light, above and to the left, outside the frame, warm white.**
+Everything in every scene obeys it. It picks out the top-left of a rim, the
+top-left of a hull, the top-left crescent of a world, the upper edge of a
+seat back. What it does not reach falls to the object's own hue turned
+toward lavender, never toward black. A green thing in shadow is
+`hullShade`, not olive.
+
+Inside a room the key comes through the window, still upper left. There is
+no fill light. Depth is done with falloff and with atmosphere caught in the
+glass, not with a second light.
+
+**Emitters** are the only things allowed to be brighter than the key:
+cabin and console lights (amber, `window` / `windowLit`), signals (mint),
+hails (peach to coral). An emitter blooms outward from itself with one
+shared blur, the way the craft's plume and porthole do. Nothing else glows.
+
+The derelict is the exception that proves it: no local light at all, only
+starlight from the same upper left, so everything there is matte and the
+depth comes from texture.
+
+## 5. Motion budget
+
+Slow and expensive, never busy. The measure is `HiButton`: several infinite
+animations, all long period, all transform or opacity, and it still reads as
+still.
+
+At rest, per screen:
+
+- **Scene tier**: at most one scene visible per screen, with at most three
+  infinite animations, every period six seconds or longer, transform and
+  opacity only. No animated blur, no animated `backdrop-filter`, no animated
+  gradients. Motion that is a story beat (a wave, a ping, a sheen) spends
+  most of its cycle not happening.
+- **Material tier**: nothing moves at rest. The sheen crosses only on hover
+  and only once per few seconds.
+- **Reduced motion** freezes every scene into a still frame chosen because
+  it is the best frame, and strips nothing. `SilenceButton`'s block is the
+  model: the ping caught a third of the way across, already fading.
+- **Raspberry Pi and mobile**: a scene may use at most two `backdrop-filter`
+  layers and at most two SVG filters. Everything else is gradients and
+  masks. If a workbench screenshot takes longer than a second to settle on
+  the Pi, the scene is over budget.
+
+On interaction the budget doubles for the duration of the interaction and
+returns to rest afterwards.
+
+## 6. The two tiers
+
+**Material tier.** Cheap, reusable, extracted from `HiButton` into
+`globals.css` (edited by the lead only, never by an agent). Five layers,
+each a class that can be stacked on any floating surface:
+
+| Class | What it is | Extracted from |
+|---|---|---|
+| `.mat-rim` | The hairline that turns hue: warm white where the key lands, mint along the top, near nothing lower right, lavender coming back. A masked gradient border, so the hue can turn. | `.hi-button__rim` |
+| `.mat-gloss` | The resting specular: one sheet of glass over the surface, caught at the top-left corner. | `.hi-button__gloss` |
+| `.mat-aura` | The light the surface throws onto what is around it. Hover and focus only. | `.hi-button__aura` |
+| `.mat-scrim` | A photographic vignette that seats a scene in its frame by taking light away, and a soft well under a label. | `.hi-button__scrim` |
+| `.mat-sheen` | The travelling specular. Parked off-frame, crosses once on hover. | `.hi-button__sheen` |
+
+All five read one `--lift` channel (0 at rest, 1 on hover and focus) and one
+`--push` channel, so a host sets two numbers and every layer moves together.
+Modals, popovers, toasts, and the primary call to action get material and
+nothing else. Material never contains a subject.
+
+**Scene tier.** Bespoke and expensive: a component with a co-located CSS
+file, one subject, layered like the reference (void, depth, subject, scrim,
+gloss, rim, label), one agent, four or more iterations. Roughly one scene
+per screen. A scene may use the material classes for its frame.
+
+## 7. Where everything lives: the inventory
+
+From a read-only tour of a live instance at desktop, narrow desktop, mobile
+and reduced-motion widths on 2026-09-09. Screenshots are session material
+and are not in the repo. "Dead space" is the fraction of the surface with
+nothing in it.
+
+| Surface | File | What is there now | Dead space | Seen |
+|---|---|---|---|---|
+| Login | `auth/LoginPage.tsx` | A card on a flat base with a 6% radial tint at the top | ~85% | Every session |
+| Register | `auth/RegisterPage.tsx` | Same card, longer | ~75% | Once, first impression |
+| Join / invalid invite | `JoinPage.tsx` | Same card; a rose warning glyph in a circle | ~85% | Every invite link |
+| Voice channel, nobody in it | `layout/MainContent.tsx` lines 405 to 436 | Channel name, one line of copy, a pill button, a purple radial pulse | ~90% | Every voice channel click |
+| Friends: online, empty | `chat/FriendsPage.tsx` line 193 | Nori idle, one line | ~90% | Every open of the home tab when nobody is on |
+| Friends: all, empty | line 213 | Nori lonely, one line | ~90% | New users |
+| Friends: pending, empty | line 233 | Nori sleeping, one line | ~90% | Often |
+| Friends: activity, empty | line 307 | Nori sleeping, one line | ~60% | Often |
+| DM list, empty | `layout/ChannelSidebar.tsx` line 514 | Nori sleeping, one line | sidebar column | New users |
+| Mobile DM list / spaces list, empty | `MobileDmsScreen.tsx` 302, `MobileSpacesScreen.tsx` 905 | Nori | full screen | New mobile users |
+| Channel welcome header | `chat/MessageList.tsx` `WelcomeHeader` | A hash in a grey disc, a title, a line, a rule | fixed block | Every new channel, every scroll to top |
+| DM and group welcome header | same | Avatar or stack, title, a line, two buttons | fixed block | Every DM top |
+| Explore, empty | `chat/ExplorePage.tsx` line 132 | Nori lonely | ~90% | Instances with no public spaces |
+| Explore cards without a banner | same | Flat two-stop gradient | card top | Most cards |
+| Modal chrome | `ui/Modal.tsx`, `.glass-modal` | Glass with one uniform border | frame | Every modal |
+| Primary call to action | 30+ inline class strings | Flat `accent-primary` fill, opacity hover | button | Everywhere |
+| Incoming call | `voice/IncomingCallModal.tsx` | Glass modal, `call-refraction`, ripple keyframes exist | modal | Every call |
+| Toasts, update toasts | `ui/ToastContainer.tsx`, `UpdateToast.tsx`, `InstanceUpdateToast.tsx` | `glass-pill` with a coloured left border | pill | Often |
+| Search popover, empty | `chat/SearchPopover.tsx` | One line of copy in a glass panel | ~70% | Every search open |
+| Confirm dialog | `ui/ConfirmDialog.tsx` | Modal chrome | modal | Destructive actions |
+| Profile popout and modal | `ui/UserProfilePopout.tsx`, `modals/UserProfileModal.tsx` | User banner or flat colour | banner | Often |
+| Mobile You screen | `layout/MobileYouScreen.tsx` | Profile card, four rows, log out | lower 50% | Every mobile session |
+| Mobile settings list | `layout/MobileSettingsScreen.tsx` | Six rows | lower 60% | Often |
+| Boot skeleton | `layout/AppLayout.tsx` | Skeleton bars | n/a | Every load |
+| Space strip buttons | `layout/SpaceSidebar.tsx` | Three round buttons | strip | Always |
+| Settings panels | `modals/settingsPanels/*`, `instanceSettingsPanels/*` | Forms | varies | Settings |
+| Voice, connected | `voice/VoiceGrid.tsx`, `VoiceControlBar.tsx` | LiveKit tiles and controls | n/a | Voice |
+| Channel sidebar, member list, message list, composer, space strip | Tier 2 files | Dense, stateful | n/a | Always |
+
+Two things the tour found that are not design work: the home sidebar shows
+two greyed "Coming Soon" rows in production, and the friends page has an
+"Activity" tab in the code that did not render on the tour. Both are for
+Jannis to decide, not for a design agent.
+
+## 8. Feasibility, by tier
+
+**Tier 1, swarmable now.** Self-contained or cheaply extractable, low state,
+generous canvas: the auth backdrop (three pages share one 6% gradient div
+that becomes one component), the voice-empty panel (a 30-line JSX block in
+`MainContent` that reads only the channel name and a join handler), the five
+friends and DM empty states (pure presentation blocks inside store-heavy
+files, extractable into one component with variants), the explore empty
+state and card banners, modal chrome, the primary call to action, the
+incoming call modal (148 lines, two stores, all state is "ringing or not"),
+toasts, the search popover empty state, the confirm dialog.
+
+**Tier 2, needs a human-directed plan.** The welcome header lives inside
+`MessageList.tsx`, whose scroll model and position memory are documented in
+`docs/systems/message-list.md`. The visual part is extractable as a
+presentational component, but its rendered height is part of the scroll
+contract and must stay static. `ChannelSidebar`, `SpaceSidebar`,
+`MessageInput`, the mobile screen stack, and everything connected to
+LiveKit stay off the swarm.
+
+**Tier 3, leave alone.** Settings panels, the boot skeleton, the member
+list, profile banners (user content dominates), the mobile You and settings
+lists (a scene under a menu is wallpaper), the space strip buttons (too
+small for a subject; material hover at most).
+
+## 9. Subjects, ranked
+
+Rank is visibility times dead space times feasibility. Effort: S is a
+material-only change or one small component; M is one agent, one scene,
+four or more iterations; L is a scene that needs a primitive or a Tier 2
+extraction first. Every scene ships with its own workbench page.
+
+| # | Surface | Current state | Proposed subject | Tier | Effort | Depends on |
+|---|---|---|---|---|---|---|
+| 0 | Palette, material classes, workbench harness | Two buttons carry everything privately | Extract the five material layers into `globals.css`, extend the palette, write the shared workbench frame (`.is-hover`, `.is-focus`, 3x, real surround) | material | M, lead only | nothing |
+| 1 | Voice channel, nobody in it | Name, line, pill, purple pulse | **The rendezvous, and nobody is moored yet.** Open space, the porthole of the telemetry answer at panel scale: the craft holds station left with its cabin lit; low right a large world on its night side, and in orbit above its lit limb a small rendezvous beacon with its docking light on and nothing moored to it. A dotted course runs from the ship, behind the channel name, to the beacon, and Join Voice sits on that line as the material call to action. Hover throttles the plume and brightens the beacon; press is the launch, and the voice grid that replaces the panel is the arrival. Ship anchored left, world anchored lower right, title and button centred, so every panel width reads as the same porthole. Desktop only; mobile opens voice channels as chat. | scene | M | 0 |
+| 2 | Login, register, join, invalid invite | Card on flat black | **Docking.** One `AuthBackdrop` behind all three cards: the slow approach to a station, its running lights strung along the lower edge of the frame, one large soft world low right, the card itself given the material rim and gloss so it reads as the airlock window. Register adds a second running light coming on. Invalid invite reuses the derelict vocabulary: the beacon you followed has gone dark. | scene + material | M | 0 |
+| 3 | Friends and DM empty states (five sites plus two mobile) | Nori and one line, five times | **The crew quarters.** One `CrewEmptyState` with a variant per mood. Nobody online: the quarters with lights dimmed, Nori at the window. No friends yet: the hailing desk, no contacts plotted. No pending: Nori asleep at the console, screen on standby (the copy already says this). No activity: the ship at cruise, nothing on the board. | scene | L | 0, Nori decision |
+| 4 | Primary call to action | 30+ flat inline fills | **Material only.** A `.cta-primary` class with rim, gloss, aura on hover and a scrim under the label; the eight highest-visibility sites swapped (Log In, Continue, Join Voice, Create, Add Friend, Join Space, Message, Save). Quieter than the reference: no stars, no scene. | material | M, lead only | 0 |
+| 5 | Modal chrome | Glass, one uniform border | **Material only.** `.glass-modal` gains the turning rim and the top-left gloss; the backdrop scrim becomes a vignette rather than a flat 50% black. Every modal inherits it. | material | S, lead only | 0 |
+| 6 | Incoming call | Glass modal with ripples | **A hail.** The comm panel lighting up: the caller's avatar is the signal source, rings leave it at the ripple's existing cadence, the panel's console lights come up from standby to `hail`. Accept is the material call to action in `signal`; decline is a quiet material button. Workbench only, since a live call cannot be surveyed read-only. | scene | M | 0, 5 |
+| 7 | Channel, DM and group welcome header | Hash in a disc, title, rule | **First light.** A presentational `WelcomeHero` extracted from `MessageList`, same height as now: the hash or the avatar sits in a porthole with the key light catching its top-left rim and a thin plotted line running out to the right where the conversation will go. DM variant keeps the avatar; group keeps the stack. | scene | L | 0, message-list plan |
+| 8 | Explore | Nori lonely; flat card gradients | **The charts.** Empty state: a star chart with nothing plotted yet and a faint grid, the compass glyph the page already uses becoming the chart's rose. Cards without a banner get the material scrim and rim so a two-stop gradient stops reading as a placeholder. | scene + material | M | 0, Nori decision |
+| 9 | Toasts and update toasts | Glass pill, coloured left border | **Material only.** Rim and an edge light in the toast's own colour, so a success toast is lit mint from the left rather than bordered by it. | material | S | 0 |
+| 10 | Search popover, empty | One line in a glass panel | **Scanning.** A short sweep line in the panel that runs once when it opens and parks; the copy stays. | scene, small | S | 0 |
+| 11 | Confirm dialog | Modal chrome | Inherits 5; the danger variant's confirm gets the derelict's cold rim instead of the warm one. | material | S | 5 |
+| 12 | Nori redraw | Flat radial blob, near-black eyes | Same silhouette and moods, relit under the light rule; the hook is untouched. | primitive | M | Jannis |
+
+Not proposed: mobile You and settings lists, boot skeleton, settings
+panels, space strip, profile banners, anything connected to voice while
+connected.
+
+## 10. Batches
+
+Dependencies are real. Material first, because accent work reuses it.
+Palette and bible before any scene. Harness before any agent. Primitives
+before the surfaces that compose them. Within a batch every agent owns only
+its component file and its co-located CSS, and nothing shared.
+
+| Batch | Contents | Who | PR |
+|---|---|---|---|
+| 0 | Rows 0, 4, 5, 9, 11: palette, material classes, `.cta-primary`, modal and toast chrome, the workbench frame, this bible committed | lead | one |
+| 1 | Rows 1, 2, 6 in parallel, plus 12 if approved | three or four agents | one |
+| 2 | Rows 3, 8 in parallel (both need Nori settled and the `CrewEmptyState` contract), row 10 | three agents | one |
+| 3 | Row 7, after a written plan against `message-list.md` | one agent, lead-directed | one |
+
+Each batch closes with the lead running `pnpm typecheck`,
+`node scripts/check-i18n.mjs`, `pnpm --filter @backspace/web test`, and a
+side-by-side look at every workbench screenshot for drift.
+
+## 11. The agent brief, fixed parts
+
+Every dispatched agent receives, verbatim: this document's sections 1, 3, 4,
+5 and 6; its own row from section 9 expanded into a subject, a mood and a
+story; the workbench URL; the screenshot recipe with a unique
+`--user-data-dir` and the warning that `--virtual-time-budget` never
+settles; the four-iteration minimum with a written critique naming the
+single weakest thing after every screenshot; the anti-slop list; the
+non-negotiables; the definition of done; and the request for a layer-by-layer
+report.
+
+Anti-slop list: flat single-colour fills; one uniform border; a lone small
+SVG floating in dead space; no light source; no texture; no depth; motion
+that just slides something across; an even repeat that reads as a barcode;
+a purple radial glow behind a title.
+
+Non-negotiables: CSS and inline SVG only, no canvas, no JS animation loops,
+no new dependencies, no external assets. `prefers-reduced-motion: reduce`
+freezes into a still frame that is itself beautiful. Visible keyboard focus,
+full label contrast, unreduced hit area, decoration spills by absolute
+positioning or `overflow: visible` and never by margin. Survives its real
+width range and mobile widths. TypeScript strict, no `any`, exported
+signatures unchanged. Every user-facing string through the i18n catalogs in
+English, German and Russian; `node scripts/check-i18n.mjs` passes. CSS
+commented the way a design system is: what each layer is and why.
+
+Done means `pnpm typecheck` passes and the final screenshot is something
+the agent would defend as an art piece.

--- a/docs/systems/design-system.md
+++ b/docs/systems/design-system.md
@@ -136,7 +136,7 @@ breakpoint. Native browser zoom and pinch gestures retain their normal behavior.
 
 **Rule:** If it floats above the content plane, it's glass. Never use `bg-surface-elevated` for floating/overlay elements.
 
-**Modal backdrops:** `bg-black/50` — light enough for glass blur to show through.
+**Modal backdrops:** `.modal-scrim` — a radial vignette from 42% black at the centre to 66% at the corners, so the dialog sits in a pool of light and the app's edges fall away. Same average darkness as the flat 50% it replaced, still light enough for glass blur to show through. Every backdrop that sits behind a `.glass-modal` uses it (`Modal`, `ConfirmDialog`, `UserProfileModal`, `TransferOwnershipModal`, `IncomingCallModal`, `MobileFolderSheet`).
 
 **Portal target — `usePortalContainer()`:** Every overlay (context menu, tooltip, popover, modal, screen-share picker) MUST portal through `usePortalContainer()` (`packages/web/src/hooks/usePortalContainer.ts`) instead of hard-coding `document.body`. The hook returns `document.fullscreenElement ?? document.body` and re-renders subscribers on `fullscreenchange`. Without this, anything portaled while an element (e.g. the voice container in fullscreen mode) is in the browser's Fullscreen API top-layer is rendered outside that layer and is invisible. Components mounted at App root that render with `fixed inset-0` (not just portals) must also portal through this hook for the same reason.
 
@@ -158,6 +158,37 @@ breakpoint. Native browser zoom and pinch gestures retain their normal behavior.
 **Vendor prefix order is load-bearing.** In `globals.css`, write `-webkit-backdrop-filter` **first** and the unprefixed `backdrop-filter` **last**. Vite 8 minifies CSS with Lightning CSS, which folds a prefixed and an unprefixed declaration of the same property into one and keeps whichever came last. With the unprefixed line first, the build ships only `-webkit-backdrop-filter`, which Firefox does not implement, so every glass surface loses its blur there with nothing in the console. The same order applies to any other property written in both forms.
 
 ---
+
+## Material Tier
+
+The reusable half of the UI soul pass (spec: `docs/superpowers/specs/2026-09-09-ui-soul-pass-scene-bible.md`), extracted from the telemetry answer buttons into `globals.css`. A surface that floats gets material; a surface with a subject gets a bespoke scene and may use material for its frame. Material never contains a subject. Only the design lead edits these classes; scene agents own their component and its co-located CSS.
+
+**The light rule.** One key light, above and to the left, outside the frame, warm white. Every layer obeys it: the rim is brightest top-left, the gloss is caught top-left, and whatever the key does not reach falls toward lavender, never toward black.
+
+**Two channels** drive every layer, set on the host and read by the layers: `--lift` (0 at rest, 1 on hover and keyboard focus) and `--push` (0 at rest, 1 while pressed). A press always lifts too. The design workbench forces them with `.is-hover`, `.is-focus` and `.is-active` on an ancestor, so every state rule in these classes and in every scene stylesheet is written twice (`:hover` and `.is-hover &`).
+
+| Class | Layer | Notes |
+|---|---|---|
+| `.mat-host` | The host | `position: relative; isolation: isolate`, owns `--lift`/`--push`, `--mat-rim-strength` (1 for a control, lower for a panel) and `--mat-aura-a/-b` (the aura's two colours, primary and mint by default) |
+| `.mat-aura` | Light thrown onto the surroundings | Outside the box, blurred, `z-index: -1`; almost nothing at rest, present on lift, flares on push |
+| `.mat-scrim` | Vignette and label well | Photographic: only takes light away |
+| `.mat-gloss` | Resting specular | One sheet of glass caught at the top-left corner |
+| `.mat-sheen` | Travelling specular | Parked off-frame; on lift crosses once per five seconds (`matSheen`). The host must clip it |
+| `.mat-rim` | The hairline that turns hue | Masked gradient border: warm white top-left, mint along the top, near nothing lower right, lavender coming back |
+
+Layers are absolutely positioned children of the host, back to front: aura, (host background), scrim, gloss, sheen, rim, then the label at `position: relative`.
+
+**Modal chrome.** `.glass-modal` carries the rim (`::before`) and the gloss (`::after`) at a third of a control's strength, at `z-index: 1` with `pointer-events: none`, so every modal inherits the material without markup. `.glass-modal` is now `position: relative`. Content that must sit above the chrome raises itself (the settings close button is `z-10`).
+
+**Primary call to action, `.cta-primary`.** The one button style that carries material without extra markup: the lavender fill lit from the top-left and falling to `--accent-primary-active` on the lower right, a lit top lip and a dark bottom lip, `::before` as the aura (a hover event, near zero at rest), `::after` as the rim. Focus adds a two-stop ring that owes nothing to the fill. Disabled desaturates and puts the aura out; `disabled:opacity-50` at the call site composes with it. The class owns colour, light and state; sizing, radius and layout stay with the call site as utilities. Do not add `bg-accent-primary`, `text-white`, `shadow-*` or `transition-colors` beside it: utilities win the cascade and undo the material. Swapped in batch 0: login, register, join page, join space, create space, create channel, explore join, the empty voice channel's Join Voice, and the friends direct-add button.
+
+**Lit toast, `.toast-lit`.** A toast is lit from the left in its own colour rather than bordered by it: a soft hard edge, a spill of the colour into the glass, and the rim warmed by it at the top-left. `--toast-rgb` carries the colour's channels; `.toast-lit--info` (sky), `.toast-lit--success` (mint) and `.toast-lit--warning` (amber) set it. Composes with `.glass-pill`.
+
+**Reduced motion.** Material holds still: no transitions, the sheen parked over the top-left shoulder at the strength of a highlight, everything else at its resting frame. Nothing is stripped.
+
+**Tokens.** The derelict's cold palette from the telemetry "no" answer is now shared: `--derelict-lit`, `--derelict-body`, `--derelict-far`, `--derelict-rime`, `--derelict-signal` in `globals.css`, mirrored as hex in `components/telemetry/scene/palette.ts` together with the room and station colours (`deck`, `bulkhead`, `console`, `seat`, `signal`, `hail`, `warn`, `dust`) that scenes paint with. Nothing in that palette is pure black or white; a test enforces it.
+
+**Design workbench.** Every material and scene ships with a dev page under `packages/web/src/dev/` plus an HTML entry beside `index.html`, built on `dev/workbench.tsx` (`WorkbenchPage`, `Section`, `Slot`, `StateRow`, `Surround`, `mountWorkbench`). A page renders the component at its real size inside its real surround, again at 3x, and in rest, hover, focus, pressed and disabled states. `dev-material.html` is the material tier's page. The i18n literal-string rule skips `src/dev/`; never use `100vh` there, the repo enforces `--app-vh`.
 
 ## Input Tiers
 

--- a/packages/web/dev-material.html
+++ b/packages/web/dev-material.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="aether-drift">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Material tier — design workbench</title>
+  </head>
+  <body class="bg-surface-base text-txt-primary">
+    <div id="root"></div>
+    <script type="module" src="/src/dev/material-preview.tsx"></script>
+  </body>
+</html>

--- a/packages/web/src/components/JoinPage.tsx
+++ b/packages/web/src/components/JoinPage.tsx
@@ -237,14 +237,14 @@ export function JoinPage() {
           {token ? (
             <button
               onClick={() => navigate('/channels/@me')}
-              className="px-6 py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors"
+              className="cta-primary px-6 py-2.5 rounded"
             >
               {t('auth:join.invalid.backToApp')}
             </button>
           ) : (
             <Link
               to="/login"
-              className="inline-block px-6 py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors"
+              className="cta-primary inline-block px-6 py-2.5 rounded"
             >
               {t('common:actions.logIn')}
             </Link>
@@ -310,7 +310,7 @@ export function JoinPage() {
                 <button
                   onClick={handleJoin}
                   disabled={isJoining}
-                  className="w-full py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="cta-primary w-full py-2.5 rounded disabled:opacity-50"
                 >
                   {isJoining ? t('auth:join.joining') : t('auth:join.joinAs', { name: user.displayName || user.username })}
                 </button>
@@ -337,7 +337,7 @@ export function JoinPage() {
               /* Token exists but user still loading */
               <button
                 disabled
-                className="w-full py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="cta-primary w-full py-2.5 rounded disabled:opacity-50"
               >
                 {t('common:states.loading')}
               </button>
@@ -346,7 +346,7 @@ export function JoinPage() {
               <div className="space-y-3">
                 <Link
                   to={`/login${redirectParam}`}
-                  className="block w-full py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors text-center"
+                  className="cta-primary block w-full py-2.5 rounded text-center"
                 >
                   {t('auth:join.loginToJoin')}
                 </Link>
@@ -394,7 +394,7 @@ export function JoinPage() {
               <button
                 type="submit"
                 disabled={!otherDomain.trim()}
-                className="px-4 py-2 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded transition-colors disabled:opacity-50"
+                className="cta-primary px-4 py-2 text-sm rounded disabled:opacity-50"
               >
                 {t('auth:join.domain.go')}
               </button>
@@ -466,7 +466,7 @@ export function JoinPage() {
               <button
                 type="submit"
                 disabled={isJoining || !password}
-                className="flex-1 py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="cta-primary flex-1 py-2.5 rounded disabled:opacity-50"
               >
                 {isJoining ? t('auth:join.connect.submitting') : t('auth:join.connect.submit')}
               </button>
@@ -523,7 +523,7 @@ export function JoinPage() {
               <button
                 type="submit"
                 disabled={isJoining || !fallbackUsername || !fallbackPassword}
-                className="flex-1 py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="cta-primary flex-1 py-2.5 rounded disabled:opacity-50"
               >
                 {isJoining ? t('auth:join.fallback.submitting') : t('auth:join.fallback.submit')}
               </button>
@@ -553,7 +553,7 @@ function AlreadyMemberCard({ spaceName, spaceId, navigate }: { spaceName: string
       <p className="text-txt-tertiary text-xs mb-4">{t('auth:join.alreadyMember.redirecting')}</p>
       <button
         onClick={() => navigate(`/channels/${spaceId}`)}
-        className="px-6 py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors"
+        className="cta-primary px-6 py-2.5 rounded"
       >
         {t('auth:join.alreadyMember.go', { space: spaceName })}
       </button>

--- a/packages/web/src/components/auth/LoginPage.tsx
+++ b/packages/web/src/components/auth/LoginPage.tsx
@@ -129,7 +129,7 @@ export function LoginPage() {
           <button
             type="submit"
             disabled={isDisabled}
-            className="w-full py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="cta-primary w-full py-2.5 rounded disabled:opacity-50"
           >
             {retryAfter > 0
               ? t('auth:login.rateLimited.retryIn', { seconds: retryAfter })

--- a/packages/web/src/components/auth/RegisterPage.tsx
+++ b/packages/web/src/components/auth/RegisterPage.tsx
@@ -584,7 +584,7 @@ export function RegisterPage() {
                 disabled={continueDisabled}
                 // py-3 on mobile yields ≥44 px tap target (Apple HIG); py-2.5 keeps the
                 // tighter desktop look from before.
-                className="w-full py-3 md:py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="cta-primary w-full py-3 md:py-2.5 rounded disabled:opacity-50"
               >
                 {t('common:actions.continue')}
               </button>
@@ -714,7 +714,7 @@ export function RegisterPage() {
               type="button"
               onClick={() => handleRegister(false)}
               disabled={isDisabled}
-              className="w-full py-3 md:py-2.5 bg-accent-primary hover:bg-accent-primary/80 text-white font-medium rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="cta-primary w-full py-3 md:py-2.5 rounded disabled:opacity-50"
             >
               {retryAfter > 0
                 ? t('auth:register.rateLimited.retryIn', { seconds: retryAfter })

--- a/packages/web/src/components/chat/ExplorePage.tsx
+++ b/packages/web/src/components/chat/ExplorePage.tsx
@@ -374,7 +374,7 @@ function SpaceCard({
           <button
             onClick={handlePublicJoin}
             disabled={joining}
-            className="w-full py-2 bg-accent-primary hover:bg-accent-primary-hover text-white text-sm font-medium rounded transition-colors disabled:opacity-50"
+            className="cta-primary w-full py-2 text-sm rounded disabled:opacity-50"
           >
             {joining ? (
               <span className="flex items-center justify-center gap-2">

--- a/packages/web/src/components/chat/FriendsPage.tsx
+++ b/packages/web/src/components/chat/FriendsPage.tsx
@@ -617,7 +617,7 @@ function AddFriendTab({
             <button
               onClick={handleDirectAdd}
               disabled={directAddLoading}
-              className="px-3 py-1.5 rounded-md bg-accent-primary hover:bg-accent-primary-hover text-white text-sm font-medium transition-colors disabled:opacity-50 flex-shrink-0"
+              className="cta-primary px-3 py-1.5 rounded-md text-sm disabled:opacity-50 flex-shrink-0"
             >
               {directAddLoading ? t('social:request.sending') : t('social:add.sendRequest')}
             </button>

--- a/packages/web/src/components/layout/MainContent.tsx
+++ b/packages/web/src/components/layout/MainContent.tsx
@@ -428,7 +428,7 @@ export function MainContent() {
             </div>
             <button
               onClick={() => joinVoiceChannel(currentChannelId, useVoiceStore.getState().connectFn ?? undefined)}
-              className="relative z-10 px-8 py-3 bg-accent-primary hover:bg-accent-primary-hover text-white font-semibold rounded-full transition-all text-[15px] shadow-[0_4px_20px_rgba(124,108,246,0.3)]"
+              className="cta-primary relative z-10 px-8 py-3 rounded-full text-[15px]"
             >
               {t('spaces:main.voice.join')}
             </button>

--- a/packages/web/src/components/layout/MobileFolderSheet.tsx
+++ b/packages/web/src/components/layout/MobileFolderSheet.tsx
@@ -96,7 +96,7 @@ export function MobileFolderSheet({ folder, onClose, onSelectSpace, onUpdateFold
 
   return (
     <>
-      <div className="fixed inset-0 z-[300] bg-black/50" onClick={onClose} />
+      <div className="fixed inset-0 z-[300] modal-scrim" onClick={onClose} />
       <div
         className={`fixed bottom-0 left-0 right-0 z-[301] rounded-t-2xl glass-modal max-h-[calc(60*var(--app-vh))] flex flex-col ${
           hasInteracted ? '' : 'animate-slide-up-sheet'

--- a/packages/web/src/components/modals/CreateChannel.tsx
+++ b/packages/web/src/components/modals/CreateChannel.tsx
@@ -170,7 +170,7 @@ export function CreateChannelModal() {
               <button
                 type="submit"
                 disabled={isLoading}
-                className="px-3 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded-full transition-colors disabled:opacity-50"
+                className="cta-primary px-3 py-1.5 text-sm rounded-full disabled:opacity-50"
               >
                 {isLoading ? t('spaces:channel.create.submitting') : t('spaces:channel.create.submit')}
               </button>

--- a/packages/web/src/components/modals/CreateSpace.tsx
+++ b/packages/web/src/components/modals/CreateSpace.tsx
@@ -288,7 +288,7 @@ export function CreateSpaceModal() {
               <button
                 type="submit"
                 disabled={isLoading || uploadingIcon}
-                className="px-3 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded-full transition-colors disabled:opacity-50"
+                className="cta-primary px-3 py-1.5 text-sm rounded-full disabled:opacity-50"
               >
                 {isLoading ? t('spaces:create.submitting') : t('spaces:create.submit')}
               </button>

--- a/packages/web/src/components/modals/JoinSpace.tsx
+++ b/packages/web/src/components/modals/JoinSpace.tsx
@@ -258,7 +258,7 @@ export function JoinSpaceModal() {
                   <button
                     type="submit"
                     disabled={isLoading || !inviteCode.trim()}
-                    className="px-3 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded-full transition-colors disabled:opacity-50"
+                    className="cta-primary px-3 py-1.5 text-sm rounded-full disabled:opacity-50"
                   >
                     {isLoading ? t('spaces:join.submitting') : t('spaces:join.submit')}
                   </button>
@@ -325,7 +325,7 @@ export function JoinSpaceModal() {
                 <button
                   type="submit"
                   disabled={isLoading || !password}
-                  className="px-3 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded-full transition-colors disabled:opacity-50"
+                  className="cta-primary px-3 py-1.5 text-sm rounded-full disabled:opacity-50"
                 >
                   {isLoading ? t('spaces:join.connect.submitting') : t('spaces:join.connect.submit')}
                 </button>
@@ -392,7 +392,7 @@ export function JoinSpaceModal() {
                 <button
                   type="submit"
                   disabled={isLoading || !fallbackUsername || !fallbackPassword}
-                  className="px-3 py-1.5 bg-accent-primary hover:bg-accent-primary/80 text-white text-sm font-medium rounded-full transition-colors disabled:opacity-50"
+                  className="cta-primary px-3 py-1.5 text-sm rounded-full disabled:opacity-50"
                 >
                   {isLoading ? t('spaces:join.fallback.submitting') : t('spaces:join.fallback.submit')}
                 </button>

--- a/packages/web/src/components/modals/TransferOwnershipModal.tsx
+++ b/packages/web/src/components/modals/TransferOwnershipModal.tsx
@@ -136,7 +136,7 @@ export function TransferOwnershipModal({ spaceId, onClose }: { spaceId: string; 
   };
 
   return ReactDOM.createPortal(
-    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center modal-scrim">
       <div
         ref={modalRef}
         className="w-[380px] max-h-[480px] glass-modal rounded-xl flex flex-col animate-in fade-in zoom-in-95 duration-150"

--- a/packages/web/src/components/modals/UserProfileModal.tsx
+++ b/packages/web/src/components/modals/UserProfileModal.tsx
@@ -253,7 +253,7 @@ export function UserProfileModal() {
 
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center animate-fade-in">
-      <div className="absolute inset-0 bg-black/50" onClick={closeModal} />
+      <div className="absolute inset-0 modal-scrim" onClick={closeModal} />
       <div className="relative max-w-lg w-full mx-4 max-h-[calc(calc(100*var(--app-vh))-2rem)] flex flex-col glass-modal rounded-lg animate-slide-up overflow-hidden">
         {/* Banner */}
         <div

--- a/packages/web/src/components/telemetry/answers/SilenceButton.css
+++ b/packages/web/src/components/telemetry/answers/SilenceButton.css
@@ -28,12 +28,12 @@
 .silence-button {
   /* Cold local palette, derived from Aether Drift tokens and pulled toward
      indigo and slate so the hull reads dead against the modal's warm glass. */
-  --sil-lit: 35 37 49; /* the starlit face, upper left */
-  --sil-body: 24 25 34; /* the hull's own colour */
-  --sil-far: 17 18 25; /* the unlit end. Deliberately above --bg-base: if it
+  --sil-lit: var(--derelict-lit); /* the starlit face, upper left */
+  --sil-body: var(--derelict-body); /* the hull's own colour */
+  --sil-far: var(--derelict-far); /* the unlit end. Deliberately above --bg-base: if it
                            matched the void the break would have no silhouette. */
-  --sil-rime: 199 210 254; /* frost and starlight: --accent-lavender toward sky */
-  --sil-signal: 140 152 186; /* the carrier's slate */
+  --sil-rime: var(--derelict-rime); /* frost and starlight: --accent-lavender toward sky */
+  --sil-signal: var(--derelict-signal); /* the carrier's slate */
   /* How much of the outboard end the break eats. Shared by the mask and the
      label's optical centring so they can never drift apart. */
   --sil-break: 22px;

--- a/packages/web/src/components/telemetry/scene/palette.ts
+++ b/packages/web/src/components/telemetry/scene/palette.ts
@@ -22,6 +22,41 @@ export const SCENE_PALETTE = {
   pilot: '#1c1826',
   // Between window and windowLit, so the beam reads as the window's own light.
   beam: '#fdf0c8',
+
+  // ── Rooms and stations (added by the UI soul pass) ──
+  // --bg-channel warmed one step: the floor and bulkheads of any interior.
+  deck: '#1d1a26',
+  // --bg-elevated: the lit face of interior structure.
+  bulkhead: '#252530',
+  // --accent-sky: standby lights on instruments, the colour of "ready". Painted
+  // at low opacity; the hex is the light itself.
+  console: '#7dd3fc',
+  // Same value as hullShade, named for the role: anything inside a room that
+  // has turned away from the key.
+  seat: '#b3a7f3',
+  // Same value as hull, named for the role: an outgoing or live signal, a
+  // plotted course, a friend who is here.
+  signal: '#86efac',
+  // --accent-peach pulled toward --accent-coral: an incoming call, someone
+  // wanting attention.
+  hail: '#fc9c7a',
+  // --accent-rose at the derelict's saturation: a beacon that has gone dark,
+  // an invalid invite.
+  warn: '#e39aa4',
+
+  // ── The derelict (lifted from SilenceButton, which now reads the same
+  //    values as --derelict-* tokens in globals.css) ──
+  // The starlit face, upper left.
+  derelictLit: '#232531',
+  // The hull's own colour.
+  derelictBody: '#181922',
+  // The unlit end. Above --bg-base on purpose: matched to the void, a
+  // silhouette has no edge.
+  derelictFar: '#111219',
+  // Frost and starlight: --accent-lavender toward sky. Also "dust".
+  dust: '#c7d2fe',
+  // The carrier's slate.
+  derelictSignal: '#8c98ba',
 } as const;
 
 export type ScenePalette = typeof SCENE_PALETTE;

--- a/packages/web/src/components/ui/ConfirmDialog.tsx
+++ b/packages/web/src/components/ui/ConfirmDialog.tsx
@@ -53,7 +53,7 @@ export function ConfirmDialog({
   return ReactDOM.createPortal(
     <div className="fixed inset-0 z-[10000] flex items-center justify-center animate-fade-in">
       <div
-        className="absolute inset-0 bg-black/50"
+        className="absolute inset-0 modal-scrim"
         onClick={() => { if (!loading) onClose(); }}
       />
       <div className="relative max-w-[440px] w-full mx-4 glass-modal rounded-xl animate-slide-up">

--- a/packages/web/src/components/ui/Modal.tsx
+++ b/packages/web/src/components/ui/Modal.tsx
@@ -63,7 +63,7 @@ export function Modal({ isOpen, onClose, title, children, maxWidth = 'max-w-md',
     return (
       <div className="fixed inset-0 z-[200] flex items-end justify-center animate-fade-in">
         <div
-          className="absolute inset-0 bg-black/50"
+          className="absolute inset-0 modal-scrim"
           onClick={onClose}
         />
         <div className="relative w-full max-h-[calc(85*var(--app-vh))] flex flex-col glass-modal rounded-t-2xl animate-slide-up" style={{ paddingBottom: 'var(--safe-bottom)' }}>
@@ -94,7 +94,7 @@ export function Modal({ isOpen, onClose, title, children, maxWidth = 'max-w-md',
     return (
       <div className="fixed inset-0 z-[200] flex items-center justify-center animate-fade-in">
         <div
-          className="absolute inset-0 bg-black/50"
+          className="absolute inset-0 modal-scrim"
           onClick={onClose}
         />
         <div className="relative w-[calc(90*var(--app-vw))] max-w-6xl h-[calc(85*var(--app-vh))] flex flex-col glass-modal rounded-xl animate-slide-up overflow-hidden">
@@ -118,7 +118,7 @@ export function Modal({ isOpen, onClose, title, children, maxWidth = 'max-w-md',
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center animate-fade-in">
       <div
-        className="absolute inset-0 bg-black/50"
+        className="absolute inset-0 modal-scrim"
         onClick={onClose}
       />
       <div className={`relative ${maxWidth} w-full mx-4 max-h-[calc(calc(100*var(--app-vh))-2rem)] flex flex-col glass-modal rounded-lg animate-slide-up`}>

--- a/packages/web/src/components/ui/ToastContainer.tsx
+++ b/packages/web/src/components/ui/ToastContainer.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { useUIStore } from '../../stores/uiStore';
 import { useVoiceStore } from '../../stores/voiceStore';
 
-const borderColors = {
-  info: 'border-l-accent-sky',
-  warning: 'border-l-accent-amber',
-  success: 'border-l-accent-mint',
+// The toast's colour lights it from the left (see .toast-lit in globals.css).
+const litClass = {
+  info: 'toast-lit--info',
+  warning: 'toast-lit--warning',
+  success: 'toast-lit--success',
 } as const;
 
 /**
@@ -95,7 +96,7 @@ export function ToastContainer() {
       {toasts.map((toast) => (
         <div
           key={toast.id}
-          className={`glass-pill border-l-2 ${borderColors[toast.type]} rounded-[10px] px-4 py-2.5 max-w-[320px] animate-slide-up pointer-events-auto cursor-pointer flex items-center gap-3`}
+          className={`glass-pill toast-lit ${litClass[toast.type]} rounded-[10px] px-4 py-2.5 max-w-[320px] animate-slide-up pointer-events-auto cursor-pointer flex items-center gap-3`}
           onClick={() => removeToast(toast.id)}
         >
           <span className="flex-1 text-sm text-txt-primary leading-snug">{toast.message}</span>

--- a/packages/web/src/components/voice/IncomingCallModal.tsx
+++ b/packages/web/src/components/voice/IncomingCallModal.tsx
@@ -80,7 +80,7 @@ export function IncomingCallModal() {
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50" />
+      <div className="absolute inset-0 modal-scrim" />
 
       {/* Call card */}
       <div className="relative glass-modal call-refraction rounded-lg w-[340px] overflow-hidden animate-fade-in animate-slide-up">

--- a/packages/web/src/dev/material-preview.tsx
+++ b/packages/web/src/dev/material-preview.tsx
@@ -1,0 +1,134 @@
+// Dev-only workbench for the material tier. Nothing in the app imports this
+// file; `dev-material.html` is its only entry. It shows every material class on
+// the surfaces that ship it: the primary call to action at its real sizes and
+// states, a modal with its chrome and scrim over a chat surface, the three
+// toasts, and the five layers stacked on a bare card so each can be judged.
+import type { ReactNode } from 'react';
+import { WorkbenchPage, Section, Slot, StateRow, Surround, mountWorkbench } from './workbench';
+
+function Cta({ disabled, className, children }: { disabled: boolean; className: string; children: ReactNode }) {
+  return (
+    <button type="button" disabled={disabled} className={`cta-primary ${className}`} onClick={() => undefined}>
+      {children}
+    </button>
+  );
+}
+
+function ModalSample({ scrim }: { scrim: boolean }) {
+  return (
+    <div style={{ position: 'relative', width: 560, height: 360, borderRadius: 8, overflow: 'hidden', background: 'rgb(var(--bg-chat))' }}>
+      {/* A stand-in for the chat behind the modal, so the scrim has something to darken. */}
+      <div style={{ position: 'absolute', inset: 0, display: 'flex' }}>
+        <div style={{ width: 72, background: 'rgb(var(--bg-base))' }} />
+        <div style={{ width: 160, background: 'rgb(var(--bg-channel))' }} />
+        <div style={{ flex: 1, padding: 20, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          {[0.9, 0.6, 0.75, 0.5].map((w, i) => (
+            <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+              <div style={{ width: 28, height: 28, borderRadius: 14, background: 'rgb(var(--accent-lavender) / 0.4)' }} />
+              <div style={{ height: 10, width: `${w * 60}%`, borderRadius: 5, background: 'rgb(var(--text-tertiary) / 0.5)' }} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className={scrim ? 'modal-scrim' : ''} style={{ position: 'absolute', inset: 0, background: scrim ? undefined : 'rgb(0 0 0 / 0.5)' }} />
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div className="glass-modal" style={{ borderRadius: 8, width: 320, padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ fontSize: 18, fontWeight: 700, color: 'rgb(var(--text-primary))' }}>Create Channel</span>
+            <span style={{ color: 'rgb(var(--text-tertiary))' }}>×</span>
+          </div>
+          <span style={{ fontSize: 11, fontWeight: 700, color: 'rgb(var(--text-secondary))', textTransform: 'uppercase' }}>Channel name</span>
+          <input className="input-standard w-full" placeholder="new-channel" readOnly />
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 4 }}>
+            <span style={{ fontSize: 13, color: 'rgb(var(--text-secondary))', padding: '6px 12px' }}>Cancel</span>
+            <Cta disabled={false} className="px-3 py-1.5 text-sm rounded-full">Create Channel</Cta>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Toast({ kind, children }: { kind: 'info' | 'success' | 'warning'; children: ReactNode }) {
+  return (
+    <div className={`glass-pill toast-lit toast-lit--${kind} rounded-[10px] px-4 py-2.5 max-w-[320px] flex items-center gap-3`}>
+      <span className="flex-1 text-sm text-txt-primary leading-snug">{children}</span>
+    </div>
+  );
+}
+
+/** The five material layers on a bare panel, so each one can be judged alone and together. */
+function LayerCard({ layers, label }: { layers: ReadonlyArray<'aura' | 'scrim' | 'gloss' | 'sheen' | 'rim'>; label: string }) {
+  const has = (l: string) => layers.includes(l as (typeof layers)[number]);
+  return (
+    <div className="mat-host" style={{ width: 176, height: 42, borderRadius: 12, overflow: 'visible', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      {has('aura') && <span className="mat-aura" aria-hidden="true" />}
+      <span style={{ position: 'absolute', inset: 0, borderRadius: 'inherit', overflow: 'hidden', background: 'linear-gradient(152deg, rgb(var(--bg-elevated)) 0%, rgb(var(--bg-chat)) 48%, rgb(var(--bg-base)) 100%)' }}>
+        {has('scrim') && <span className="mat-scrim" aria-hidden="true" />}
+        {has('gloss') && <span className="mat-gloss" aria-hidden="true" />}
+        {has('sheen') && <span className="mat-sheen" aria-hidden="true" />}
+        {has('rim') && <span className="mat-rim" aria-hidden="true" />}
+      </span>
+      <span style={{ position: 'relative', fontSize: 13, fontWeight: 600, color: 'rgb(var(--text-primary))', textShadow: '0 1px 3px rgb(var(--bg-base) / 0.75)' }}>{label}</span>
+    </div>
+  );
+}
+
+function Workbench() {
+  return (
+    <WorkbenchPage
+      title="Material tier — design workbench"
+      description="The reusable half of the soul pass: the primary call to action, modal chrome and scrim, lit toasts, and the five layers on their own. Hover, focus and press are forced by class so a screenshot can show them."
+    >
+      <Section title="Primary call to action, shipping sizes">
+        <StateRow width={176} height={44} render={(d) => <Cta disabled={d} className="w-full py-2.5 rounded">Log In</Cta>} />
+        <StateRow width={140} height={48} render={(d) => <Cta disabled={d} className="px-8 py-3 rounded-full text-[15px]">Join Voice</Cta>} />
+        <StateRow width={128} height={30} render={(d) => <Cta disabled={d} className="px-3 py-1.5 text-sm rounded-full">Create Space</Cta>} />
+      </Section>
+
+      <Section title="Primary call to action at 3x">
+        <div style={{ display: 'flex', gap: 48 }}>
+          <Slot caption="rest" width={176} height={44} scale={3}><Cta disabled={false} className="w-full py-2.5 rounded">Log In</Cta></Slot>
+          <Slot caption="hover" className="is-hover" width={176} height={44} scale={3}><Cta disabled={false} className="w-full py-2.5 rounded">Log In</Cta></Slot>
+        </div>
+      </Section>
+
+      <Section title="Modal chrome and scrim">
+        <div style={{ display: 'flex', gap: 32, flexWrap: 'wrap' }}>
+          <Slot caption="before: flat 50% black, uniform border" width={560} height={360}><ModalSample scrim={false} /></Slot>
+          <Slot caption="after: vignette scrim, turning rim, gloss" width={560} height={360}><ModalSample scrim /></Slot>
+        </div>
+      </Section>
+
+      <Section title="Lit toasts">
+        <Surround kind="chat" width={400}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'flex-end' }}>
+            <Toast kind="success">Invite link copied</Toast>
+            <Toast kind="info">Reconnecting to the remote instance…</Toast>
+            <Toast kind="warning">Failed to update registration settings</Toast>
+          </div>
+        </Surround>
+        <div style={{ display: 'flex', gap: 48 }}>
+          <Slot caption="success at 3x" width={220} height={40} scale={3}><Toast kind="success">Invite link copied</Toast></Slot>
+        </div>
+      </Section>
+
+      <Section title="The five layers, one at a time, then stacked">
+        <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
+          <Slot caption="rim" width={176} height={42}><LayerCard layers={['rim']} label="rim" /></Slot>
+          <Slot caption="gloss" width={176} height={42}><LayerCard layers={['gloss']} label="gloss" /></Slot>
+          <Slot caption="scrim" width={176} height={42}><LayerCard layers={['scrim']} label="scrim" /></Slot>
+          <Slot caption="aura (hover)" className="is-hover" width={176} height={42}><LayerCard layers={['aura']} label="aura" /></Slot>
+          <Slot caption="sheen (hover)" className="is-hover" width={176} height={42}><LayerCard layers={['sheen']} label="sheen" /></Slot>
+        </div>
+        <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
+          <Slot caption="all, rest" width={176} height={42}><LayerCard layers={['aura', 'scrim', 'gloss', 'sheen', 'rim']} label="material" /></Slot>
+          <Slot caption="all, hover" className="is-hover" width={176} height={42}><LayerCard layers={['aura', 'scrim', 'gloss', 'sheen', 'rim']} label="material" /></Slot>
+          <Slot caption="all, 3x" width={176} height={42} scale={3}><LayerCard layers={['aura', 'scrim', 'gloss', 'sheen', 'rim']} label="material" /></Slot>
+        </div>
+      </Section>
+    </WorkbenchPage>
+  );
+}
+
+mountWorkbench(<Workbench />);

--- a/packages/web/src/dev/workbench.tsx
+++ b/packages/web/src/dev/workbench.tsx
@@ -1,0 +1,132 @@
+// The shared frame for design workbench pages. Nothing in the app imports this
+// file; the `dev-*.html` entries beside index.html are its only consumers.
+//
+// A workbench page renders one component at its real shipping size inside the
+// real surrounding surface, again at 3x for detail work, and in every state a
+// static screenshot needs to show. Hover, focus and press are forced by the
+// classes .is-hover, .is-focus and .is-active on an ancestor; every material
+// and scene stylesheet writes its state rules twice so those classes work.
+import type { CSSProperties, ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+import '../styles/globals.css';
+
+const captionStyle: CSSProperties = { fontSize: 11, color: 'rgb(var(--text-tertiary))', letterSpacing: '0.02em' };
+
+export function WorkbenchPage({ title, description, children }: { title: string; description: string; children: ReactNode }) {
+  return (
+    <div
+      style={{
+        minHeight: 'calc(100 * var(--app-vh))',
+        background: 'rgb(var(--bg-chat))',
+        padding: 40,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 56,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <h1 style={{ fontSize: 16, fontWeight: 600, color: 'rgb(var(--text-primary))' }}>{title}</h1>
+        <p style={{ fontSize: 12, color: 'rgb(var(--text-secondary))', maxWidth: 620 }}>{description}</p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <h2 style={{ fontSize: 12, fontWeight: 600, color: 'rgb(var(--text-secondary))', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * One captioned slot. `width` and `height` are the component's real layout
+ * size; `scale` blows it up for detail work without changing that size, so a
+ * 3x slot shows exactly the pixels the 1x slot ships.
+ */
+export function Slot({
+  caption,
+  className = '',
+  scale = 1,
+  width,
+  height,
+  children,
+}: {
+  caption: string;
+  className?: string;
+  scale?: number;
+  width: number;
+  height: number;
+  children: ReactNode;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <span style={captionStyle}>{caption}</span>
+      <div style={{ width: width * scale, height: height * scale }}>
+        <div className={className} style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', display: 'flex' }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** The four states a static screenshot has to show, side by side, at one size. */
+export function StateRow({ width, height, render }: { width: number; height: number; render: (disabled: boolean) => ReactNode }) {
+  return (
+    <div style={{ display: 'flex', gap: 32, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+      <Slot caption="rest" width={width} height={height}>{render(false)}</Slot>
+      <Slot caption="hover (.is-hover)" className="is-hover" width={width} height={height}>{render(false)}</Slot>
+      <Slot caption="focus (.is-focus)" className="is-focus" width={width} height={height}>{render(false)}</Slot>
+      <Slot caption="pressed (.is-active)" className="is-active" width={width} height={height}>{render(false)}</Slot>
+      <Slot caption="disabled" width={width} height={height}>{render(true)}</Slot>
+    </div>
+  );
+}
+
+const surroundBackground: Record<'base' | 'chat' | 'channel' | 'modal', CSSProperties> = {
+  base: { background: 'rgb(var(--bg-base))' },
+  chat: { background: 'rgb(var(--bg-chat))' },
+  channel: { background: 'rgb(var(--bg-channel))' },
+  modal: {},
+};
+
+/**
+ * The real surface a component ships on. `modal` renders the glass panel
+ * itself so modal content and modal chrome can be judged together.
+ */
+export function Surround({
+  kind,
+  width,
+  padding = 24,
+  children,
+}: {
+  kind: 'base' | 'chat' | 'channel' | 'modal';
+  width: number;
+  padding?: number;
+  children: ReactNode;
+}) {
+  if (kind === 'modal') {
+    return (
+      <div className="glass-modal" style={{ borderRadius: 16, padding, width }}>
+        {children}
+      </div>
+    );
+  }
+  return (
+    <div style={{ ...surroundBackground[kind], borderRadius: 8, padding, width }}>
+      {children}
+    </div>
+  );
+}
+
+export function mountWorkbench(node: ReactNode) {
+  const host = document.getElementById('root');
+  if (!host) throw new Error('missing #root');
+  createRoot(host).render(node);
+}

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -86,6 +86,16 @@
 
     /* ── Notification ── */
     --notification: 253 164 175;
+
+    /* ── The derelict: the cold end of the scene palette ──
+     * Shared by SilenceButton and by anything else that has stopped
+     * transmitting (a dark beacon, an expired connection). Mirrored as hex in
+     * components/telemetry/scene/palette.ts for SVG use. */
+    --derelict-lit: 35 37 49;
+    --derelict-body: 24 25 34;
+    --derelict-far: 17 18 25;
+    --derelict-rime: 199 210 254;
+    --derelict-signal: 140 152 186;
   }
 
   * {
@@ -222,6 +232,336 @@
   }
   .glass-pill-mine:hover {
     background: rgba(134, 239, 172, 0.16);
+  }
+
+  /* ── Material tier ──
+   * The cheap, reusable half of the UI soul pass, extracted from the telemetry
+   * answer buttons (components/telemetry/answers/HiButton.css). A surface that
+   * floats gets material; a surface that has a subject gets a scene, and may use
+   * material for its frame. Material never contains a subject.
+   *
+   * Every layer obeys one key light: above and to the left, outside the frame,
+   * warm white. What it does not reach falls toward lavender, never to black.
+   *
+   * Two channels drive all of it, set on the host and read by every layer:
+   *   --lift  0 at rest, 1 on hover and keyboard focus
+   *   --push  0 at rest, 1 while pressed
+   * The design workbench forces them with .is-hover, .is-focus and .is-active on
+   * an ancestor, so a static screenshot can show each state.
+   *
+   * Layers, back to front, each an absolutely positioned child of a .mat-host:
+   *   .mat-aura   the light the surface throws onto what is around it
+   *   .mat-scrim  a vignette that seats content in its frame by taking light away
+   *   .mat-gloss  the resting specular: one sheet of glass, caught top-left
+   *   .mat-sheen  the travelling specular, hover only
+   *   .mat-rim    the hairline that turns hue with the light
+   * The host's own content sits between scrim and gloss in the stacking order
+   * when it is given `position: relative`.
+   */
+  .mat-host {
+    --lift: 0;
+    --push: 0;
+    /* Strength of the rim, 1 for a control, lower for a large panel where a
+       bright hairline would compete with the content. */
+    --mat-rim-strength: 1;
+    /* The two colours the aura is made of. Primary and mint by default; a
+       scene sets its own. */
+    --mat-aura-a: var(--accent-primary);
+    --mat-aura-b: var(--accent-mint);
+    position: relative;
+    isolation: isolate;
+  }
+  .mat-host:hover:not(:disabled),
+  .is-hover .mat-host:not(:disabled),
+  .mat-host:focus-visible,
+  .is-focus .mat-host {
+    --lift: 1;
+  }
+  .mat-host:active:not(:disabled),
+  .is-active .mat-host:not(:disabled) {
+    --lift: 1;
+    --push: 1;
+  }
+
+  /* AURA: sits outside the host's box, blurred, and only really appears on
+     lift. z-index -1 keeps it behind the host's own background inside the
+     host's isolated stacking context. */
+  .mat-aura {
+    position: absolute;
+    inset: -12px -16px;
+    z-index: -1;
+    border-radius: 22px;
+    background:
+      radial-gradient(46% 120% at 26% 60%, rgb(var(--mat-aura-a) / 0.34), transparent 68%),
+      radial-gradient(46% 120% at 82% 76%, rgb(var(--mat-aura-b) / 0.22), transparent 70%);
+    filter: blur(9px);
+    opacity: calc(0.06 + 0.6 * var(--lift) + 0.45 * var(--push));
+    transform: scale(calc(0.96 + 0.04 * var(--lift) + 0.03 * var(--push)));
+    transition: opacity 420ms ease, transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+    pointer-events: none;
+  }
+
+  /* SCRIM: photographic, not decorative. A vignette so a scene is seated in
+     its frame rather than pasted into it, and a soft well of the base colour
+     under whatever sits at the centre. */
+  .mat-scrim {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background:
+      radial-gradient(46% 78% at 50% 52%, rgb(var(--bg-base) / 0.72), rgb(var(--bg-base) / 0.3) 62%, transparent 82%),
+      radial-gradient(130% 150% at 50% 45%, transparent 44%, rgb(var(--bg-base) / 0.5) 100%);
+    pointer-events: none;
+  }
+
+  /* GLOSS: the key landing on the top-left corner of one sheet of glass. */
+  .mat-gloss {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background:
+      linear-gradient(168deg, rgb(255 255 255 / 0.12) 0%, rgb(255 255 255 / 0.03) 26%, transparent 50%),
+      radial-gradient(140% 90% at -6% -20%, rgb(255 255 255 / 0.09), transparent 58%);
+    pointer-events: none;
+  }
+
+  /* SHEEN: parked off-frame at rest. On lift it crosses once every five
+     seconds and spends most of the cycle gone, so it registers as expensive
+     rather than as a loop. The host must clip it. */
+  .mat-sheen {
+    position: absolute;
+    inset: -40% -30%;
+    background: linear-gradient(
+      104deg,
+      transparent 40%,
+      rgb(255 255 255 / 0.07) 46%,
+      rgb(255 255 255 / 0.16) 50%,
+      rgb(255 255 255 / 0.07) 54%,
+      transparent 60%
+    );
+    transform: translateX(-130%);
+    opacity: 0;
+    pointer-events: none;
+  }
+  .mat-host:hover:not(:disabled) .mat-sheen,
+  .is-hover .mat-host:not(:disabled) .mat-sheen,
+  .mat-host:focus-visible .mat-sheen,
+  .is-focus .mat-host .mat-sheen {
+    animation: matSheen 5s cubic-bezier(0.5, 0, 0.3, 1) infinite;
+  }
+
+  /* RIM: one hairline, not one colour. Warm white where the key lands, mint
+     along the top edge, nearly nothing on the shaded lower right, lavender as
+     it comes back up. A masked gradient border, so the hue can turn. */
+  .mat-rim {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      146deg,
+      rgb(var(--text-primary) / calc((0.36 + 0.26 * var(--lift)) * var(--mat-rim-strength))) 0%,
+      rgb(var(--accent-mint) / calc((0.24 + 0.3 * var(--lift)) * var(--mat-rim-strength))) 26%,
+      rgb(255 255 255 / calc((0.1 + 0.05 * var(--lift)) * var(--mat-rim-strength))) 58%,
+      rgb(var(--accent-lavender) / calc((0.22 + 0.26 * var(--lift)) * var(--mat-rim-strength))) 100%
+    );
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    transition: background 420ms ease;
+    pointer-events: none;
+  }
+
+  /* ── Modal chrome ──
+   * Every .glass-modal carries the rim and the gloss as pseudo-elements, so the
+   * dozen places that compose a modal inherit the material without markup. The
+   * rim runs at a third of a control's strength: a panel this large with a
+   * bright hairline reads as a picture frame. Both layers ignore the pointer and
+   * sit above the content plane at z-index 1, below anything the content raises
+   * (the floating close button is z-10). */
+  .glass-modal {
+    position: relative;
+  }
+  .glass-modal::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      146deg,
+      rgb(var(--text-primary) / 0.24) 0%,
+      rgb(var(--accent-mint) / 0.14) 22%,
+      rgb(255 255 255 / 0.035) 56%,
+      rgb(var(--accent-lavender) / 0.14) 100%
+    );
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+  }
+  .glass-modal::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
+    background:
+      linear-gradient(168deg, rgb(255 255 255 / 0.05) 0%, rgb(255 255 255 / 0.015) 22%, transparent 42%),
+      radial-gradient(90% 60% at -4% -10%, rgb(255 255 255 / 0.05), transparent 56%);
+    pointer-events: none;
+  }
+
+  /* MODAL SCRIM: the backdrop. A vignette rather than a flat 50% black, so the
+     dialog sits in a pool of the key light and the edges of the app fall away.
+     Same average darkness as before; the middle is lighter, the corners darker. */
+  .modal-scrim {
+    background: radial-gradient(110% 110% at 50% 42%, rgb(0 0 0 / 0.42) 0%, rgb(0 0 0 / 0.66) 100%);
+  }
+
+  /* ── Lit toast ──
+   * A toast is lit from the left in its own colour rather than bordered by it:
+   * a hard edge of the colour, a soft spill of it into the glass, and the rim
+   * warmed by it at the top-left corner. --toast-rgb is the colour's channels. */
+  .toast-lit {
+    --toast-rgb: var(--accent-sky);
+    position: relative;
+    isolation: isolate;
+    border-color: rgb(var(--toast-rgb) / 0.16);
+    box-shadow:
+      inset 1.5px 0 0 0 rgb(var(--toast-rgb) / 0.7),
+      inset 22px 0 30px -16px rgb(var(--toast-rgb) / 0.38),
+      0 6px 16px -8px rgb(0 0 0 / 0.6),
+      inset 0 1px 0 rgb(255 255 255 / 0.04);
+  }
+  .toast-lit::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      146deg,
+      rgb(var(--toast-rgb) / 0.45) 0%,
+      rgb(var(--text-primary) / 0.14) 30%,
+      rgb(255 255 255 / 0.03) 60%,
+      rgb(var(--accent-lavender) / 0.12) 100%
+    );
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+  }
+  .toast-lit--info { --toast-rgb: var(--accent-sky); }
+  .toast-lit--success { --toast-rgb: var(--accent-mint); }
+  .toast-lit--warning { --toast-rgb: var(--accent-amber); }
+
+  /* ── Primary call to action ──
+   * The one button style that carries the material without extra markup: the
+   * body is the lavender fill lit from the top-left and falling to the active
+   * shade on the lower right, ::before is the aura, ::after is the rim. Quieter
+   * than the telemetry answer on purpose: no scene, no stars, and the aura is
+   * mostly a hover event. Sizing, radius and layout stay with the call site as
+   * utilities; this class owns colour, light and state. */
+  .cta-primary {
+    --lift: 0;
+    --push: 0;
+    position: relative;
+    isolation: isolate;
+    color: rgb(var(--text-primary));
+    font-weight: 600;
+    background:
+      /* the gloss: the key on the top-left of the sheet */
+      linear-gradient(168deg, rgb(255 255 255 / 0.16) 0%, rgb(255 255 255 / 0.04) 28%, transparent 54%),
+      /* the key catching the lit corner, in the fill's own lighter hue */
+      radial-gradient(120% 100% at 0% 0%, rgb(var(--accent-lavender) / 0.4), transparent 58%),
+      /* the body, lit to shaded, never toward black */
+      linear-gradient(152deg, rgb(var(--accent-primary)) 0%, rgb(var(--accent-primary-hover)) 55%, rgb(var(--accent-primary-active)) 100%);
+    box-shadow:
+      /* the thickness of the sheet: a lit top lip, a dark bottom one */
+      inset 0 1px 0 rgb(255 255 255 / 0.2),
+      inset 0 -1px 0 rgb(var(--bg-base) / 0.55),
+      /* its weight on the surface below */
+      0 10px 22px -12px rgb(var(--bg-base) / 0.9),
+      0 2px 6px -3px rgb(var(--bg-base) / 0.7);
+    text-shadow: 0 1px 2px rgb(var(--bg-base) / 0.35);
+    transform: translateY(calc(var(--push) * 1px)) scale(calc(1 - var(--push) * 0.012));
+    filter: brightness(calc(1 + 0.07 * var(--lift)));
+    transition: transform 260ms cubic-bezier(0.22, 1, 0.36, 1), filter 260ms ease, box-shadow 260ms ease;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .cta-primary::before {
+    content: '';
+    position: absolute;
+    inset: -6px -8px;
+    z-index: -1;
+    border-radius: inherit;
+    background:
+      radial-gradient(50% 120% at 30% 60%, rgb(var(--accent-primary) / 0.6), transparent 70%),
+      radial-gradient(50% 120% at 78% 70%, rgb(var(--accent-lavender) / 0.35), transparent 72%);
+    filter: blur(8px);
+    /* At rest the aura is almost not there: a button should not glow on a
+       calm surface. It is a hover event, and a press flares it. */
+    opacity: calc(0.04 + 0.5 * var(--lift) + 0.4 * var(--push));
+    transform: scale(calc(0.94 + 0.06 * var(--lift) + 0.03 * var(--push)));
+    transition: opacity 420ms ease, transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+    pointer-events: none;
+  }
+  .cta-primary::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      146deg,
+      rgb(var(--text-primary) / calc(0.42 + 0.28 * var(--lift))) 0%,
+      rgb(var(--accent-lavender) / calc(0.3 + 0.3 * var(--lift))) 30%,
+      rgb(255 255 255 / 0.06) 58%,
+      rgb(var(--accent-lavender) / calc(0.18 + 0.22 * var(--lift))) 100%
+    );
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    transition: background 420ms ease;
+    pointer-events: none;
+  }
+  .cta-primary:hover:not(:disabled),
+  .is-hover .cta-primary:not(:disabled) {
+    --lift: 1;
+  }
+  .cta-primary:active:not(:disabled),
+  .is-active .cta-primary:not(:disabled) {
+    --lift: 1;
+    --push: 1;
+  }
+  /* Focus: the same lift as hover, plus a ring that owes nothing to the fill:
+     two stops, so it survives on any surface behind the button. */
+  .cta-primary:focus-visible,
+  .is-focus .cta-primary {
+    --lift: 1;
+    outline: none;
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.2),
+      inset 0 -1px 0 rgb(var(--bg-base) / 0.55),
+      0 0 0 2px rgb(var(--bg-chat)),
+      0 0 0 4px rgb(var(--accent-primary));
+  }
+  /* Disabled: power down. The colour drains, the aura goes out, nothing lifts.
+     Call sites may still add disabled:opacity-50; it composes. */
+  .cta-primary:disabled {
+    cursor: not-allowed;
+    transform: none;
+    filter: saturate(0.4) brightness(0.85);
+    color: rgb(var(--text-primary) / 0.8);
+  }
+  .cta-primary:disabled::before {
+    opacity: 0;
   }
 
   /* ── Input Tiers ── */
@@ -543,12 +883,33 @@
   z-index: 1;
 }
 
+/* Material: one pass of the key across the glass, then four seconds of nothing. */
+@keyframes matSheen {
+  0% { transform: translateX(-130%); opacity: 0; }
+  6% { opacity: 1; }
+  30% { transform: translateX(130%); opacity: 1; }
+  36%, 100% { transform: translateX(130%); opacity: 0; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-call-ripple,
   .animate-call-glow,
   .animate-call-button-glow { animation: none !important; }
   .call-refraction::after { animation: none !important; opacity: 0; }
   .skeleton { animation: none; }
+  /* Material holds still. The sheen is parked over the top-left shoulder of
+     the glass at the strength of a highlight, not of a wipe; nothing transitions. */
+  .mat-aura, .mat-rim, .mat-sheen, .cta-primary, .cta-primary::before, .cta-primary::after {
+    transition: none !important;
+    animation: none !important;
+  }
+  .mat-host:hover:not(:disabled) .mat-sheen,
+  .is-hover .mat-host:not(:disabled) .mat-sheen,
+  .mat-host:focus-visible .mat-sheen,
+  .is-focus .mat-host .mat-sheen {
+    transform: translateX(-46%);
+    opacity: 0.5;
+  }
 }
 
 /* ── MOBILE SCREEN TRANSITIONS ── */


### PR DESCRIPTION
Batch 0 of the UI soul pass, the reusable half. No scene in this PR; scenes come one batch at a time on top of these classes.

## What changes

- **Material tier** in `globals.css`: `.mat-host` plus five layers (`.mat-aura`, `.mat-scrim`, `.mat-gloss`, `.mat-sheen`, `.mat-rim`) extracted from the telemetry answer buttons. Two channels, `--lift` and `--push`, drive every layer; the workbench forces them with `.is-hover`, `.is-focus`, `.is-active`.
- **`.cta-primary`**: one primary button style, lit from the top-left, with a lit top lip, a rim and an aura that is a hover event rather than a resting glow. Swapped at the highest-visibility sites: login, register, the join page, join space, create space, create channel, explore, the empty voice channel, and the friends direct-add button. The class owns colour, light and state; sizing and radius stay at the call site.
- **Modal chrome**: every `.glass-modal` carries a turning rim and a gloss as pseudo-elements. The backdrop becomes `.modal-scrim`, a vignette, at the same average darkness as the flat 50% black it replaces. Applied to `Modal`, `ConfirmDialog`, `UserProfileModal`, `TransferOwnershipModal`, `IncomingCallModal`, `MobileFolderSheet`.
- **Toasts**: lit from the left in their own colour (`.toast-lit` and three variants) instead of a coloured left border.
- **Palette**: `SCENE_PALETTE` gains the room, station and derelict colours the scene batches will paint with; the derelict tokens move out of `SilenceButton.css` into `globals.css` as `--derelict-*` so they can be shared. Nothing pure black or white; the existing palette test enforces that.
- **Workbench**: `src/dev/workbench.tsx` is the shared frame for design pages; `dev-material.html` shows the material tier at shipping size, at 3x, and in every state.
- **Docs**: the scene bible for the pass under `docs/superpowers/specs/`, a Material Tier section in `docs/systems/design-system.md`, and the backdrop line in `CLAUDE.md`.

## Reduced motion

Material holds still: no transitions, the sheen parked over the top-left shoulder at highlight strength. Verified with `--force-prefers-reduced-motion` on the workbench page.

## Verification

- `pnpm typecheck` across packages: green
- `node scripts/check-i18n.mjs`: no findings (no user-facing strings change)
- `pnpm --filter @backspace/web test`: 102 files, 912 tests, green
- Workbench screenshotted through four iterations; the real login page checked on the dev server.

## Things to look at

- The resting aura on `.cta-primary` is deliberately near zero. If it reads as flat on your screen, the hover state is where the material lives.
- `.glass-modal` is now `position: relative`. Content that needs to sit above the chrome raises itself; the settings close button already does.